### PR TITLE
Use uv for docs

### DIFF
--- a/build_mkdocs.sh
+++ b/build_mkdocs.sh
@@ -1,3 +1,17 @@
-pip install -r requirements.txt
-pip install -r requirements-doc.txt
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure uv is installed
+if ! command -v uv >/dev/null 2>&1; then
+    pip install uv
+fi
+
+# Install dependencies using uv
+uv pip install --system -r requirements.txt
+uv pip install --system -r requirements-doc.txt
+
+# Ensure newly installed executables are available
+pyenv rehash
+
+# Build the documentation
 mkdocs build


### PR DESCRIPTION
## Summary
- install docs requirements via `uv pip`
- rehash pyenv so MkDocs is on PATH

## Testing
- `bash build_mkdocs.sh`

------
https://chatgpt.com/codex/tasks/task_e_68683ccbb4948326b402b4c12e5e8aba