### PR TITLE
Added a check for genai response 

### DIFF
--- a/instructor/reask.py
+++ b/instructor/reask.py
@@ -372,7 +372,7 @@ def reask_perplexity_json(
     kwargs["messages"].extend(reask_msgs)
     return kwargs
 
-  
+
 def reask_genai_tools(
     kwargs: dict[str, Any],
     response: Any,
@@ -406,16 +406,24 @@ def reask_genai_structured_outputs(
     from google.genai import types
 
     kwargs = kwargs.copy()
+
+    genai_response = (
+        response.text
+        if response and hasattr(response, "text")
+        else "You must generate a response to the user's request that is consistent with the response model"
+    )
+
     kwargs["contents"].append(
         types.ModelContent(
             parts=[
                 types.Part.from_text(
-                    text=f"Validation Error found:\n{exception}\nRecall the function correctly, fix the errors in the following attempt:\n{response.text}"
+                    text=f"Validation Error found:\n{exception}\nRecall the function correctly, fix the errors in the following attempt:\n{genai_response}"
                 ),
             ]
         ),
     )
-    return kwargs  
+    return kwargs
+
 
 def reask_mistral_structured_outputs(
     kwargs: dict[str, Any],
@@ -461,7 +469,6 @@ def reask_mistral_tools(
         )
     kwargs["messages"].extend(reask_msgs)
     return kwargs
-
 
 
 def handle_reask_kwargs(


### PR DESCRIPTION
GenAI structured Outputs sometimes returns a null response. This checks for that
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a null response check in `reask_genai_structured_outputs()` to handle GenAI structured outputs returning null.
> 
>   - **Behavior**:
>     - Adds a check for null `response` in `reask_genai_structured_outputs()` to handle cases where GenAI structured outputs return null.
>     - If `response` is null or lacks `text`, defaults to a specific error message.
>   - **Misc**:
>     - Removes trailing whitespace in `reask.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 5f3ad40c391b1bd31b04f231cce8edfa8fed1fa4. You can [customize](https://app.ellipsis.dev/instructor-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->