### PR TITLE
Propose improvements for response handlers

### DIFF
--- a/docs/concepts/handler_architecture.md
+++ b/docs/concepts/handler_architecture.md
@@ -1,0 +1,69 @@
+# Handler Architecture (Experimental)
+
+> **Status:** Experimental in vNEXT – currently covers Anthropic modes. More providers will migrate in future releases.
+
+Instructor now uses a plug-in style *handler* system to prepare requests and parse responses.  
+Every provider / mode combination can live in its own file, making the codebase easier to extend and maintain.
+
+## Why a new layer?
+
+* The former `handle_response_model` function ballooned beyond 1 000 lines.
+* Adding a new provider meant appending yet another `elif` block.
+* Testing isolated behaviour was hard because of tight coupling.
+
+## Core interfaces
+
+```python
+from instructor.handlers.base import ResponseHandler
+```
+
+A concrete handler must implement:
+
+* `supported_modes`: tuple of `Mode` values it is responsible for.
+* `prepare_request(..) -> (response_model, kwargs)` – mutate the outgoing kwargs **without touching the original dict**.
+* `parse_response(..) -> Any | None` – convert the raw provider completion into the final return type or return `None` to delegate to the legacy parser.
+
+Handlers register themselves via:
+
+```python
+from instructor.handlers.registry import register
+
+register(MyHandler())
+```
+
+## Current builtin handler
+
+* `AnthropicHandler` – covers the following modes:
+  * `Mode.ANTHROPIC_TOOLS`
+  * `Mode.ANTHROPIC_REASONING_TOOLS`
+  * `Mode.ANTHROPIC_JSON`
+
+## Extending Instructor with your own handler
+
+```python
+from instructor.mode import Mode
+from instructor.handlers.base import ResponseHandler
+from instructor.handlers.registry import register
+
+class MyCustomHandler(ResponseHandler):
+    supported_modes = (Mode.GEMINI_TOOLS,)
+
+    def prepare_request(self, mode, response_model, call_kwargs):
+        # mutate call_kwargs here
+        return response_model, call_kwargs
+
+    def parse_response(self, mode, raw_completion, *, response_model, stream, validation_context, strict):
+        # convert raw_completion here
+        return parsed_object
+
+register(MyCustomHandler())
+```
+
+## Deprecation timeline
+
+The legacy monolithic path is still available but raises a `DeprecationWarning` when used.  
+It will be removed once all major providers have migrated to the new handler system.
+
+---
+
+*Questions?* Join the discussion on GitHub or [Discord](https://discord.gg/instructor).

--- a/examples/test_handler_impl.py
+++ b/examples/test_handler_impl.py
@@ -1,0 +1,73 @@
+"""Minimal playground to showcase the new handler architecture.
+
+Run:
+
+```bash
+python examples/test_handler_impl.py
+```
+
+No network calls are made – we only exercise the *prepare_request* step of the
+`AnthropicHandler` so you can see how it mutates the kwargs per‐mode.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+try:
+    from pydantic import BaseModel  # type: ignore
+except ImportError:  # pragma: no cover
+    raise SystemExit("pydantic must be installed to run this example")
+
+from instructor.mode import Mode
+from instructor.handlers.registry import get as get_handler
+
+
+class DummyModel(BaseModel):
+    """Simplest possible response model for demonstration purposes."""
+
+    foo: str
+
+    # Minimal fields consumed by the Anthropic handler – in production these
+    # are generated automatically by `openai_schema()`.
+    anthropic_schema: dict[str, Any] = {
+        "name": "DummyModel",
+        "parameters": {
+            "type": "object",
+            "properties": {"foo": {"type": "string"}},
+        },
+    }
+
+
+# Fake chat messages from the caller
+INITIAL_KWARGS: dict[str, Any] = {
+    "messages": [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "return JSON with foo='bar'"},
+    ]
+}
+
+
+def main() -> None:
+    for mode in (
+        Mode.ANTHROPIC_JSON,
+        Mode.ANTHROPIC_TOOLS,
+        Mode.ANTHROPIC_REASONING_TOOLS,
+    ):
+        handler = get_handler(mode)
+        if handler is None:
+            raise RuntimeError(f"No handler registered for {mode}")
+
+        # Always work on a copy so we can re-use INITIAL_KWARGS for each mode
+        response_model, patched_kwargs = handler.prepare_request(  # type: ignore[arg-type]
+            mode, DummyModel, INITIAL_KWARGS.copy()
+        )
+
+        print("\n" + "=" * 60)
+        print(f"Mode: {mode.value}")
+        print("Prepared kwargs →")
+        print(json.dumps(patched_kwargs, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/instructor/handlers/__init__.py
+++ b/instructor/handlers/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .registry import get, register  # noqa: F401
+
+# Ensure built-in handlers are registered on import
+from . import anthropic  # noqa: F401

--- a/instructor/handlers/anthropic.py
+++ b/instructor/handlers/anthropic.py
@@ -7,10 +7,10 @@ from typing import Any, TypeVar
 from instructor.mode import Mode
 from instructor.utils import combine_system_messages, extract_system_messages
 
-from .base import ResponseHandler
+from .base import ResponseHandler, SupportsModelJsonSchema
 from .registry import register
 
-T = TypeVar("T")
+T = TypeVar("T", bound=SupportsModelJsonSchema)
 
 
 class AnthropicHandler(ResponseHandler):
@@ -117,6 +117,76 @@ class AnthropicHandler(ResponseHandler):
                 new_kwargs["system"], [{"type": "text", "text": json_schema_message}]
             )
         return response_model, new_kwargs
+
+    # ------------------------------------------------------------------
+    # Response-side parsing
+    # ------------------------------------------------------------------
+    def parse_response(
+        self,
+        mode: Mode,
+        raw_completion: Any,
+        *,
+        response_model: type[T] | None,
+        stream: bool,
+        validation_context: dict[str, Any] | None,
+        strict: bool | None,
+    ) -> Any | None:
+        """Convert Anthropic raw response into the caller-facing object.
+
+        For the initial refactor we simply rely on the existing
+        ``from_response`` helpers shipped with Instructor. But by placing the
+        logic here we decouple provider-specific quirks from the enormous
+        ``process_response`` file.
+        """
+
+        # If no structured output was requested fall back to legacy path
+        if response_model is None:
+            return None  # Delegate to legacy parser
+
+        # Import deferred to avoid unnecessary heavy imports at module load
+        from instructor.dsl.iterable import IterableBase
+        from instructor.dsl.parallel import ParallelBase
+        from instructor.dsl.partial import PartialBase
+        from instructor.dsl.simple_type import AdapterBase
+
+        # Streaming iterable / partial handling --------------------------------
+        if (
+            stream
+            and isinstance(response_model, type)
+            and issubclass(response_model, (IterableBase, PartialBase))
+        ):
+            # For now reuse the async/sync helpers already attached to the model
+            if hasattr(response_model, "from_streaming_response"):
+                model = response_model.from_streaming_response(  # type: ignore[attr-defined]
+                    raw_completion, mode=mode
+                )
+                return model
+
+        # Fallback to the generic ``from_response`` method --------------------
+        model = response_model.from_response(  # type: ignore[attr-defined]
+            raw_completion,
+            validation_context=validation_context,
+            strict=strict,
+            mode=mode,
+        )
+
+        # Harmonise return types (copied from legacy logic) -------------------
+        if isinstance(model, IterableBase):
+            return [task for task in model.tasks]  # type: ignore[attr-defined]
+
+        if isinstance(response_model, ParallelBase):
+            return model
+
+        if isinstance(model, AdapterBase):
+            return model.content
+
+        # Attach raw completion for caller inspection
+        try:
+            model._raw_response = raw_completion  # type: ignore[attr-defined]
+        except Exception:
+            pass
+
+        return model
 
 # Register a singleton instance with the central registry
 register(AnthropicHandler())

--- a/instructor/handlers/anthropic.py
+++ b/instructor/handlers/anthropic.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from textwrap import dedent
+from typing import Any, TypeVar
+
+from instructor.mode import Mode
+from instructor.utils import combine_system_messages, extract_system_messages
+
+from .base import ResponseHandler
+from .registry import register
+
+T = TypeVar("T")
+
+
+class AnthropicHandler(ResponseHandler):
+    """Request-side handler for Anthropic modes (tools & JSON)."""
+
+    supported_modes = (
+        Mode.ANTHROPIC_TOOLS,
+        Mode.ANTHROPIC_REASONING_TOOLS,
+        Mode.ANTHROPIC_JSON,
+    )
+
+    # Main public API -----------------------------------------------------
+    def prepare_request(
+        self,
+        mode: Mode,
+        response_model: type[T] | None,
+        call_kwargs: dict[str, Any],
+    ) -> tuple[type[T] | None, dict[str, Any]]:
+        if response_model is None:
+            # Nothing to patch if user did not request structured output
+            return None, call_kwargs
+
+        # Work on a shallow copy so we never mutate caller's dict
+        new_kwargs = call_kwargs.copy()
+
+        if mode is Mode.ANTHROPIC_TOOLS:
+            return self._anthropic_tools(response_model, new_kwargs)
+        elif mode is Mode.ANTHROPIC_REASONING_TOOLS:
+            return self._anthropic_reasoning_tools(response_model, new_kwargs)
+        elif mode is Mode.ANTHROPIC_JSON:
+            return self._anthropic_json(response_model, new_kwargs)
+        else:  # pragma: no cover — defensive fallback
+            return response_model, new_kwargs
+
+    # ------------------------------------------------------------------
+    # Internal helpers (largely copied from previous implementation)
+    # ------------------------------------------------------------------
+    def _anthropic_tools(
+        self, response_model: type[T], new_kwargs: dict[str, Any]
+    ) -> tuple[type[T], dict[str, Any]]:
+        tool_descriptions = response_model.anthropic_schema  # type: ignore[attr-defined]
+        new_kwargs["tools"] = [tool_descriptions]
+        new_kwargs["tool_choice"] = {"type": "tool", "name": response_model.__name__}
+
+        system_messages = extract_system_messages(new_kwargs.get("messages", []))
+        if system_messages:
+            new_kwargs["system"] = combine_system_messages(
+                new_kwargs.get("system"), system_messages
+            )
+
+        new_kwargs["messages"] = [
+            m for m in new_kwargs.get("messages", []) if m.get("role") != "system"
+        ]
+        return response_model, new_kwargs
+
+    def _anthropic_reasoning_tools(
+        self, response_model: type[T], new_kwargs: dict[str, Any]
+    ) -> tuple[type[T], dict[str, Any]]:
+        # Start from baseline tool handling
+        response_model, new_kwargs = self._anthropic_tools(response_model, new_kwargs)
+
+        # Reasoning mode cannot force tool usage
+        new_kwargs["tool_choice"] = {"type": "auto"}
+
+        implicit_message = dedent(
+            """
+            Return only the tool call and no additional text.
+            """
+        )
+        new_kwargs["system"] = combine_system_messages(
+            new_kwargs.get("system"), [{"type": "text", "text": implicit_message}]
+        )
+        return response_model, new_kwargs
+
+    def _anthropic_json(
+        self, response_model: type[T], new_kwargs: dict[str, Any]
+    ) -> tuple[type[T], dict[str, Any]]:
+        system_messages = extract_system_messages(new_kwargs.get("messages", []))
+        if system_messages:
+            new_kwargs["system"] = combine_system_messages(
+                new_kwargs.get("system"), system_messages
+            )
+
+        # Strip system messages from the messages list
+        new_kwargs["messages"] = [
+            m for m in new_kwargs.get("messages", []) if m.get("role") != "system"
+        ]
+
+        json_schema_message = dedent(
+            f"""
+            As a genius expert, your task is to understand the content and provide
+            the parsed objects in json that match the following json_schema:\n
+            {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=False)}  # type: ignore[attr-defined]
+
+            Make sure to return an instance of the JSON, not the schema itself
+            """
+        )
+
+        # Anthropic uses separate system field; merge or create it
+        if "system" not in new_kwargs:
+            new_kwargs["system"] = [{"type": "text", "text": json_schema_message}]
+        else:
+            new_kwargs["system"] = combine_system_messages(
+                new_kwargs["system"], [{"type": "text", "text": json_schema_message}]
+            )
+        return response_model, new_kwargs
+
+# Register a singleton instance with the central registry
+register(AnthropicHandler())

--- a/instructor/handlers/base.py
+++ b/instructor/handlers/base.py
@@ -1,10 +1,26 @@
 from __future__ import annotations
 
-from typing import Any, Protocol, TypeVar
+from typing import Any, Protocol, TypeVar, runtime_checkable
 
 from instructor.mode import Mode
 
-T = TypeVar("T")
+
+# ---------------------------------------------------------------------------
+# Helper protocol to express models that expose `.model_json_schema()`
+# and (optionally) `.anthropic_schema`. This lets us keep strong typing while
+# avoiding `# type: ignore` comments across the codebase.
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class SupportsModelJsonSchema(Protocol):
+    @classmethod
+    def model_json_schema(cls) -> dict[str, Any]: ...
+
+    anthropic_schema: Any  # Provider-specific
+
+
+T = TypeVar("T", bound=SupportsModelJsonSchema)
 
 
 class ResponseHandler(Protocol):
@@ -12,6 +28,7 @@ class ResponseHandler(Protocol):
 
     supported_modes: tuple[Mode, ...]
 
+    # Request-side ---------------------------------------------------------
     def prepare_request(
         self,
         mode: Mode,
@@ -28,6 +45,25 @@ class ResponseHandler(Protocol):
         Returns
         -------
         A tuple of (possibly modified) response_model and kwargs.
+        """
+
+        ...
+
+    # Response-side --------------------------------------------------------
+    def parse_response(
+        self,
+        mode: Mode,
+        raw_completion: Any,
+        *,
+        response_model: type[T] | None,
+        stream: bool,
+        validation_context: dict[str, Any] | None,
+        strict: bool | None,
+    ) -> Any | None:
+        """Convert the raw provider completion into the final return type.
+
+        If the handler does not apply, return ``None`` to fall back to the
+        legacy parsing path.
         """
 
         ...

