### PR TITLE
fix: move CLI dependencies behind optional install group (fixes #1512)

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -37,10 +37,16 @@ description: Command-line utilities for monitoring API usage, fine-tuning models
 
 ### Installation
 
-The CLI tools are included with the Instructor package:
+The CLI tools require the CLI dependencies to be installed:
 
 ```bash
-pip install instructor
+pip install "instructor[cli]"
+```
+
+If you've already installed Instructor without the CLI dependencies, you can install them separately:
+
+```bash
+pip install "typer>=0.9.0" "rich>=13.7.0" "aiohttp>=3.9.1"
 ```
 
 ### API Setup

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,11 +9,41 @@ Installation is as simple as:
 pip install instructor
 ```
 
-Instructor has a few dependencies:
+Instructor has a few core dependencies:
 
 - [`openai`](https://pypi.org/project/openai/): OpenAI's Python client.
-- [`typer`](https://pypi.org/project/typer/): Build great CLIs. Easy to code. Based on Python type hints.
-- [`docstring-parser`](https://pypi.org/project/docstring-parser/): A parser for Python docstrings, to improve the experience of working with docstrings in jsonschema.
 - [`pydantic`](https://pypi.org/project/pydantic/): Data validation and settings management using python type annotations.
+- [`docstring-parser`](https://pypi.org/project/docstring-parser/): A parser for Python docstrings, to improve the experience of working with docstrings in jsonschema.
+
+## Optional Dependencies
+
+### CLI Dependencies
+
+If you want to use the Instructor CLI tools, install with the CLI extras:
+
+```bash
+pip install "instructor[cli]"
+```
+
+This will install additional dependencies:
+
+- [`typer`](https://pypi.org/project/typer/): Build great CLIs. Easy to code. Based on Python type hints.
+- [`rich`](https://pypi.org/project/rich/): Rich text and beautiful formatting in the terminal.
+- [`aiohttp`](https://pypi.org/project/aiohttp/): Async HTTP client/server framework.
+
+### Provider-specific Dependencies
+
+To use specific LLM providers, you can install the required dependencies:
+
+```bash
+# For Anthropic Claude
+pip install "instructor[anthropic]"
+
+# For Gemini
+pip install "instructor[google-generativeai]"
+
+# For multiple providers
+pip install "instructor[anthropic,google-generativeai,cli]"
+```
 
 If you've got Python 3.9+ and `pip` installed, you're good to go.

--- a/instructor/cli/cli.py
+++ b/instructor/cli/cli.py
@@ -1,34 +1,56 @@
 from typing import Optional
-import typer
-from typer import Typer, launch
-import instructor.cli.jobs as jobs
-import instructor.cli.files as files
-import instructor.cli.usage as usage
-import instructor.cli.deprecated_hub as hub
-import instructor.cli.batch as batch
+import sys
+import importlib.util
 
-app: Typer = typer.Typer()
+# Check for required CLI dependencies
+missing_deps = []
+for package in ["typer", "rich", "aiohttp"]:
+    if importlib.util.find_spec(package) is None:
+        missing_deps.append(package)
 
-app.add_typer(jobs.app, name="jobs", help="Monitor and create fine tuning jobs")
-app.add_typer(files.app, name="files", help="Manage files on OpenAI's servers")
-app.add_typer(usage.app, name="usage", help="Check OpenAI API usage data")
-app.add_typer(
-    hub.app, name="hub", help="[DEPRECATED] The instructor hub is no longer available"
-)
-app.add_typer(batch.app, name="batch", help="Manage OpenAI Batch jobs")
+if missing_deps:
+
+    def app():
+        print("Error: CLI dependencies are missing. Please install them with:")
+        print(f'pip install "instructor[cli]"')
+        print("or")
+        print(f"pip install {' '.join(missing_deps)}")
+        sys.exit(1)
+else:
+    import typer
+    from typer import Typer, launch
+    import instructor.cli.jobs as jobs
+    import instructor.cli.files as files
+    import instructor.cli.usage as usage
+    import instructor.cli.deprecated_hub as hub
+    import instructor.cli.batch as batch
+
+    app: Typer = typer.Typer()
+
+    app.add_typer(jobs.app, name="jobs", help="Monitor and create fine tuning jobs")
+    app.add_typer(files.app, name="files", help="Manage files on OpenAI's servers")
+    app.add_typer(usage.app, name="usage", help="Check OpenAI API usage data")
+    app.add_typer(
+        hub.app,
+        name="hub",
+        help="[DEPRECATED] The instructor hub is no longer available",
+    )
+    app.add_typer(batch.app, name="batch", help="Manage OpenAI Batch jobs")
 
 
-@app.command()
-def docs(
-    query: Optional[str] = typer.Argument(None, help="Search the documentation"),
-) -> None:
-    """
-    Open the instructor documentation website.
-    """
-    if query:
-        launch(f"https://python.useinstructor.com/?q={query}")
-    else:
-        launch("https://python.useinstructor.com/")
+if not missing_deps:
+
+    @app.command()
+    def docs(
+        query: Optional[str] = typer.Argument(None, help="Search the documentation"),
+    ) -> None:
+        """
+        Open the instructor documentation website.
+        """
+        if query:
+            launch(f"https://python.useinstructor.com/?q={query}")
+        else:
+            launch("https://python.useinstructor.com/")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,6 @@ dependencies = [
     "openai<2.0.0,>=1.52.0",
     "pydantic<3.0.0,>=2.8.0",
     "docstring-parser<1.0,>=0.16",
-    "typer<1.0.0,>=0.9.0",
-    "rich<14.0.0,>=13.7.0",
-    "aiohttp<4.0.0,>=3.9.1",
     "tenacity<10.0.0,>=9.0.0",
     "pydantic-core<3.0.0,>=2.18.0",
     "jiter<0.9,>=0.6.1",
@@ -47,6 +44,11 @@ pythonVersion = "3.9"
 pythonPlatform = "Linux"
 
 [project.optional-dependencies]
+cli = [
+    "typer<1.0.0,>=0.9.0",
+    "rich<14.0.0,>=13.7.0",
+    "aiohttp<4.0.0,>=3.9.1",
+]
 test-docs = [
     "fastapi<0.116.0,>=0.109.2",
     "redis<6.0.0,>=5.0.1",
@@ -77,6 +79,11 @@ google-genai=["google-genai>=1.5.0","jsonref<2.0.0,>=1.1.0"]
 instructor = "instructor.cli.cli:app"
 
 [dependency-groups]
+cli = [
+    "typer<1.0.0,>=0.9.0",
+    "rich<14.0.0,>=13.7.0", 
+    "aiohttp<4.0.0,>=3.9.1",
+]
 dev = [
     "pytest<9.0.0,>=8.3.3",
     "pytest-asyncio<1.0.0,>=0.24.0",


### PR DESCRIPTION
## Summary
- Move typer, rich, and aiohttp from base dependencies to the new 'cli' optional dependency group
- Update installation documentation to explain CLI dependency installation
- Add graceful handling of missing CLI dependencies with user-friendly error messages

This resolves dependency conflicts with other packages that require different versions of these libraries (specifically the browseruse issue mentioned in #1512, which requires Rich >= 14, while instructor previously required Rich < 14).

## Test plan
- Install instructor without CLI dependencies: `pip install instructor`
- Try to use CLI and verify error message is helpful
- Install CLI dependencies: `pip install "instructor[cli]"`
- Verify CLI works correctly with dependencies installed

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move CLI dependencies to optional group, update installation docs, and add error handling for missing dependencies.
> 
>   - **Dependencies**:
>     - Move `typer`, `rich`, and `aiohttp` from base dependencies to `cli` optional group in `pyproject.toml`.
>     - Add `cli` dependency group to `[dependency-groups]` in `pyproject.toml`.
>   - **Documentation**:
>     - Update `docs/cli/index.md` and `docs/installation.md` to reflect new CLI installation instructions.
>   - **Error Handling**:
>     - Add check for missing CLI dependencies in `instructor/cli/cli.py` with user-friendly error messages if not installed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for eded34936cf2b684cc00e5c47bbdaf2923b578e7. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->