### PR TITLE
feat: add Azure OpenAI support to auto_client.py

### DIFF
--- a/docs/integrations/azure.md
+++ b/docs/integrations/azure.md
@@ -51,6 +51,38 @@ client = AzureOpenAI(
 client = instructor.from_openai(client)
 ```
 
+## Using Auto Client (Recommended)
+
+The easiest way to get started with Azure OpenAI is using the `from_provider` method:
+
+```python
+import instructor
+import os
+
+# Set your Azure OpenAI credentials
+os.environ["AZURE_OPENAI_API_KEY"] = "your-api-key"
+os.environ["AZURE_OPENAI_ENDPOINT"] = "https://your-resource.openai.azure.com/"
+
+# Create client using the provider string
+client = instructor.from_provider("azure_openai/gpt-4o-mini")
+
+# Or async client
+async_client = instructor.from_provider("azure_openai/gpt-4o-mini", async_client=True)
+```
+
+You can also pass credentials as parameters:
+
+```python
+import instructor
+
+client = instructor.from_provider(
+    "azure_openai/gpt-4o-mini",
+    api_key="your-api-key",
+    azure_endpoint="https://your-resource.openai.azure.com/",
+    api_version="2024-02-01"  # Optional, defaults to 2024-02-01
+)
+```
+
 ## Basic Usage
 
 Here's a simple example using a Pydantic model:

--- a/tests/test_auto_client.py
+++ b/tests/test_auto_client.py
@@ -21,6 +21,7 @@ PROVIDERS = [
     "anthropic/claude-3-5-haiku-latest",
     "google/gemini-2.0-flash",
     "openai/gpt-4o-mini",
+    "azure_openai/gpt-4o-mini",
     "mistral/ministral-8b-latest",
     "cohere/command-r-plus",
     "perplexity/sonar-pro",


### PR DESCRIPTION
This PR adds Azure OpenAI support to the auto_client.py file, enabling external packages to use the `.from_provider()* method with Azure OpenAI models.

## Changes
- Added `azure_openai` to supported providers list
- Implemented Azure OpenAI client creation with environment variable support
- Added support for `azure_openai/model` format in from_provider()
- Updated tests to include azure_openai provider
- Updated Azure documentation with auto_client usage examples

## Usage
```python
import instructor
client = instructor.from_provider("azure_openai/gpt-4o-mini")
```

Resolves #1622

Generated with [Claude Code](https://claude.ai/code)