### PR TITLE
Fix docs build path

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -86,7 +86,7 @@ huggingface-hub==0.27.0
 idna==3.10
 importlib-metadata==8.5.0
 iniconfig==2.0.0
--e file:///Users/ivanleo/Documents/coding/instructor
+-e .
 ipykernel==6.29.5
 ipython==8.18.1
 jedi==0.19.2


### PR DESCRIPTION
## Summary
- fix requirements path for editable install

## Testing
- `pre-commit run --files requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_686c1769cb608326b73ea56635f7ecbf