### PR TITLE
fix(bedrock): minimal working example with from_bedrock client

### DIFF
--- a/docs/integrations/bedrock.md
+++ b/docs/integrations/bedrock.md
@@ -39,10 +39,10 @@ class User(BaseModel):
 
 
 # Create structured output
-user = client.converse(
+user = client.chat.completions.create(
     modelId="anthropic.claude-3-sonnet-20240229-v1:0",
     messages=[
-        {"role": "user", "content": "Extract: Jason is 25 years old"},
+        {"role": "user", "content": [{ "text": "Extract: Jason is 25 years old" }]},
     ],
     response_model=User,
 )
@@ -69,7 +69,7 @@ bedrock_client = boto3.client('bedrock-runtime')
 
 # Enable instructor patches for Bedrock client with specific mode
 client = instructor.from_bedrock(
-    bedrock_client, 
+    bedrock_client,
     mode=Mode.BEDROCK_TOOLS
 )
 
@@ -148,4 +148,4 @@ print(user)
 ## Additional Resources
 
 - [AWS Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
-- [Boto3 Bedrock Client](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock.html) 
+- [Boto3 Bedrock Client](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock.html)


### PR DESCRIPTION
This PR introduces minimal fixes to get the starter code working for Bedrock clients (sans Anthropic SDK). https://github.com/567-labs/instructor/issues/1472 has broader discussion of what's not working with the `converse` method but it appears that isn't ready to be used in the getting started docs.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes method and message format in `bedrock.md` for Bedrock client chat completions.
> 
>   - **Behavior**:
>     - Replaces `client.converse` with `client.chat.completions.create` in `bedrock.md` to correctly create chat completions.
>     - Updates message format to include `[{ "text": "..." }]` in `bedrock.md`.
>   - **Misc**:
>     - Removes trailing whitespace in `bedrock.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for b93f8d1f99d287b7c468c227440843ad765a368d. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->