### PR TITLE
pop generation_config for genai models and use as additional kwargs

### DIFF
--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -551,10 +551,14 @@ def handle_genai_structured_outputs(
 
     new_kwargs["contents"] = convert_to_genai_messages(new_kwargs["messages"])
     new_kwargs["contents"] = extract_genai_multimodal_content(new_kwargs["contents"])
+    
+    config: dict[str, Any] | None = new_kwargs.pop("generation_config", None)
+    
     new_kwargs["config"] = types.GenerateContentConfig(
         system_instruction=system_message,
         response_mime_type="application/json",
         response_schema=response_model,
+        **(config if config else {}),
     )
     new_kwargs.pop("response_model", None)
     new_kwargs.pop("messages", None)
@@ -582,6 +586,8 @@ def handle_genai_tools(
     else:
         system_message = None
 
+    config: dict[str, Any] | None = new_kwargs.pop("generation_config", None)
+    
     new_kwargs["config"] = types.GenerateContentConfig(
         system_instruction=system_message,
         tools=[types.Tool(function_declarations=[function_definition])],
@@ -590,6 +596,7 @@ def handle_genai_tools(
                 mode="ANY", allowed_function_names=[response_model.__name__]
             ),
         ),
+        **(config if config else {}),
     )
 
     new_kwargs["contents"] = convert_to_genai_messages(new_kwargs["messages"])


### PR DESCRIPTION
This PR fixed the passing genai generation_config down to the genai client issue #1531 