### PR TITLE
fix(reask): handle ThinkingBlock in reask_anthropic_json

### DIFF
--- a/instructor/reask.py
+++ b/instructor/reask.py
@@ -73,9 +73,18 @@ def reask_anthropic_json(
 
     assert isinstance(response, Message), "Response must be a Anthropic Message"
 
+    # Filter for text blocks to handle ThinkingBlock and other non-text content
+    text_blocks = [c for c in response.content if c.type == "text"]
+    if not text_blocks:
+        # Fallback if no text blocks found
+        text_content = "No text content found in response"
+    else:
+        # Use the last text block, similar to function_calls.py:396-397
+        text_content = text_blocks[-1].text
+
     reask_msg = {
         "role": "user",
-        "content": f"""Validation Errors found:\n{exception}\nRecall the function correctly, fix the errors found in the following attempt:\n{response.content[0].text}""",  # type: ignore
+        "content": f"""Validation Errors found:\n{exception}\nRecall the function correctly, fix the errors found in the following attempt:\n{text_content}""",
     }
     kwargs["messages"].append(reask_msg)
     return kwargs


### PR DESCRIPTION
Fixes #1596

The `reask_anthropic_json` function was failing when Anthropic used extended thinking because it assumed `response.content[0]` was always a text block. With extended thinking, the first content can be a `ThinkingBlock` which doesn't have a `.text` attribute, causing `AttributeError`.

## Solution

Fixed by filtering for text blocks similar to the pattern in `function_calls.py`:
- Filter content by `c.type == "text"` to exclude ThinkingBlocks
- Use the last text block for consistent behavior
- Add fallback handling if no text blocks are found

## Testing

The fix ensures compatibility with:
- Regular Anthropic responses without thinking
- Extended thinking responses with ThinkingBlocks
- Mixed content responses

Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `reask_anthropic_json` to handle `ThinkingBlock` by filtering for text blocks and adding fallback handling.
> 
>   - **Behavior**:
>     - Fixes `reask_anthropic_json` in `reask.py` to handle `ThinkingBlock` by filtering for text blocks.
>     - Uses the last text block for consistent behavior and adds fallback if no text blocks are found.
>   - **Compatibility**:
>     - Ensures compatibility with regular Anthropic responses, extended thinking responses, and mixed content responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 7e66231fe578fc67638200060d18e7b818a91c70. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->