### PR TITLE
docs(blog): fix code block formatting in blog post

### DIFF
--- a/docs/blog/posts/introducing-structured-outputs.md
+++ b/docs/blog/posts/introducing-structured-outputs.md
@@ -205,9 +205,6 @@ This built-in retry logic allows for targeted correction to the generated respon
 A common use-case is to define a single schema and extract multiple instances of it. With `instructor`, doing this is relatively straightforward by using [our `create_iterable` method](../../concepts/lists.md).
 
 ```python
-
-```
-
 client = instructor.from_openai(openai.OpenAI(), mode=instructor.Mode.TOOLS_STRICT)
 
 


### PR DESCRIPTION
This PR fixes a code block formatting issue in the blog post where the closing triple backticks were incorrectly placed, which was breaking code rendering.

This PR was written manually and follows Instructor’s contribution guidelines.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes code block formatting in `introducing-structured-outputs.md` by removing misplaced backticks.
> 
>   - **Fixes**:
>     - Corrects code block formatting in `introducing-structured-outputs.md` by removing misplaced closing triple backticks, resolving rendering issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for cb7989aafce57a39495b7cde61b852f0a496d891. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->