### PR TITLE
Fix: Handle Literal types correctly in Partial streaming mode

### DIFF
--- a/examples/literal_string_stream/README.md
+++ b/examples/literal_string_stream/README.md
@@ -1,0 +1,47 @@
+# Literal Types with Streaming
+
+This example demonstrates how to use Literal types with streaming in Instructor.
+
+## The Problem
+
+Previously, when using `Literal` types with streaming mode and `Partial`, validation would fail for partial strings. For example, if the model is outputting "Alice" character by character, the intermediate values like "A", "Al", "Ali" would cause validation errors because they're not valid literal values.
+
+## The Solution
+
+Instructor now handles `Literal` types specially during streaming. When using `Partial`, literal fields accept any string value during streaming, allowing the model to output values character by character. The final validation ensures the value matches one of the allowed literal values.
+
+## Usage
+
+```python
+from instructor import Partial
+from pydantic import BaseModel
+from typing import Literal
+
+class User(BaseModel):
+    name: Literal["Bob", "Alice", "John"]
+    role: Literal["admin", "user", "guest"]
+    age: int
+
+# Use Partial[User] for streaming
+stream = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Create a user named Alice"}],
+    response_model=Partial[User],
+    stream=True,
+)
+
+for partial_user in stream:
+    print(partial_user)  # Works even with partial literal values!
+```
+
+## Running the Example
+
+```bash
+python run.py
+```
+
+This will demonstrate:
+1. Non-streaming mode (works normally)
+2. Direct streaming without Partial (fails as expected)
+3. Streaming with Partial (now works with Literal types!)
+4. Complex models with multiple Literal fields

