### PR TITLE
Skip LLM tests without API keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "pyright<2.0.0",
     "jsonref<2.0.0,>=1.1.0",
     "pytest-examples>=0.0.15",
+    "python-dotenv>=1.0.1",
 ]
 docs = [
     "mkdocs<2.0.0,>=1.6.1",
@@ -115,6 +116,7 @@ dev = [
     "pyright<2.0.0",
     "jsonref<2.0.0,>=1.1.0",
     "pytest-examples>=0.0.15",
+    "python-dotenv>=1.0.1",
 ]
 docs = [
     "mkdocs<2.0.0,>=1.4.3",

--- a/tests/llm/test_anthropic/conftest.py
+++ b/tests/llm/test_anthropic/conftest.py
@@ -1,7 +1,17 @@
 # conftest.py
-from anthropic import AsyncAnthropic, Anthropic
-import pytest
 import os
+import pytest
+
+if not (os.getenv("ANTHROPIC_API_KEY") or os.getenv("BRAINTRUST_API_KEY")):
+    pytest.skip(
+        "ANTHROPIC_API_KEY environment variable not set",
+        allow_module_level=True,
+    )
+
+try:
+    from anthropic import AsyncAnthropic, Anthropic
+except ImportError:  # pragma: no cover - optional dependency
+    pytest.skip("anthropic package is not installed", allow_module_level=True)
 
 try:
     import braintrust

--- a/tests/llm/test_cohere/conftest.py
+++ b/tests/llm/test_cohere/conftest.py
@@ -1,6 +1,17 @@
 # conftest.py
-from cohere import Client, AsyncClient
+import os
 import pytest
+
+if not os.getenv("COHERE_API_KEY"):
+    pytest.skip(
+        "COHERE_API_KEY environment variable not set",
+        allow_module_level=True,
+    )
+
+try:
+    from cohere import Client, AsyncClient
+except ImportError:  # pragma: no cover - optional dependency
+    pytest.skip("cohere package is not installed", allow_module_level=True)
 
 
 @pytest.fixture(scope="session")

--- a/tests/llm/test_fireworks/conftest.py
+++ b/tests/llm/test_fireworks/conftest.py
@@ -1,0 +1,8 @@
+import os
+import pytest
+
+if not os.getenv("FIREWORKS_API_KEY"):
+    pytest.skip(
+        "FIREWORKS_API_KEY environment variable not set",
+        allow_module_level=True,
+    )

--- a/tests/llm/test_gemini/conftest.py
+++ b/tests/llm/test_gemini/conftest.py
@@ -1,11 +1,15 @@
 import os
 import pytest
-from google import generativeai as genai
+
+if not os.getenv("GOOGLE_API_KEY"):
+    pytest.skip("GOOGLE_API_KEY environment variable not set", allow_module_level=True)
+
+try:
+    from google import generativeai as genai
+except ImportError:  # pragma: no cover - optional dependency
+    pytest.skip("google-generativeai package is not installed", allow_module_level=True)
 
 
 @pytest.fixture(scope="session", autouse=True)
 def configure_genai():
-    api_key = os.getenv("GOOGLE_API_KEY")
-    if not api_key:
-        pytest.skip("GOOGLE_API_KEY environment variable not set")
-    genai.configure(api_key=api_key)
+    genai.configure(api_key=os.getenv("GOOGLE_API_KEY"))

--- a/tests/llm/test_genai/conftest.py
+++ b/tests/llm/test_genai/conftest.py
@@ -1,6 +1,17 @@
 # conftest.py
-from google.genai import Client
+import os
 import pytest
+
+if not os.getenv("GOOGLE_API_KEY"):
+    pytest.skip(
+        "GOOGLE_API_KEY environment variable not set",
+        allow_module_level=True,
+    )
+
+try:
+    from google.genai import Client
+except ImportError:  # pragma: no cover - optional dependency
+    pytest.skip("google-genai package is not installed", allow_module_level=True)
 
 
 @pytest.fixture(scope="function")

--- a/tests/llm/test_litellm.py
+++ b/tests/llm/test_litellm.py
@@ -1,5 +1,17 @@
+import os
+import pytest
 import instructor
-from litellm import acompletion, completion
+
+if not os.getenv("OPENAI_API_KEY"):
+    pytest.skip(
+        "OPENAI_API_KEY environment variable not set",
+        allow_module_level=True,
+    )
+
+try:
+    from litellm import acompletion, completion
+except ImportError:  # pragma: no cover - optional dependency
+    pytest.skip("litellm package is not installed", allow_module_level=True)
 
 
 def test_litellm_create():

--- a/tests/llm/test_mistral/conftest.py
+++ b/tests/llm/test_mistral/conftest.py
@@ -1,7 +1,17 @@
 # conftest.py
-import pytest
 import os
-from mistralai import Mistral
+import pytest
+
+if not os.getenv("MISTRAL_API_KEY"):
+    pytest.skip(
+        "MISTRAL_API_KEY environment variable not set",
+        allow_module_level=True,
+    )
+
+try:
+    from mistralai import Mistral
+except ImportError:  # pragma: no cover - optional dependency
+    pytest.skip("mistralai package is not installed", allow_module_level=True)
 
 
 @pytest.fixture(scope="function")

--- a/tests/llm/test_new_client.py
+++ b/tests/llm/test_new_client.py
@@ -1,9 +1,23 @@
-import cohere
 import os
-import openai
-import instructor
-import anthropic
 import pytest
+
+if not (
+    os.getenv("OPENAI_API_KEY")
+    and os.getenv("ANTHROPIC_API_KEY")
+    and os.getenv("COHERE_API_KEY")
+):
+    pytest.skip(
+        "Required API keys not set",
+        allow_module_level=True,
+    )
+
+try:
+    import cohere
+    import openai
+    import instructor
+    import anthropic
+except ImportError:  # pragma: no cover - optional dependency
+    pytest.skip("Required LLM packages are not installed", allow_module_level=True)
 from pydantic import BaseModel, Field
 
 

--- a/tests/llm/test_openai/conftest.py
+++ b/tests/llm/test_openai/conftest.py
@@ -1,7 +1,17 @@
 # conftest.py
-from openai import AsyncOpenAI, OpenAI
-import pytest
 import os
+import pytest
+
+if not (os.getenv("OPENAI_API_KEY") or os.getenv("BRAINTRUST_API_KEY")):
+    pytest.skip(
+        "OPENAI_API_KEY environment variable not set",
+        allow_module_level=True,
+    )
+
+try:
+    from openai import AsyncOpenAI, OpenAI
+except ImportError:  # pragma: no cover - optional dependency
+    pytest.skip("openai package is not installed", allow_module_level=True)
 
 try:
     import braintrust

--- a/tests/llm/test_perplexity/conftest.py
+++ b/tests/llm/test_perplexity/conftest.py
@@ -1,13 +1,22 @@
 import os
 
 import pytest
-from openai import OpenAI
+
+if not os.getenv("PERPLEXITY_API_KEY"):
+    pytest.skip(
+        "PERPLEXITY_API_KEY environment variable not set",
+        allow_module_level=True,
+    )
+
+try:
+    from openai import OpenAI
+except ImportError:  # pragma: no cover - optional dependency
+    pytest.skip("openai package is not installed", allow_module_level=True)
 
 
 @pytest.fixture(scope="session")
 def client():
-    if os.environ.get("PERPLEXITY_API_KEY"):
-        yield OpenAI(
-            api_key=os.environ["PERPLEXITY_API_KEY"],
-            base_url="https://api.perplexity.ai",
-        )
+    yield OpenAI(
+        api_key=os.environ["PERPLEXITY_API_KEY"],
+        base_url="https://api.perplexity.ai",
+    )

--- a/tests/llm/test_vertexai/conftest.py
+++ b/tests/llm/test_vertexai/conftest.py
@@ -1,0 +1,15 @@
+import os
+import pytest
+
+if not os.getenv("GOOGLE_API_KEY"):
+    pytest.skip(
+        "GOOGLE_API_KEY environment variable not set",
+        allow_module_level=True,
+    )
+
+try:
+    import vertexai  # noqa: F401
+except ImportError:  # pragma: no cover - optional dependency
+    pytest.skip(
+        "google-cloud-aiplatform package is not installed", allow_module_level=True
+    )

--- a/tests/llm/test_writer/conftest.py
+++ b/tests/llm/test_writer/conftest.py
@@ -1,9 +1,15 @@
 import os
 import pytest
 
+if not os.getenv("WRITER_API_KEY"):
+    pytest.skip("WRITER_API_KEY environment variable not set", allow_module_level=True)
+
+try:
+    import writerai  # noqa: F401
+except ImportError:  # pragma: no cover - optional dependency
+    pytest.skip("writer-sdk package is not installed", allow_module_level=True)
+
 
 @pytest.fixture(scope="session", autouse=True)
 def configure_writer():
-    api_key = os.getenv("WRITER_API_KEY")
-    if not api_key:
-        pytest.skip("WRITER_API_KEY environment variable not set")
+    pass

--- a/uv.lock
+++ b/uv.lock
@@ -211,6 +211,20 @@ wheels = [
 ]
 
 [[package]]
+name = "backrefs"
+version = "5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/a7/312f673df6a79003279e1f55619abbe7daebbb87c17c976ddc0345c04c7b/backrefs-5.9.tar.gz", hash = "sha256:808548cb708d66b82ee231f962cb36faaf4f2baab032f2fbb783e9c2fdddaa59", size = 5765857, upload-time = "2025-06-22T19:34:13.97Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/4d/798dc1f30468134906575156c089c492cf79b5a5fd373f07fe26c4d046bf/backrefs-5.9-py310-none-any.whl", hash = "sha256:db8e8ba0e9de81fcd635f440deab5ae5f2591b54ac1ebe0550a2ca063488cd9f", size = 380267, upload-time = "2025-06-22T19:34:05.252Z" },
+    { url = "https://files.pythonhosted.org/packages/55/07/f0b3375bf0d06014e9787797e6b7cc02b38ac9ff9726ccfe834d94e9991e/backrefs-5.9-py311-none-any.whl", hash = "sha256:6907635edebbe9b2dc3de3a2befff44d74f30a4562adbb8b36f21252ea19c5cf", size = 392072, upload-time = "2025-06-22T19:34:06.743Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/12/4f345407259dd60a0997107758ba3f221cf89a9b5a0f8ed5b961aef97253/backrefs-5.9-py312-none-any.whl", hash = "sha256:7fdf9771f63e6028d7fee7e0c497c81abda597ea45d6b8f89e8ad76994f5befa", size = 397947, upload-time = "2025-06-22T19:34:08.172Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bf/fa31834dc27a7f05e5290eae47c82690edc3a7b37d58f7fb35a1bdbf355b/backrefs-5.9-py313-none-any.whl", hash = "sha256:cc37b19fa219e93ff825ed1fed8879e47b4d89aa7a1884860e2db64ccd7c676b", size = 399843, upload-time = "2025-06-22T19:34:09.68Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/24/b29af34b2c9c41645a9f4ff117bae860291780d73880f449e0b5d948c070/backrefs-5.9-py314-none-any.whl", hash = "sha256:df5e169836cc8acb5e440ebae9aad4bf9d15e226d3bad049cf3f6a5c20cc8dc9", size = 411762, upload-time = "2025-06-22T19:34:11.037Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ff/392bff89415399a979be4a65357a41d92729ae8580a66073d8ec8d810f98/backrefs-5.9-py39-none-any.whl", hash = "sha256:f48ee18f6252b8f5777a22a00a09a85de0ca931658f1dd96d4406a34f3748c60", size = 380265, upload-time = "2025-06-22T19:34:12.405Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.12.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1673,7 +1687,7 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.9.0"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1716,12 +1730,13 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-examples" },
+    { name = "python-dotenv" },
 ]
 docs = [
-    { name = "material" },
     { name = "mkdocs" },
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-material", extra = ["imaging"] },
+    { name = "mkdocs-material-extensions" },
     { name = "mkdocs-minify-plugin" },
     { name = "mkdocs-redirects" },
     { name = "mkdocs-rss-plugin" },
@@ -1806,6 +1821,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-examples" },
+    { name = "python-dotenv" },
 ]
 docs = [
     { name = "cairosvg" },
@@ -1813,6 +1829,7 @@ docs = [
     { name = "mkdocs" },
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-material", extra = ["imaging"] },
+    { name = "mkdocs-material-extensions" },
     { name = "mkdocs-minify-plugin" },
     { name = "mkdocs-redirects" },
     { name = "mkdocs-rss-plugin" },
@@ -1908,19 +1925,20 @@ requires-dist = [
     { name = "jsonref", marker = "extra == 'vertexai'", specifier = ">=1.1.0,<2.0.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.35.31,<2.0.0" },
     { name = "litellm", marker = "extra == 'test-docs'", specifier = ">=1.35.31,<2.0.0" },
-    { name = "material", marker = "extra == 'docs'", specifier = ">=0.1" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.5.1,<2.0.0" },
     { name = "mistralai", marker = "extra == 'test-docs'", specifier = ">=1.5.1,<2.0.0" },
     { name = "mkdocs", specifier = ">=1.6.1" },
-    { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.4.3,<2.0.0" },
+    { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.1,<2.0.0" },
     { name = "mkdocs-jupyter", marker = "extra == 'docs'", specifier = ">=0.24.6,<0.26.0" },
     { name = "mkdocs-material", specifier = ">=9.5.49" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.6.14" },
     { name = "mkdocs-material", extras = ["imaging"], marker = "extra == 'docs'", specifier = ">=9.5.9,<10.0.0" },
+    { name = "mkdocs-material-extensions", marker = "extra == 'docs'", specifier = ">=1.3.1" },
     { name = "mkdocs-minify-plugin", marker = "extra == 'docs'", specifier = ">=0.8.0,<1.0.0" },
     { name = "mkdocs-redirects", marker = "extra == 'docs'", specifier = ">=1.2.1,<2.0.0" },
     { name = "mkdocs-rss-plugin", marker = "extra == 'docs'", specifier = ">=1.12.0,<2.0.0" },
-    { name = "mkdocstrings", marker = "extra == 'docs'", specifier = ">=0.26.1,<0.30.0" },
-    { name = "mkdocstrings-python", marker = "extra == 'docs'", specifier = ">=1.11.1,<2.0.0" },
+    { name = "mkdocstrings", marker = "extra == 'docs'", specifier = ">=0.27.1,<0.30.0" },
+    { name = "mkdocstrings-python", marker = "extra == 'docs'", specifier = ">=1.12.2,<2.0.0" },
     { name = "openai", specifier = ">=1.70.0,<2.0.0" },
     { name = "openai", marker = "extra == 'perplexity'", specifier = ">=1.52.0,<2.0.0" },
     { name = "pandas", marker = "extra == 'test-docs'", specifier = ">=2.2.0,<3.0.0" },
@@ -1935,6 +1953,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0,<1.0.0" },
     { name = "pytest-examples", marker = "extra == 'dev'", specifier = ">=0.0.15" },
     { name = "pytest-examples", marker = "extra == 'docs'", specifier = ">=0.0.15" },
+    { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0.1" },
     { name = "redis", marker = "extra == 'test-docs'", specifier = ">=5.0.1,<7.0.0" },
     { name = "requests", specifier = ">=2.32.3,<3.0.0" },
     { name = "rich", specifier = ">=13.7.0,<15.0.0" },
@@ -1963,6 +1982,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.3,<9.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.24.0,<1.0.0" },
     { name = "pytest-examples", specifier = ">=0.0.15" },
+    { name = "python-dotenv", specifier = ">=1.0.1" },
 ]
 docs = [
     { name = "cairosvg", specifier = ">=2.7.1" },
@@ -1970,6 +1990,7 @@ docs = [
     { name = "mkdocs", specifier = ">=1.4.3,<2.0.0" },
     { name = "mkdocs-jupyter", specifier = ">=0.24.6,<0.26.0" },
     { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.5.9,<10.0.0" },
+    { name = "mkdocs-material-extensions", specifier = ">=1.3.1" },
     { name = "mkdocs-minify-plugin", specifier = ">=0.8.0,<1.0.0" },
     { name = "mkdocs-redirects", specifier = ">=1.2.1,<2.0.0" },
     { name = "mkdocs-rss-plugin", specifier = ">=1.12.0,<2.0.0" },
@@ -2635,16 +2656,16 @@ wheels = [
 
 [[package]]
 name = "mkdocs-autorefs"
-version = "1.2.0"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "markupsafe" },
     { name = "mkdocs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/ae/0f1154c614d6a8b8a36fff084e5b82af3a15f7d2060cf0dcdb1c53297a71/mkdocs_autorefs-1.2.0.tar.gz", hash = "sha256:a86b93abff653521bda71cf3fc5596342b7a23982093915cb74273f67522190f", size = 40262, upload-time = "2024-09-01T18:29:18.514Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/0c/c9826f35b99c67fa3a7cddfa094c1a6c43fafde558c309c6e4403e5b37dc/mkdocs_autorefs-1.4.2.tar.gz", hash = "sha256:e2ebe1abd2b67d597ed19378c0fff84d73d1dbce411fce7a7cc6f161888b6749", size = 54961, upload-time = "2025-05-20T13:09:09.886Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/26/4d39d52ea2219604053a4d05b98e90d6a335511cc01806436ec4886b1028/mkdocs_autorefs-1.2.0-py3-none-any.whl", hash = "sha256:d588754ae89bd0ced0c70c06f58566a4ee43471eeeee5202427da7de9ef85a2f", size = 16522, upload-time = "2024-09-01T18:29:16.605Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/fc063b78f4b769d1956319351704e23ebeba1e9e1d6a41b4b602325fd7e4/mkdocs_autorefs-1.4.2-py3-none-any.whl", hash = "sha256:83d6d777b66ec3c372a1aad4ae0cf77c243ba5bcda5bf0c6b8a2c5e7a3d89f13", size = 24969, upload-time = "2025-05-20T13:09:08.237Z" },
 ]
 
 [[package]]
@@ -2681,10 +2702,11 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.5.49"
+version = "9.6.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
+    { name = "backrefs" },
     { name = "colorama" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -2693,12 +2715,11 @@ dependencies = [
     { name = "paginate" },
     { name = "pygments" },
     { name = "pymdown-extensions" },
-    { name = "regex" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/14/8daeeecee2e25bd84239a843fdcb92b20db88ebbcb26e0d32f414ca54a22/mkdocs_material-9.5.49.tar.gz", hash = "sha256:3671bb282b4f53a1c72e08adbe04d2481a98f85fed392530051f80ff94a9621d", size = 3949559, upload-time = "2024-12-16T10:25:10.539Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/c1/f804ba2db2ddc2183e900befe7dad64339a34fa935034e1ab405289d0a97/mkdocs_material-9.6.15.tar.gz", hash = "sha256:64adf8fa8dba1a17905b6aee1894a5aafd966d4aeb44a11088519b0f5ca4f1b5", size = 3951836, upload-time = "2025-07-01T10:14:15.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/2d/2dd23a36b48421db54f118bb6f6f733dbe2d5c78fe7867375e48649fd3df/mkdocs_material-9.5.49-py3-none-any.whl", hash = "sha256:c3c2d8176b18198435d3a3e119011922f3e11424074645c24019c2dcf08a360e", size = 8684098, upload-time = "2024-12-16T10:25:02.326Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/30/dda19f0495a9096b64b6b3c07c4bfcff1c76ee0fc521086d53593f18b4c0/mkdocs_material-9.6.15-py3-none-any.whl", hash = "sha256:ac969c94d4fe5eb7c924b6d2f43d7db41159ea91553d18a9afc4780c34f2717a", size = 8716840, upload-time = "2025-07-01T10:14:13.18Z" },
 ]
 
 [package.optional-dependencies]
@@ -2761,23 +2782,20 @@ wheels = [
 
 [[package]]
 name = "mkdocstrings"
-version = "0.27.0"
+version = "0.29.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "jinja2" },
     { name = "markdown" },
     { name = "markupsafe" },
     { name = "mkdocs" },
     { name = "mkdocs-autorefs" },
-    { name = "platformdirs" },
     { name = "pymdown-extensions" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/5a/5de70538c2cefae7ac3a15b5601e306ef3717290cb2aab11d51cbbc2d1c0/mkdocstrings-0.27.0.tar.gz", hash = "sha256:16adca6d6b0a1f9e0c07ff0b02ced8e16f228a9d65a37c063ec4c14d7b76a657", size = 94830, upload-time = "2024-11-08T17:07:41.627Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/e8/d22922664a627a0d3d7ff4a6ca95800f5dde54f411982591b4621a76225d/mkdocstrings-0.29.1.tar.gz", hash = "sha256:8722f8f8c5cd75da56671e0a0c1bbed1df9946c0cef74794d6141b34011abd42", size = 1212686, upload-time = "2025-03-31T08:33:11.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/10/4c27c3063c2b3681a4b7942f8dbdeb4fa34fecb2c19b594e7345ebf4f86f/mkdocstrings-0.27.0-py3-none-any.whl", hash = "sha256:6ceaa7ea830770959b55a16203ac63da24badd71325b96af950e59fd37366332", size = 30658, upload-time = "2024-11-08T17:07:39.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/14/22533a578bf8b187e05d67e2c1721ce10e3f526610eebaf7a149d557ea7a/mkdocstrings-0.29.1-py3-none-any.whl", hash = "sha256:37a9736134934eea89cbd055a513d40a020d87dfcae9e3052c2a6b8cd4af09b6", size = 1631075, upload-time = "2025-03-31T08:33:09.661Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- skip LLM tests when API keys or optional packages are missing
- add `python-dotenv` to dev dependencies

## Testing
- `pre-commit run --files pyproject.toml tests/llm/test_anthropic/conftest.py tests/llm/test_cohere/conftest.py tests/llm/test_genai/conftest.py tests/llm/test_litellm.py tests/llm/test_mistral/conftest.py tests/llm/test_new_client.py tests/llm/test_openai/conftest.py tests/llm/test_perplexity/conftest.py tests/llm/test_fireworks/conftest.py tests/llm/test_vertexai/conftest.py tests/llm/test_gemini/conftest.py tests/llm/test_writer/conftest.py`
- `pytest -k 'nothing' -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*


------
https://chatgpt.com/codex/tasks/task_e_686c1e6ec5b4832691c9ca39f3e68f4a