### PR TITLE
Fix SambaNova capitalization

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -35,7 +35,7 @@ Learn how to integrate Instructor with various AI model providers. These compreh
     [:octicons-arrow-right-16: Cerebras](./cerebras.md)      ·
     [:octicons-arrow-right-16: Writer](./writer.md)          ·
     [:octicons-arrow-right-16: Perplexity](./perplexity.md)
-    [:octicons-arrow-right-16: Sambanova](./sambanova.md)
+    [:octicons-arrow-right-16: SambaNova](./sambanova.md)
 
 - :material-open-source-initiative: **Open Source**
 


### PR DESCRIPTION
## Summary
- capitalize SambaNova link on integrations index

## Testing
- `pytest -k 'not llm and not openai'` *(fails: ModuleNotFoundError/32 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68683d0490348326ada32454d111b3c5