### PR TITLE
fix: respect timeout parameter in retry mechanism for Ollama compatibility

### DIFF
--- a/docs/concepts/retrying.md
+++ b/docs/concepts/retrying.md
@@ -275,6 +275,42 @@ print(response.model_dump_json(indent=2))
 """
 ```
 
+## Global Timeout Support
+
+Instructor supports a global timeout parameter that limits the total time spent on retries across all attempts. This is particularly useful when working with providers like Ollama where you need strict control over request timeouts.
+
+```python
+import openai
+import instructor
+from pydantic import BaseModel
+
+client = instructor.from_openai(openai.OpenAI(), mode=instructor.Mode.TOOLS)
+
+class UserDetail(BaseModel):
+    name: str
+    age: int
+
+response = client.chat.completions.create(
+    model="gpt-4-turbo-preview",
+    response_model=UserDetail,
+    messages=[
+        {"role": "user", "content": "Extract `jason is 12`"},
+    ],
+    max_retries=3,
+    timeout=5.0,  # Total timeout across all retry attempts
+)
+```
+
+The timeout parameter works by:
+
+- **Global Timeout**: Limits the total time spent across all retry attempts, not per individual attempt
+- **OR Logic**: Combines with other stop conditions - retries stop if ANY condition is met (max attempts OR timeout reached)
+- **Provider Compatibility**: Ensures consistent timeout behavior across different providers, especially Ollama
+
+!!! note "Timeout vs Per-Attempt Timeout"
+
+    The timeout parameter controls the **total time** spent on retries, not the timeout for each individual attempt. This prevents scenarios where a 3-second timeout becomes 9+ seconds total when retrying multiple times.
+
 ## Other Features of Tenacity
 
 Tenacity features a huge number of different retrying capabilities. A few of them are listed below.


### PR DESCRIPTION
Fixes issue where timeout doesn't work as expected with Ollama integration

## Problem
Instructor's retry mechanism was multiplying timeout duration by the number of retry attempts, causing a 3-second timeout to become 9-13+ seconds total.

## Solution
- Add timeout parameter to initialize_retrying() function
- Extract timeout from kwargs in both sync and async retry functions
- Combine stop_after_attempt and stop_after_delay with OR logic
- Ensures total retry time respects global timeout instead of multiplying per attempt

## Testing
Tested with unit tests and verified timeout logic works correctly.

Resolves #1597

Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes timeout handling in retry mechanism for Ollama integration by adding a timeout parameter and ensuring global timeout is respected.
> 
>   - **Behavior**:
>     - Fixes timeout handling in retry mechanism for Ollama integration by ensuring global timeout is respected.
>     - Adds `timeout` parameter to `initialize_retrying()` to limit total retry duration.
>     - Extracts `timeout` from `kwargs` in `retry_sync()` and `retry_async()`.
>     - Combines `stop_after_attempt` and `stop_after_delay` with OR logic in `initialize_retrying()`.
>   - **Functions**:
>     - Modifies `initialize_retrying()` to accept and handle `timeout` parameter.
>     - Updates `retry_sync()` and `retry_async()` to pass `timeout` to `initialize_retrying()`.
>   - **Testing**:
>     - Verified with unit tests to ensure timeout logic functions correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for af719fba6d9efab153908855b8b48625aec15672. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->