### PR TITLE
Remove `enable_prompt_caching` from Anthropic integration since we ha…

### DIFF
--- a/docs/integrations/anthropic.md
+++ b/docs/integrations/anthropic.md
@@ -419,7 +419,6 @@ class Character(BaseModel):
 client = instructor.from_anthropic(
     Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY")),
     mode=instructor.Mode.ANTHROPIC_TOOLS,
-    enable_prompt_caching=True  # Enable prompt caching
 )
 
 try:
@@ -496,7 +495,6 @@ class ImageAnalyzer(BaseModel):
 client = instructor.from_anthropic(
     Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY")),
     mode=instructor.Mode.ANTHROPIC_TOOLS,
-    enable_prompt_caching=True  # Enable prompt caching
 )
 
 try:

--- a/instructor/client_anthropic.py
+++ b/instructor/client_anthropic.py
@@ -48,7 +48,6 @@ def from_anthropic(
     Args:
         client: An instance of Anthropic client (sync or async)
         mode: The mode to use for the client (ANTHROPIC_JSON or ANTHROPIC_TOOLS)
-        enable_prompt_caching: Whether to enable prompt caching (requires Anthropic or AsyncAnthropic client)
         beta: Whether to use beta API features (uses client.beta.messages.create)
         **kwargs: Additional keyword arguments to pass to the Instructor constructor
 


### PR DESCRIPTION
…ve migrated to use the beta keyword
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `enable_prompt_caching` from `from_anthropic()` and update `anthropic.md` to reflect this change.
> 
>   - **Functionality**:
>     - Remove `enable_prompt_caching` parameter from `from_anthropic()` in `client_anthropic.py`.
>     - Remove `enable_prompt_caching` usage in `anthropic.md` examples.
>   - **Documentation**:
>     - Update `anthropic.md` to reflect removal of `enable_prompt_caching` in client initialization examples.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 7d96b2220d9bc3a164415f6f10bd3702fe2c1971. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->