### PR TITLE
fix: expose exception classes in public API

### DIFF
--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -4,6 +4,14 @@ from .mode import Mode
 from .process_response import handle_response_model
 from .distil import FinetuneFormat, Instructions
 from .multimodal import Image, Audio
+from .exceptions import (
+    InstructorError,
+    ValidationError,
+    ProviderError,
+    ConfigurationError,
+    ModeError,
+    ClientError,
+)
 from .dsl import (
     CitationMixin,
     Maybe,
@@ -48,6 +56,12 @@ __all__ = [
     "Instructions",
     "handle_parallel_model",
     "handle_response_model",
+    "InstructorError",
+    "ValidationError",
+    "ProviderError",
+    "ConfigurationError",
+    "ModeError",
+    "ClientError",
 ]
 
 


### PR DESCRIPTION
Fixes issue #1612 where exception classes were not accessible for import.

Imports and exports all exception classes from instructor/__init__.py to make them accessible via:
- `from instructor.exceptions import ValidationError`
- `from instructor import ValidationError`

Generated with [Claude Code](https://claude.ai/code)