### PR TITLE
feat: Enable Audio module to work with Windows

### DIFF
--- a/instructor/multimodal.py
+++ b/instructor/multimodal.py
@@ -319,6 +319,9 @@ class Audio(BaseModel):
 
         if mime_type == "audio/x-wav":
             mime_type = "audio/wav"
+        
+        if mime_type == "audio/vnd.dlna.adts":   # <--- this is the case for aac audio files in Windows
+            mime_type = "audio/aac"
 
         assert (
             mime_type in VALID_AUDIO_MIME_TYPES


### PR DESCRIPTION
### Description
This PR makes the Audio Module work with Windows .aac files which gives mime type error due to mismatch of mime type in WINDOWS.

- Maps mime type = "audio/vnd.dlna.adts" to "audio/aac"

### Changes
- Mapped mime type = "audio/vnd.dlna.adts" to "audio/aac" in the "from_path" method in the "Audio" module.


### Testing
- Manual Verification of mime type checking.