### PR TITLE
fix(bedrock): handle default message format for converse endpoint

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1646,7 +1646,7 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.8.0"
+version = "1.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Somewhat related to https://github.com/567-labs/instructor/pull/1528 , it is not possible to switch from another provider to the bedrock provider without code changes. This PR introduces the ability to handle `chat.completion.create` messages consistently when moving from other providers by massaging the `model` and `messages` kwargs into the [format that `boto3.client('bedrock-runtime').converse(...)` expects](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime/client/converse.html). I suspect users will see similar issues with `from_provider`, but we're not currently using this pattern in our project (we've built our own boilerplate over time to manage switching providers) so I can't verify.

I also notice there's no `tests/llm/bedrock` dir, if that's not intentional I could see about adding a few tests, but I'd hate to hold up this PR in the meantime. I've validated that this works with the following setup:

```python
import boto3
from instructor.client_bedrock import from_bedrock
from pydantic import BaseModel


class Recipe(BaseModel):
    instructions: list[str]


def main():
    client = from_bedrock(boto3.client("bedrock-runtime", region_name="us-west-2"))
    print(
        client.chat.completions.create(
            # model="us.anthropic.claude-3-5-sonnet-20241022-v2:0",
            model="us.meta.llama3-1-8b-instruct-v1:0",
            response_model=Recipe,
            messages=[
                {
                    "role": "user",
                    "content": "Write me a recipe for chocolate chip cookies",
                }
            ],
        ).model_dump_json(indent=2)
    )


if __name__ == "__main__":
    main()
```

```toml
[project]
name = "instructor-test"
version = "0.1.0"
readme = "README.md"
requires-python = ">=3.13"
dependencies = ["instructor[bedrock]"]

[dependency-groups]
dev = ["ruff>=0.11.10"]

[tool.uv.sources]
instructor = { path = "../../567-labs/instructor", editable = true }
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for Bedrock's `converse` method by transforming `model` and `messages` kwargs in `process_response.py`.
> 
>   - **Behavior**:
>     - Adds `_prepare_bedrock_converse_kwargs_internal` in `process_response.py` to transform `model` and `messages` kwargs for Bedrock's `converse` method.
>     - Updates `handle_bedrock_json` and `handle_bedrock_tools` to use `_prepare_bedrock_converse_kwargs_internal` for consistent message handling.
>   - **Versioning**:
>     - Updates `instructor` version to `1.8.2` in `uv.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 7216ccbf95a640710f50791e7a336d971b86678f. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->