### PR TITLE
Add custom error message for Gemini Optional and Enums

### DIFF
--- a/docs/integrations/genai.md
+++ b/docs/integrations/genai.md
@@ -31,6 +31,10 @@ pip install "instructor[google-genai]"
 
 ## Basic Usage
 
+!!! warning "Unions and Optionals"
+
+    Gemini doesn't have support for Union and Optional types in the structured outputs and tool calling integrations. We currently throw an error when we detect these in your response model.
+
 Getting started with Instructor and the genai SDK is straightforward. Just create a Pydantic model defining your output structure, patch the genai client, and make your request with a response_model parameter:
 
 ```python

--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -551,6 +551,9 @@ def handle_genai_structured_outputs(
 
     new_kwargs["contents"] = convert_to_genai_messages(new_kwargs["messages"])
 
+    # We validate that the schema doesn't contain any optional fields
+    map_to_gemini_function_schema(response_model.model_json_schema())
+
     new_kwargs["config"] = types.GenerateContentConfig(
         system_instruction=system_message,
         response_mime_type="application/json",

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -660,6 +660,21 @@ def transform_to_gemini_prompt(
     return messages_gemini
 
 
+def verify_no_enums(obj: dict[str, Any]) -> bool:
+    """
+    Verify that the object does not contain any enums.
+    """
+    print(obj)
+    for prop_name, prop_value in obj["properties"].items():
+        if "anyOf" in prop_value:
+            return False
+
+        if "properties" in prop_value and not verify_no_enums(prop_value):
+            return False
+
+    return True
+
+
 def map_to_gemini_function_schema(obj: dict[str, Any]) -> dict[str, Any]:
     """
     Map OpenAPI schema to Gemini properties: gemini function call schemas
@@ -696,6 +711,11 @@ def map_to_gemini_function_schema(obj: dict[str, Any]) -> dict[str, Any]:
             return obj
 
     schema = add_enum_format(schema)
+
+    if not verify_no_enums(schema):
+        raise ValueError(
+            "Gemini does not support Optional types. Please change your function schema"
+        )
 
     return FunctionSchema(**schema).model_dump(exclude_none=True, exclude_unset=True)
 

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -665,7 +665,7 @@ def verify_no_enums(obj: dict[str, Any]) -> bool:
     Verify that the object does not contain any enums.
     """
     print(obj)
-    for prop_name, prop_value in obj["properties"].items():
+    for prop_value in obj["properties"].values():
         if "anyOf" in prop_value:
             return False
 

--- a/tests/llm/test_genai/test_invalid_schema.py
+++ b/tests/llm/test_genai/test_invalid_schema.py
@@ -1,6 +1,5 @@
-import unittest
 import pytest
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import instructor
 from google.genai import Client

--- a/tests/llm/test_genai/test_invalid_schema.py
+++ b/tests/llm/test_genai/test_invalid_schema.py
@@ -1,0 +1,70 @@
+import unittest
+import pytest
+from typing import List, Optional, Union
+
+import instructor
+from google.genai import Client
+from pydantic import BaseModel
+from .util import models, modes
+from itertools import product
+
+
+@pytest.mark.parametrize("mode,model", product(modes, models))
+def test_nested(mode, model):
+    """Test that nested schemas raise appropriate error with Gemini."""
+    client = instructor.from_genai(Client(), mode=mode)
+
+    class Address(BaseModel):
+        street: str
+        city: str
+
+    class Person(BaseModel):
+        name: str
+        address: Optional[Address] = None
+
+    with pytest.raises(ValueError, match="Gemini does not support Optional types"):
+        client.chat.completions.create(
+            model=model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "John loves to go gardenning with his friends",
+                }
+            ],
+            response_model=Person,
+        )
+
+
+@pytest.mark.parametrize("mode,model", product(modes, models))
+def test_union(mode, model):
+    """Test that union types raise appropriate error with Gemini."""
+    client = instructor.from_genai(Client(), mode=mode)
+
+    class UserData(BaseModel):
+        name: str
+        id_value: Union[str, int]
+
+    with pytest.raises(ValueError, match="Gemini does not support Optional types"):
+        client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "User name is Alice with ID 12345"}],
+            response_model=UserData,
+        )
+
+
+@pytest.mark.parametrize("mode,model", product(modes, models))
+def test_optional(mode, model):
+    """Test that optional fields raise appropriate error with Gemini."""
+    client = instructor.from_genai(Client(), mode=mode)
+
+    class Profile(BaseModel):
+        name: str
+        age: int
+        bio: Optional[str] = None
+
+    with pytest.raises(ValueError, match="Gemini does not support Optional types"):
+        client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "Alice is 30 years old"}],
+            response_model=Profile,
+        )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds custom error handling for unsupported Union and Optional types in Gemini, with documentation updates, validation logic, and tests.
> 
>   - **Behavior**:
>     - Adds a warning in `genai.md` about Gemini's lack of support for Union and Optional types.
>     - In `process_response.py`, `map_to_gemini_function_schema()` now validates schemas to ensure no Optional fields are present.
>   - **Validation**:
>     - Adds `verify_no_enums()` in `utils.py` to check for enums in schemas.
>     - Raises `ValueError` in `map_to_gemini_function_schema()` if Optional types are detected.
>   - **Testing**:
>     - Adds `test_invalid_schema.py` to test that `ValueError` is raised for Optional and Union types in response models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for e496e2b3a04266e800b69e6a880220c7b0835bdc. You can [customize](https://app.ellipsis.dev/instructor-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->