--- a/examples/literal_string_stream/run.py
+++ b/examples/literal_string_stream/run.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating how Literal types work with streaming in Instructor.
+
+This example shows:
+1. Non-streaming mode works fine with Literal types
+2. Direct streaming without Partial doesn't work (expected behavior)
+3. Streaming with Partial now works correctly with Literal types
+"""
+
+import instructor
+from openai import OpenAI
+from pydantic import BaseModel
+from typing import Literal
+
+
+class User(BaseModel):
+    name: Literal["Bob", "Alice", "John"]
+    role: Literal["admin", "user", "guest"]
+    age: int
+
+
+def test_non_streaming():
+    """Test with non-streaming mode - works correctly"""
+    print("Testing non-streaming mode...")
+
+    client = instructor.from_openai(OpenAI())
+
+    try:
+        user = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Create a user named Alice who is 25 years old and has admin role",
+                }
+            ],
+            response_model=User,
+        )
+        print(f"✓ Non-streaming success: {user}")
+    except Exception as e:
+        print(f"✗ Non-streaming failed: {type(e).__name__}: {e}")
+
+
+def test_streaming_without_partial():
+    """Test with streaming mode without Partial - expected to fail"""
+    print("\nTesting streaming without Partial (expected to fail)...")
+
+    client = instructor.from_openai(OpenAI())
+
+    try:
+        # This will fail because direct streaming requires using Partial
+        user = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Create a user named Bob who is 30 years old and has user role",
+                }
+            ],
+            response_model=User,
+            stream=True,
+        )
+        print(f"✓ Streaming success: {user}")
+    except Exception as e:
+        print(
+            f"✗ Expected failure - {type(e).__name__}: Direct streaming requires Partial"
+        )
+
+
+def test_streaming_with_partial():
+    """Test with streaming mode using Partial - now works with Literal types!"""
+    print("\nTesting streaming with Partial (fixed to work with Literals)...")
+
+    from instructor import Partial
+
+    client = instructor.from_openai(OpenAI())
+
+    try:
+        stream = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Create a user named John who is 35 years old and has guest role",
+                }
+            ],
+            response_model=Partial[User],
+            stream=True,
+        )
+
+        # Track the progression of the stream
+        updates = []
+        for partial_user in stream:
+            update = {
+                "name": partial_user.name,
+                "role": partial_user.role,
+                "age": partial_user.age,
+            }
+            # Only print if something changed
+            if not updates or updates[-1] != update:
+                print(
+                    f"  Partial update: name={update['name']!r}, role={update['role']!r}, age={update['age']}"
+                )
+                updates.append(update)
+
+        print("✓ Streaming with Partial completed successfully!")
+        print(f"  Final result: {updates[-1]}")
+    except Exception as e:
+        print(f"✗ Streaming with Partial failed: {type(e).__name__}: {e}")
+        import traceback
+
+        traceback.print_exc()
+
+
+def test_complex_literal_streaming():
+    """Test more complex model with multiple Literal fields"""
+    print("\nTesting complex model with multiple Literal fields...")
+
+    from instructor import Partial
+
+    class Product(BaseModel):
+        name: str
+        category: Literal["electronics", "clothing", "food", "books"]
+        status: Literal["available", "out_of_stock", "discontinued"]
+        condition: Literal["new", "used", "refurbished"]
+        priority: Literal["low", "medium", "high"]
+        price: float
+
+    client = instructor.from_openai(OpenAI())
+
+    stream = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {
+                "role": "user",
+                "content": "Create a product: iPhone 15 in electronics category, available, new condition, high priority, $999",
+            }
+        ],
+        response_model=Partial[Product],
+        stream=True,
+    )
+
+    final_product = None
+    for partial_product in stream:
+        final_product = partial_product
+
+    print(f"✓ Complex streaming completed: {final_product}")
+
+
+if __name__ == "__main__":
+    print("Literal Types with Streaming in Instructor")
+    print("=" * 50)
+    print("This example demonstrates the fix for Literal types in streaming mode.")
+    print("Previously, Literal fields would cause validation errors during streaming")
+    print("because partial values (e.g., 'Al' while typing 'Alice') are not valid.")
+    print("The fix allows any string during streaming, then validates the final value.")
+    print("=" * 50)
+
+    test_non_streaming()
+    test_streaming_without_partial()
+    test_streaming_with_partial()
+    test_complex_literal_streaming()

--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -126,11 +126,11 @@ def _make_field_optional(
             # 2. Any string (to handle partial values during streaming)
             # 3. None only if the original field was optional
             if is_optional or field.is_required() is False:
-                tmp_field.annotation = Optional[Union[annotation, str]]
+                tmp_field.annotation = Optional[Union[annotation, str]]  # type: ignore[assignment]
                 tmp_field.default = None
             else:
                 # Required literal field - don't allow None
-                tmp_field.annotation = Union[annotation, str]
+                tmp_field.annotation = Union[annotation, str]  # type: ignore[assignment]
                 tmp_field.default = ""  # Use empty string instead of None
         else:
             # Get the generic base (like List, Dict) and its arguments (like User in List[User])
@@ -154,7 +154,7 @@ def _make_field_optional(
             Optional[original_annotation]
             if original_annotation
             else Optional[field.annotation]
-        )  # type:ignore
+        )  # type: ignore[assignment]
         tmp_field.default = None
 
     return tmp_field.annotation, tmp_field  # type: ignore

--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -101,6 +101,19 @@ def _make_field_optional(
 
     annotation = field.annotation
 
+    # Check if the original field is already Optional
+    is_optional = False
+    original_annotation = annotation
+    if get_origin(annotation) is Union:
+        # Check if None is in the union args (meaning it's Optional)
+        union_args = get_args(annotation)
+        if type(None) in union_args:
+            is_optional = True
+            # Get the non-None type from the Union
+            non_none_args = [arg for arg in union_args if arg is not type(None)]
+            if len(non_none_args) == 1:
+                annotation = non_none_args[0]
+
     # Handle generics (like List, Dict, etc.)
     if get_origin(annotation) is not None:
         generic_base = get_origin(annotation)
@@ -111,9 +124,14 @@ def _make_field_optional(
             # For Literal types during streaming, we want to accept:
             # 1. The literal values themselves
             # 2. Any string (to handle partial values during streaming)
-            # 3. None (for optional fields)
-            tmp_field.annotation = Optional[Union[annotation, str]]
-            tmp_field.default = None
+            # 3. None only if the original field was optional
+            if is_optional or field.is_required() is False:
+                tmp_field.annotation = Optional[Union[annotation, str]]
+                tmp_field.default = None
+            else:
+                # Required literal field - don't allow None
+                tmp_field.annotation = Union[annotation, str]
+                tmp_field.default = ""  # Use empty string instead of None
         else:
             # Get the generic base (like List, Dict) and its arguments (like User in List[User])
             modified_args = tuple(
@@ -132,7 +150,11 @@ def _make_field_optional(
         tmp_field.annotation = Optional[Partial[annotation, MakeFieldsOptional]]  # type: ignore[assignment, valid-type]
         tmp_field.default = {}
     else:
-        tmp_field.annotation = Optional[field.annotation]  # type:ignore
+        tmp_field.annotation = (
+            Optional[original_annotation]
+            if original_annotation
+            else Optional[field.annotation]
+        )  # type:ignore
         tmp_field.default = None
 
     return tmp_field.annotation, tmp_field  # type: ignore

--- a/tests/dsl/test_literal_comprehensive.py
+++ b/tests/dsl/test_literal_comprehensive.py
@@ -1,0 +1,221 @@
+"""Comprehensive tests for Literal types with Partial"""
+
+from pydantic import BaseModel, ValidationError
+from typing import Literal, Optional, Union
+from instructor.dsl.partial import Partial
+import pytest
+
+
+class TestLiteralPartialHandling:
+    """Test suite for Literal type handling in Partial models"""
+
+    def test_required_literal_basic(self):
+        """Test basic required literal field behavior"""
+
+        class Model(BaseModel):
+            status: Literal["active", "inactive", "pending"]
+
+        partial_model = Partial[Model].get_partial_model()
+
+        # Should accept partial strings during streaming
+        assert partial_model.model_validate({"status": "a"}).status == "a"
+        assert partial_model.model_validate({"status": "ac"}).status == "ac"
+        assert partial_model.model_validate({"status": "active"}).status == "active"
+
+        # Should NOT accept None for required field
+        with pytest.raises(ValidationError):
+            partial_model.model_validate({"status": None})
+
+        # Empty object should default to empty string
+        assert partial_model.model_validate({}).status == ""
+
+    def test_optional_literal_basic(self):
+        """Test basic optional literal field behavior"""
+
+        class Model(BaseModel):
+            status: Optional[Literal["active", "inactive", "pending"]]
+
+        partial_model = Partial[Model].get_partial_model()
+
+        # Should accept partial strings during streaming
+        assert partial_model.model_validate({"status": "a"}).status == "a"
+        assert partial_model.model_validate({"status": "ac"}).status == "ac"
+        assert partial_model.model_validate({"status": "active"}).status == "active"
+
+        # SHOULD accept None for optional field
+        assert partial_model.model_validate({"status": None}).status is None
+
+        # Empty object should default to None for optional
+        assert partial_model.model_validate({}).status is None
+
+    def test_literal_union_with_none(self):
+        """Test Literal in Union with None (another way to express Optional)"""
+
+        class Model(BaseModel):
+            status: Union[Literal["active", "inactive"], None]
+
+        partial_model = Partial[Model].get_partial_model()
+
+        # Should behave like Optional
+        assert partial_model.model_validate({"status": None}).status is None
+        assert partial_model.model_validate({}).status is None
+        assert partial_model.model_validate({"status": "a"}).status == "a"
+
+    def test_final_validation_required(self):
+        """Test that final validation works correctly for required literals"""
+
+        class Model(BaseModel):
+            color: Literal["red", "green", "blue"]
+
+        partial_model = Partial[Model].get_partial_model()
+
+        # Partial accepts invalid literal
+        partial_result = partial_model.model_validate({"color": "yellow"})
+        assert partial_result.color == "yellow"
+
+        # But final validation should fail
+        with pytest.raises(ValidationError) as exc_info:
+            Model.model_validate(partial_result.model_dump())
+        assert "literal_error" in str(exc_info.value)
+
+        # Valid literal should work end-to-end
+        partial_valid = partial_model.model_validate({"color": "red"})
+        final_valid = Model.model_validate(partial_valid.model_dump())
+        assert final_valid.color == "red"
+
+    def test_final_validation_optional(self):
+        """Test that final validation works correctly for optional literals"""
+
+        class Model(BaseModel):
+            color: Optional[Literal["red", "green", "blue"]]
+
+        partial_model = Partial[Model].get_partial_model()
+
+        # Test None preservation
+        partial_none = partial_model.model_validate({"color": None})
+        final_none = Model.model_validate(partial_none.model_dump())
+        assert final_none.color is None
+
+        # Test invalid literal
+        partial_invalid = partial_model.model_validate({"color": "yellow"})
+        with pytest.raises(ValidationError):
+            Model.model_validate(partial_invalid.model_dump())
+
+        # Test valid literal
+        partial_valid = partial_model.model_validate({"color": "blue"})
+        final_valid = Model.model_validate(partial_valid.model_dump())
+        assert final_valid.color == "blue"
+
+    def test_streaming_simulation(self):
+        """Simulate realistic streaming scenarios"""
+
+        class User(BaseModel):
+            name: str
+            role: Literal["admin", "user", "guest"]
+            status: Optional[Literal["active", "inactive"]]
+
+        partial_model = Partial[User].get_partial_model()
+
+        # Simulate streaming "admin" for role
+        streaming_chunks = [
+            '{"name": "John", "role": ""}',
+            '{"name": "John", "role": "a"}',
+            '{"name": "John", "role": "ad"}',
+            '{"name": "John", "role": "adm"}',
+            '{"name": "John", "role": "admi"}',
+            '{"name": "John", "role": "admin"}',
+            '{"name": "John", "role": "admin", "status": "active"}',
+        ]
+
+        for chunk in streaming_chunks:
+            result = partial_model.model_validate_json(chunk)
+            # All chunks should validate successfully
+            assert result.name == "John"
+            assert isinstance(result.role, str)  # Can be partial string
+
+        # Final validation
+        final_data = partial_model.model_validate_json(streaming_chunks[-1])
+        final_user = User.model_validate(final_data.model_dump())
+        assert final_user.role == "admin"
+        assert final_user.status == "active"
+
+    def test_complex_nested_literals(self):
+        """Test complex models with nested literal fields"""
+
+        class Address(BaseModel):
+            country: Literal["US", "UK", "CA"]
+            state: Optional[str]
+
+        class User(BaseModel):
+            name: str
+            role: Literal["admin", "user"]
+            address: Address
+            preferred_contact: Optional[Literal["email", "phone", "mail"]]
+
+        partial_model = Partial[User].get_partial_model()
+
+        # Test partial data
+        data = {
+            "name": "Alice",
+            "role": "adm",  # Partial
+            "address": {
+                "country": "U",  # Partial
+                "state": "NY",
+            },
+            "preferred_contact": "em",  # Partial
+        }
+
+        result = partial_model.model_validate(data)
+        assert result.role == "adm"
+        assert result.address.country == "U"  # type: ignore
+        assert result.preferred_contact == "em"
+
+    def test_literal_with_single_value(self):
+        """Test Literal with single value"""
+
+        class Model(BaseModel):
+            version: Literal["1.0"]
+            optional_flag: Optional[Literal[True]]
+
+        partial_model = Partial[Model].get_partial_model()
+
+        # Even single literals should accept partial strings
+        assert partial_model.model_validate({"version": "1"}).version == "1"
+        assert partial_model.model_validate({"version": "1."}).version == "1."
+        assert partial_model.model_validate({"version": "1.0"}).version == "1.0"
+
+        # Optional literal with boolean
+        assert partial_model.model_validate({}).optional_flag is None
+        assert (
+            partial_model.model_validate({"optional_flag": True}).optional_flag is True
+        )
+
+    def test_schema_generation(self):
+        """Test that schemas are generated correctly"""
+
+        class Model(BaseModel):
+            required_lit: Literal["a", "b", "c"]
+            optional_lit: Optional[Literal["x", "y", "z"]]
+
+        partial_model = Partial[Model].get_partial_model()
+        schema = partial_model.model_json_schema()
+
+        # Check required literal schema
+        required_schema = schema["properties"]["required_lit"]
+        assert "anyOf" in required_schema
+        assert any(
+            opt.get("enum") == ["a", "b", "c"] for opt in required_schema["anyOf"]
+        )
+        assert any(opt.get("type") == "string" for opt in required_schema["anyOf"])
+        assert not any(opt.get("type") == "null" for opt in required_schema["anyOf"])
+        assert required_schema.get("default") == ""
+
+        # Check optional literal schema
+        optional_schema = schema["properties"]["optional_lit"]
+        assert "anyOf" in optional_schema
+        assert any(
+            opt.get("enum") == ["x", "y", "z"] for opt in optional_schema["anyOf"]
+        )
+        assert any(opt.get("type") == "string" for opt in optional_schema["anyOf"])
+        assert any(opt.get("type") == "null" for opt in optional_schema["anyOf"])
+        assert optional_schema.get("default") is None

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -1,6 +1,6 @@
 # type: ignore[all]
 from pydantic import BaseModel, Field
-from typing import Optional, Union
+from typing import Optional, Union, Literal
 from instructor.dsl.partial import Partial, PartialLiteralMixin
 import pytest
 import instructor
@@ -195,3 +195,75 @@ def test_union_with_nested():
     partial.get_partial_model().model_validate_json(
         '{"a": [{"b": "b"}, {"d": "d"}], "b": [{"b": "b"}], "c": {"d": "d"}, "e": [1, "a"]}'
     )
+
+
+def test_literal_partial_streaming():
+    """Test that Literal types work correctly with Partial during streaming"""
+
+    class UserWithLiteral(BaseModel):
+        name: Literal["Bob", "Alice", "John"]
+        status: Literal["active", "inactive", "pending"]
+        age: int
+
+    partial = Partial[UserWithLiteral]
+    partial_model = partial.get_partial_model()
+
+    # Test various streaming scenarios
+    test_cases = [
+        ("{}", {"name": None, "status": None, "age": None}),
+        ('{"name": ""}', {"name": "", "status": None, "age": None}),
+        ('{"name": "A"}', {"name": "A", "status": None, "age": None}),
+        ('{"name": "Al"}', {"name": "Al", "status": None, "age": None}),
+        ('{"name": "Ali"}', {"name": "Ali", "status": None, "age": None}),
+        ('{"name": "Alice"}', {"name": "Alice", "status": None, "age": None}),
+        (
+            '{"name": "Alice", "status": "a"}',
+            {"name": "Alice", "status": "a", "age": None},
+        ),
+        (
+            '{"name": "Alice", "status": "active"}',
+            {"name": "Alice", "status": "active", "age": None},
+        ),
+        (
+            '{"name": "Alice", "status": "active", "age": 25}',
+            {"name": "Alice", "status": "active", "age": 25},
+        ),
+    ]
+
+    for json_str, expected in test_cases:
+        result = partial_model.model_validate_json(json_str)
+        assert result.model_dump() == expected, f"Failed for {json_str}"
+
+
+def test_literal_field_schema():
+    """Test that Literal fields in Partial models have the correct schema"""
+
+    class ModelWithLiteral(BaseModel):
+        color: Literal["red", "green", "blue"]
+        size: int
+
+    partial = Partial[ModelWithLiteral]
+    partial_model = partial.get_partial_model()
+    schema = partial_model.model_json_schema()
+
+    # Check that the color field allows both literal values and strings
+    color_schema = schema["properties"]["color"]
+    assert "anyOf" in color_schema
+
+    # Should have 3 options: the literal enum, string type, and null
+    any_of_options = color_schema["anyOf"]
+    assert len(any_of_options) == 3
+
+    # Check for the literal enum option
+    has_enum = any(
+        opt.get("enum") == ["red", "green", "blue"] for opt in any_of_options
+    )
+    assert has_enum, "Should have literal enum option"
+
+    # Check for string type option
+    has_string = any(opt.get("type") == "string" for opt in any_of_options)
+    assert has_string, "Should have string type option"
+
+    # Check for null type option
+    has_null = any(opt.get("type") == "null" for opt in any_of_options)
+    assert has_null, "Should have null type option"

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -210,12 +210,15 @@ def test_literal_partial_streaming():
 
     # Test various streaming scenarios
     test_cases = [
-        ("{}", {"name": None, "status": None, "age": None}),
-        ('{"name": ""}', {"name": "", "status": None, "age": None}),
-        ('{"name": "A"}', {"name": "A", "status": None, "age": None}),
-        ('{"name": "Al"}', {"name": "Al", "status": None, "age": None}),
-        ('{"name": "Ali"}', {"name": "Ali", "status": None, "age": None}),
-        ('{"name": "Alice"}', {"name": "Alice", "status": None, "age": None}),
+        (
+            "{}",
+            {"name": "", "status": "", "age": None},
+        ),  # Required literals default to ""
+        ('{"name": ""}', {"name": "", "status": "", "age": None}),
+        ('{"name": "A"}', {"name": "A", "status": "", "age": None}),
+        ('{"name": "Al"}', {"name": "Al", "status": "", "age": None}),
+        ('{"name": "Ali"}', {"name": "Ali", "status": "", "age": None}),
+        ('{"name": "Alice"}', {"name": "Alice", "status": "", "age": None}),
         (
             '{"name": "Alice", "status": "a"}',
             {"name": "Alice", "status": "a", "age": None},

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -253,9 +253,9 @@ def test_literal_field_schema():
     color_schema = schema["properties"]["color"]
     assert "anyOf" in color_schema
 
-    # Should have 3 options: the literal enum, string type, and null
+    # Should have 2 options for required literal: the literal enum and string type
     any_of_options = color_schema["anyOf"]
-    assert len(any_of_options) == 3
+    assert len(any_of_options) == 2  # No null for required fields
 
     # Check for the literal enum option
     has_enum = any(
@@ -267,6 +267,6 @@ def test_literal_field_schema():
     has_string = any(opt.get("type") == "string" for opt in any_of_options)
     assert has_string, "Should have string type option"
 
-    # Check for null type option
+    # Check that there's NO null type option (because it's required)
     has_null = any(opt.get("type") == "null" for opt in any_of_options)
-    assert has_null, "Should have null type option"
+    assert not has_null, "Should NOT have null type option for required field"


### PR DESCRIPTION
## Summary
- Fixed ValidationError when using Literal types with Partial in streaming mode
- Modified `_make_field_optional` to accept any string for Literal fields during streaming
- Properly handles required vs optional Literal fields
- Added comprehensive tests and example demonstrating the fix

## Problem
When using `Literal` types with `Partial` in streaming mode, validation would fail because partial strings (e.g., "A", "Al", "Ali" while typing "Alice") are not valid literal values.

```python
class User(BaseModel):
    name: Literal["Bob", "Alice", "John"]
    age: int

# This would fail during streaming when name is partially complete
stream = client.chat.completions.create(
    model="gpt-4o-mini",
    response_model=Partial[User],
    stream=True,
)
```

## Solution
Modified the `_make_field_optional` function in `instructor/dsl/partial.py` to handle Literal types specially:
- During streaming, required literal fields accept `Union[Literal[...], str]` (no None allowed)
- Optional literal fields accept `Optional[Union[Literal[...], str]]`
- This allows partial strings to pass validation while streaming
- Final validation against the original model ensures invalid literals are still caught

## Important Notes
- **Required fields stay required**: Required Literal fields don't accept None during streaming
- **Type safety maintained**: Invalid literal values (e.g., "Mary" instead of "Alice") will still fail validation when used with the original model
- **Streaming experience**: Smooth streaming without validation errors for partial strings

## Test plan
- [x] Added unit tests for Literal types with Partial streaming
- [x] Added schema validation tests
- [x] Added tests for required vs optional Literal fields
- [x] Created comprehensive example in `examples/literal_string_stream/`
- [x] All existing tests pass
- [x] Manually tested with OpenAI API

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes handling of `Literal` types in `Partial` streaming mode by allowing partial strings, with updates to `_make_field_optional` and comprehensive tests.
> 
>   - **Behavior**:
>     - Fixes `ValidationError` for `Literal` types with `Partial` in streaming mode by allowing partial strings.
>     - Modifies `_make_field_optional` in `partial.py` to handle `Literal` types, allowing `Union[Literal[...], str]` for required fields and `Optional[Union[Literal[...], str]]` for optional fields.
>   - **Tests**:
>     - Adds `test_literal_comprehensive.py` with tests for required and optional `Literal` fields, final validation, and schema generation.
>     - Updates `test_partial.py` with tests for `Literal` types in streaming scenarios and schema validation.
>   - **Examples**:
>     - Adds `literal_string_stream` example demonstrating `Literal` types with streaming in `README.md` and `run.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 62f933436a5f3dc3f202bc9123adb50896204053. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->