### PR TITLE
feat(auto_client): add Ollama provider support

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -125,6 +125,7 @@ Supported provider strings:
 - `fireworks/model-name`: Fireworks models
 - `vertexai/model-name`: Vertex AI models
 - `genai/model-name`: Google GenAI models
+- `ollama/model-name`: Ollama models
 
 ### 2. Manual Client Setup
 

--- a/docs/integrations/ollama.md
+++ b/docs/integrations/ollama.md
@@ -63,6 +63,34 @@ resp = client.chat.completions.create(
 )
 ```
 
+### Intelligent Mode Selection
+
+The auto client automatically selects the best mode based on your model:
+
+- **Function Calling Models** (llama3.1, llama3.2, llama4, mistral-nemo, qwen2.5, etc.): Uses `TOOLS` mode for enhanced function calling support
+- **Other Models**: Uses `JSON` mode for structured output
+
+```python
+# These models automatically use TOOLS mode
+client = instructor.from_provider("ollama/llama3.1")
+client = instructor.from_provider("ollama/qwen2.5")
+
+# Other models use JSON mode
+client = instructor.from_provider("ollama/llama2")
+```
+
+You can also override the mode manually:
+
+```python
+import instructor
+
+# Force JSON mode
+client = instructor.from_provider("ollama/llama3.1", mode=instructor.Mode.JSON)
+
+# Force TOOLS mode  
+client = instructor.from_provider("ollama/llama2", mode=instructor.Mode.TOOLS)
+```
+
 ## Manual Setup
 
 ```python

--- a/docs/integrations/ollama.md
+++ b/docs/integrations/ollama.md
@@ -42,6 +42,29 @@ Start by downloading [Ollama](https://ollama.ai/download), and then pull a model
 ollama pull llama2
 ```
 
+## Quick Start with Auto Client
+
+You can use Ollama with Instructor's auto client for a simple setup:
+
+```python
+import instructor
+from pydantic import BaseModel
+
+class Character(BaseModel):
+    name: str
+    age: int
+
+# Simple setup - automatically configured for Ollama
+client = instructor.from_provider("ollama/llama2")
+
+resp = client.chat.completions.create(
+    messages=[{"role": "user", "content": "Tell me about Harry Potter"}],
+    response_model=Character,
+)
+```
+
+## Manual Setup
+
 ```python
 from openai import OpenAI
 from pydantic import BaseModel, Field

--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -349,10 +349,35 @@ def from_provider(
                 if async_client
                 else openai.OpenAI(base_url=base_url, api_key=api_key)
             )
+
+            # Models that support function calling (tools mode)
+            tool_capable_models = {
+                "llama3.1",
+                "llama3.2",
+                "llama4",
+                "mistral-nemo",
+                "firefunction-v2",
+                "command-r-plus",
+                "qwen2.5",
+                "qwen2.5-coder",
+                "qwen3",
+                "devstral",
+            }
+
+            # Check if model supports tools by looking at model name
+            supports_tools = any(
+                capable_model in model_name.lower()
+                for capable_model in tool_capable_models
+            )
+
+            default_mode = (
+                instructor.Mode.TOOLS if supports_tools else instructor.Mode.JSON
+            )
+
             return from_openai(
                 client,
                 model=model_name,
-                mode=mode if mode else instructor.Mode.JSON,
+                mode=mode if mode else default_mode,
                 **kwargs,
             )
         except ImportError:

--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -23,6 +23,7 @@ supported_providers = [
     "fireworks",
     "vertexai",
     "generative-ai",
+    "ollama",
 ]
 
 
@@ -82,6 +83,7 @@ def from_provider(
         >>> # Sync clients
         >>> client = instructor.from_provider("openai/gpt-4")
         >>> client = instructor.from_provider("anthropic/claude-3-sonnet")
+        >>> client = instructor.from_provider("ollama/llama2")
         >>> # Async clients
         >>> async_client = instructor.from_provider("openai/gpt-4", async_client=True)
     """
@@ -332,6 +334,34 @@ def from_provider(
                 "Install it with `pip install google-genai`."
             )
             raise import_err from None
+
+    elif provider == "ollama":
+        try:
+            import openai
+            from instructor import from_openai
+
+            # Get base_url from kwargs or use default
+            base_url = kwargs.pop("base_url", "http://localhost:11434/v1")
+            api_key = kwargs.pop("api_key", "ollama")  # required but unused
+
+            client = (
+                openai.AsyncOpenAI(base_url=base_url, api_key=api_key)
+                if async_client
+                else openai.OpenAI(base_url=base_url, api_key=api_key)
+            )
+            return from_openai(
+                client,
+                model=model_name,
+                mode=mode if mode else instructor.Mode.JSON,
+                **kwargs,
+            )
+        except ImportError:
+            from instructor.exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "The openai package is required to use the Ollama provider. "
+                "Install it with `pip install openai`."
+            ) from None
 
     else:
         from instructor.exceptions import ConfigurationError


### PR DESCRIPTION
Adds Ollama provider to auto_client for easy setup with instructor.from_provider('ollama/model-name'). Uses default JSON mode and localhost:11434 base URL.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds Ollama provider support to `auto_client` with automatic mode selection and updates documentation for usage.
> 
>   - **Behavior**:
>     - Adds support for `ollama/model-name` in `from_provider()` in `auto_client.py`, using default JSON mode and localhost:11434 base URL.
>     - Automatically selects `TOOLS` mode for function-calling models (e.g., `llama3.1`, `qwen2.5`), otherwise uses `JSON` mode.
>   - **Documentation**:
>     - Updates `index.md` and `ollama.md` to include Ollama provider details and usage examples.
>     - Adds Ollama to the list of supported providers in `index.md`.
>   - **Misc**:
>     - Raises `ConfigurationError` if `openai` package is not installed when using Ollama provider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 404bf6c4ba1117a0eae0cbf4489e971295f19f17. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->