### PR TITLE
Update TaskAction method description for clarity on task creation and…

### DIFF
--- a/examples/multi-actions/run.py
+++ b/examples/multi-actions/run.py
@@ -33,7 +33,7 @@ class Buckets(enum.Enum):
 class TaskAction(BaseModel):
     id: int
     method: Action = Field(
-        description="Method of creating, for closing a task the task, to close a task only a id is required"
+        description="Method of creating and closing a task: to close a task, only an ID is required"
     )
     waiting_on: Optional[list[int]] = Field(
         None, description="IDs of tasks that this task is waiting on"


### PR DESCRIPTION
… closing

The fix improves clarity significantly.

**Original:**
*"Method of creating, for closing a task the task, to close a task only a id is required"* This is unclear, redundant, and grammatically incorrect.

**the fix:**
*"Method of creating and closing a task: to close a task, only an ID is required"* This is concise, clear, and precise.

It correctly:

* Replaces awkward phrasing.
* Removes redundancy (“the task the task”).
* Fixes grammar (“a id” → “an ID”).
* Clearly states that an ID is sufficient for closing.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `TaskAction` method description in `run.py` for clarity and grammar.
> 
>   - **Documentation**:
>     - Update `description` in `TaskAction` class in `run.py` for clarity and grammar.
>     - Original: "Method of creating, for closing a task the task, to close a task only a id is required".
>     - Updated: "Method of creating and closing a task: to close a task, only an ID is required".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for ca3b6b675aa41713eed50f35519b817b06b4620a. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->