--- a/instructor/handlers/base.py
+++ b/instructor/handlers/base.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any, Protocol, TypeVar
+
+from instructor.mode import Mode
+
+T = TypeVar("T")
+
+
+class ResponseHandler(Protocol):
+    """Protocol for request/response transformation handlers."""
+
+    supported_modes: tuple[Mode, ...]
+
+    def prepare_request(
+        self,
+        mode: Mode,
+        response_model: type[T] | None,
+        call_kwargs: dict[str, Any],
+    ) -> tuple[type[T] | None, dict[str, Any]]:
+        """Mutate/augment kwargs before the provider call.
+
+        Args:
+            mode: The operation mode triggering this handler.
+            response_model: Parsed response model requested by the caller.
+            call_kwargs: Keyword arguments destined for the provider SDK.
+
+        Returns
+        -------
+        A tuple of (possibly modified) response_model and kwargs.
+        """
+
+        ...

--- a/instructor/handlers/registry.py
+++ b/instructor/handlers/registry.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from instructor.mode import Mode
+
+from .base import ResponseHandler
+
+# Internal registry mapping Mode -> handler instance
+_registry: Dict[Mode, ResponseHandler] = {}
+
+
+def register(handler: ResponseHandler) -> ResponseHandler:
+    """Register a handler instance for all its supported modes."""
+    for mode in handler.supported_modes:
+        if mode in _registry:
+            # Later registrations override previous ones to make overriding easy
+            # but emit a debug log so users are aware
+            try:
+                import logging
+
+                logging.getLogger("instructor.handlers").debug(
+                    "Overriding existing handler for mode %s with %s",
+                    mode,
+                    handler.__class__.__name__,
+                )
+            except Exception:
+                pass
+        _registry[mode] = handler
+    return handler
+
+
+def get(mode: Mode):
+    """Return a handler instance for the given mode or None."""
+    return _registry.get(mode)

--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -41,6 +41,10 @@ from instructor.utils import (
     update_genai_kwargs,
 )
 
+# New handler registry for request-side transformations
+import instructor.handlers as _instructor_handlers  # noqa: F401  # side-effect import
+from instructor.handlers.registry import get as get_handler
+
 logger = logging.getLogger("instructor")
 
 T_Model = TypeVar("T_Model", bound=BaseModel)
@@ -1123,6 +1127,41 @@ def handle_response_model(
         return handle_vertexai_parallel_tools(response_model, new_kwargs)
 
     response_model = prepare_response_model(response_model)
+
+    # ------------------------------------------------------------------
+    # New extensible handler mechanism (anthropic-only for now)
+    # ------------------------------------------------------------------
+    handler = get_handler(mode)
+    if handler is not None:
+        response_model, new_kwargs = handler.prepare_request(  # type: ignore[arg-type]
+            mode, response_model, new_kwargs
+        )
+
+        # After a handler runs we still apply generic multimedia conversions
+        if "messages" in new_kwargs:
+            new_kwargs["messages"] = convert_messages(
+                new_kwargs["messages"],
+                mode,
+                autodetect_images=autodetect_images,
+            )
+
+        if mode in {Mode.GENAI_TOOLS, Mode.GENAI_STRUCTURED_OUTPUTS}:
+            new_kwargs["contents"] = extract_genai_multimodal_content(
+                new_kwargs["contents"], autodetect_images
+            )
+
+        logger.debug(
+            f"Instructor Request (new handler): {mode.value=}, {response_model=}, {new_kwargs=}",
+            extra={
+                "mode": mode.value,
+                "response_model": (
+                    response_model.__name__ if response_model and hasattr(response_model, "__name__") else str(response_model)
+                ),
+                "new_kwargs": new_kwargs,
+            },
+        )
+
+        return response_model, new_kwargs
 
     mode_handlers = {  # type: ignore
         Mode.FUNCTIONS: handle_functions,

--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -83,6 +83,21 @@ async def process_response_async(
     logger.debug(
         f"Instructor Raw Response: {response}",
     )
+
+    # Try new handler-based response parsing first
+    handler = get_handler(mode)
+    if handler is not None:
+        parsed = handler.parse_response(
+            mode,
+            response,
+            response_model=response_model,  # type: ignore[arg-type]
+            stream=stream,
+            validation_context=validation_context,
+            strict=strict,
+        )
+        if parsed is not None:
+            return parsed  # type: ignore[return-value]
+
     if response_model is None:
         return response
 
@@ -119,6 +134,7 @@ async def process_response_async(
         return model.content
 
     model._raw_response = response
+
     return model
 
 
@@ -156,6 +172,20 @@ def process_response(
     logger.debug(
         f"Instructor Raw Response: {response}",
     )
+
+    # Try new handler-based response parsing first
+    handler = get_handler(mode)
+    if handler is not None:
+        parsed = handler.parse_response(
+            mode,
+            response,
+            response_model=response_model,  # type: ignore[arg-type]
+            stream=stream,
+            validation_context=validation_context,
+            strict=strict,
+        )
+        if parsed is not None:
+            return parsed  # type: ignore[return-value]
 
     if response_model is None:
         logger.debug("No response model, returning response as is")
@@ -1133,7 +1163,7 @@ def handle_response_model(
     # ------------------------------------------------------------------
     handler = get_handler(mode)
     if handler is not None:
-        response_model, new_kwargs = handler.prepare_request(  # type: ignore[arg-type]
+        response_model, new_kwargs = handler.prepare_request(
             mode, response_model, new_kwargs
         )
 
@@ -1199,6 +1229,14 @@ def handle_response_model(
     }
 
     if mode in mode_handlers:
+        import warnings
+        warnings.warn(
+            "process_response: Falling back to legacy mode handler mapping. "
+            "This path is deprecated and will be removed in a future release. "
+            "Please migrate to the new ResponseHandler architecture.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         response_model, new_kwargs = mode_handlers[mode](response_model, new_kwargs)
     else:
         raise ValueError(f"Invalid patch mode: {mode}")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -247,6 +247,7 @@ nav:
     - Multimodal : 'concepts/multimodal.md'
     - Patching: 'concepts/patching.md'
     - Hooks: 'concepts/hooks.md'
+    - Handler Architecture: 'concepts/handler_architecture.md'
     - Types: 'concepts/types.md'
     - TypedDicts: 'concepts/typeddicts.md'
     - Validators: "concepts/reask_validation.md"

--- a/tests/handlers/test_anthropic_handler.py
+++ b/tests/handlers/test_anthropic_handler.py
@@ -1,0 +1,64 @@
+import pytest
+from typing import Any
+
+from pydantic import BaseModel
+
+import instructor
+from instructor.mode import Mode
+from instructor.handlers.registry import get as get_handler
+
+
+class DummyModel(BaseModel):
+    foo: str
+
+    # Minimal schema attributes required by the Anthropic handler
+    anthropic_schema: dict[str, Any] = {
+        "name": "DummyModel",
+        "parameters": {
+            "type": "object",
+            "properties": {"foo": {"type": "string"}},
+        },
+    }
+
+
+@pytest.mark.parametrize("mode", [
+    Mode.ANTHROPIC_JSON,
+    Mode.ANTHROPIC_TOOLS,
+    Mode.ANTHROPIC_REASONING_TOOLS,
+])
+def test_prepare_request(mode: Mode):
+    handler = get_handler(mode)
+    assert handler is not None, "Handler should be registered"
+
+    call_kwargs = {
+        "messages": [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hi"},
+        ]
+    }
+    rm, new_kwargs = handler.prepare_request(mode, DummyModel, call_kwargs)
+
+    # Ensure original kwargs are not mutated
+    assert call_kwargs is not new_kwargs
+    assert rm is DummyModel
+
+    # Basic sanity checks depending on mode
+    if mode is Mode.ANTHROPIC_JSON:
+        assert "system" in new_kwargs, "Json mode should inject system schema"
+    else:
+        assert "tools" in new_kwargs, "Tools modes should include tool definitions"
+
+
+def test_parse_response_passthrough():
+    """parse_response should return None when no model is supplied, delegating to legacy parser."""
+    mode = Mode.ANTHROPIC_JSON
+    handler = get_handler(mode)
+    result = handler.parse_response(  # type: ignore[attr-defined]
+        mode,
+        raw_completion={"dummy": 1},
+        response_model=None,
+        stream=False,
+        validation_context=None,
+        strict=None,
+    )
+    assert result is None


### PR DESCRIPTION
> refactor: Introduce handler architecture for Anthropic modes

## Describe your changes

This PR introduces a new plug-in style handler system for request preparation and response parsing, starting with Anthropic modes.

**Why this change?**
The previous monolithic `handle_response_model` function was becoming difficult to extend, maintain, and test. This new architecture provides a clear contract for handlers, a central registry, and allows provider/mode-specific logic to live in isolated modules.

**Key changes:**
- **New Handler Architecture**: Implemented `ResponseHandler` protocol and a central registry (`instructor/handlers/`).
- **Anthropic Migration**: Migrated `ANTHROPIC_TOOLS`, `ANTHROPIC_REASONING_TOOLS`, and `ANTHROPIC_JSON` modes to use the new `AnthropicHandler` for both request (kwargs mutation) and response (raw completion parsing).
- **Type Safety**: Introduced `SupportsModelJsonSchema` protocol to enhance type checking.
- **Deprecation**: Added `DeprecationWarning` for legacy handler paths.
- **Documentation**: New `docs/concepts/handler_architecture.md` explains the system.
- **Testing**: Added dedicated unit tests for `AnthropicHandler`.
- **Example**: Included `examples/test_handler_impl.py` to demonstrate handler usage.

This refactor significantly improves extensibility, maintainability, and testability of provider-specific logic, while keeping the public API unchanged.

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces a new handler architecture for Anthropic modes, improving code extensibility and maintainability.
> 
>   - **Handler Architecture**:
>     - Introduces `ResponseHandler` protocol and central registry in `instructor/handlers/`.
>     - Implements `AnthropicHandler` for `ANTHROPIC_TOOLS`, `ANTHROPIC_REASONING_TOOLS`, and `ANTHROPIC_JSON` modes.
>     - Adds `SupportsModelJsonSchema` protocol for type safety.
>   - **Deprecation**:
>     - Adds `DeprecationWarning` for legacy handler paths in `process_response.py`.
>   - **Documentation**:
>     - Adds `docs/concepts/handler_architecture.md` to explain the new system.
>   - **Testing**:
>     - Adds `tests/handlers/test_anthropic_handler.py` for `AnthropicHandler` unit tests.
>   - **Examples**:
>     - Includes `examples/test_handler_impl.py` to demonstrate handler usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for a46bd5ba0bcdeba0f9f16a77863e5338c0e55de6. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->