### PR TITLE
Refactor: deduplicate OpenAI-style handlers

### DIFF
--- a/instructor/client_anthropic.py
+++ b/instructor/client_anthropic.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import anthropic
 import instructor
+import json
+from textwrap import dedent
+from typing import overload, Any, TypeVar
+from instructor.utils import combine_system_messages, extract_system_messages
 
-from typing import overload, Any
+T = TypeVar("T")
 
 
 @overload
@@ -115,3 +119,82 @@ def from_anthropic(
             mode=mode,
             **kwargs,
         )
+
+
+def handle_anthropic_tools(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    tool_descriptions = response_model.anthropic_schema
+    new_kwargs["tools"] = [tool_descriptions]
+    new_kwargs["tool_choice"] = {
+        "type": "tool",
+        "name": response_model.__name__,
+    }
+
+    system_messages = extract_system_messages(new_kwargs.get("messages", []))
+
+    if system_messages:
+        new_kwargs["system"] = combine_system_messages(
+            new_kwargs.get("system"), system_messages
+        )
+
+    new_kwargs["messages"] = [
+        m for m in new_kwargs.get("messages", []) if m["role"] != "system"
+    ]
+
+    return response_model, new_kwargs
+
+
+def handle_anthropic_reasoning_tools(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    # https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview#forcing-tool-use
+
+    response_model, new_kwargs = handle_anthropic_tools(response_model, new_kwargs)
+
+    # https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview#forcing-tool-use
+    # Reasoning does not allow forced tool use
+    new_kwargs["tool_choice"] = {"type": "auto"}
+
+    # But add a message recommending only to use the tools if they are relevant
+    implict_forced_tool_message = dedent(
+        f"""
+        Return only the tool call and no additional text.
+        """
+    )
+    new_kwargs["system"] = combine_system_messages(
+        new_kwargs.get("system"),
+        [{"type": "text", "text": implict_forced_tool_message}],
+    )
+    return response_model, new_kwargs
+
+
+def handle_anthropic_json(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    system_messages = extract_system_messages(new_kwargs.get("messages", []))
+
+    if system_messages:
+        new_kwargs["system"] = combine_system_messages(
+            new_kwargs.get("system"), system_messages
+        )
+
+    new_kwargs["messages"] = [
+        m for m in new_kwargs.get("messages", []) if m["role"] != "system"
+    ]
+
+    json_schema_message = dedent(
+        f"""
+        As a genius expert, your task is to understand the content and provide
+        the parsed objects in json that match the following json_schema:\n
+        {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=False)}
+        Make sure to return an instance of the JSON, not the schema itself
+        """
+    )
+
+    new_kwargs["system"] = combine_system_messages(
+        new_kwargs.get("system"),
+        [{"type": "text", "text": json_schema_message}],
+    )
+
+    return response_model, new_kwargs

--- a/instructor/client_bedrock.py
+++ b/instructor/client_bedrock.py
@@ -1,6 +1,10 @@
 from __future__ import annotations  # type: ignore
 
-from typing import Any, Literal, overload
+from typing import Any, Literal, overload, TypeVar
+import json
+from textwrap import dedent
+
+T = TypeVar("T")
 
 import boto3
 from botocore.client import BaseClient
@@ -25,15 +29,6 @@ def from_bedrock(
     _async: Literal[True] = True,
     **kwargs: Any,
 ) -> AsyncInstructor: ...
-
-
-def handle_bedrock_json(
-    response_model: Any,
-    new_kwargs: Any,
-) -> tuple[Any, Any]:
-    print(f"handle_bedrock_json: response_model {response_model}")
-    print(f"handle_bedrock_json: new_kwargs {new_kwargs}")
-    return response_model, new_kwargs
 
 
 def from_bedrock(
@@ -85,3 +80,125 @@ def from_bedrock(
             mode=mode,
             **kwargs,
         )
+
+
+def _prepare_bedrock_converse_kwargs_internal(
+    call_kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """Minimal processing to support `converse` parameters for the Bedrock client
+
+    See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime/client/converse.html
+    """
+    if "model" in call_kwargs and "modelId" not in call_kwargs:
+        call_kwargs["modelId"] = call_kwargs.pop("model")
+
+    inference_config_params = {}
+
+    if "temperature" in call_kwargs:
+        inference_config_params["temperature"] = call_kwargs.pop("temperature")
+
+    if "max_tokens" in call_kwargs:
+        inference_config_params["maxTokens"] = call_kwargs.pop("max_tokens")
+    elif "maxTokens" in call_kwargs:
+        inference_config_params["maxTokens"] = call_kwargs.pop("maxTokens")
+
+    if "top_p" in call_kwargs:
+        inference_config_params["topP"] = call_kwargs.pop("top_p")
+    elif "topP" in call_kwargs:
+        inference_config_params["topP"] = call_kwargs.pop("topP")
+
+    if "stop" in call_kwargs:
+        stop_val = call_kwargs.pop("stop")
+        if isinstance(stop_val, str):
+            inference_config_params["stopSequences"] = [stop_val]
+        elif isinstance(stop_val, list):
+            inference_config_params["stopSequences"] = stop_val
+    elif "stop_sequences" in call_kwargs:
+        inference_config_params["stopSequences"] = call_kwargs.pop("stop_sequences")
+    elif "stopSequences" in call_kwargs:
+        inference_config_params["stopSequences"] = call_kwargs.pop("stopSequences")
+
+    if inference_config_params:
+        if "inferenceConfig" in call_kwargs:
+            existing_inference_config = call_kwargs["inferenceConfig"]
+            for key, value in inference_config_params.items():
+                if key not in existing_inference_config:
+                    existing_inference_config[key] = value
+        else:
+            call_kwargs["inferenceConfig"] = inference_config_params
+
+    if "messages" in call_kwargs and isinstance(call_kwargs["messages"], list):
+        original_input_messages = call_kwargs.pop("messages")
+
+        bedrock_system_list: list[dict[str, Any]] = []
+        bedrock_user_assistant_messages_list: list[dict[str, Any]] = []
+
+        for msg_dict in original_input_messages:
+            if not isinstance(msg_dict, dict):
+                bedrock_user_assistant_messages_list.append(msg_dict)
+                continue
+
+            current_message_for_api = msg_dict.copy()
+            role = current_message_for_api.get("role")
+            content = current_message_for_api.get("content")
+
+            if role == "system":
+                if isinstance(content, str):
+                    bedrock_system_list.append({"text": content})
+                else:
+                    raise ValueError(
+                        "System message content must be a string for Bedrock processing by this handler. "
+                        f"Found type: {type(content)}."
+                    )
+            else:
+                if "content" in current_message_for_api:
+                    if isinstance(content, str):
+                        current_message_for_api["content"] = [{"text": content}]
+                    else:
+                        raise NotImplementedError(
+                            "Non-text prompts are not currently supported in the Bedrock provider."
+                        )
+                bedrock_user_assistant_messages_list.append(current_message_for_api)
+
+        if bedrock_system_list:
+            call_kwargs["system"] = bedrock_system_list
+
+        call_kwargs["messages"] = bedrock_user_assistant_messages_list
+    return call_kwargs
+
+
+def handle_bedrock_json(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    new_kwargs = _prepare_bedrock_converse_kwargs_internal(new_kwargs)
+    json_message = dedent(
+        f"""
+        As a genius expert, your task is to understand the content and provide
+        the parsed objects in json that match the following json_schema:\n
+        {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=False)}
+
+        Make sure to return an instance of the JSON, not the schema itself
+        and don't include any other text in the response apart from the json
+        """
+    )
+    system_message = new_kwargs.pop("system", None)
+    if not system_message:
+        new_kwargs["system"] = [{"text": json_message}]
+    else:
+        if not isinstance(system_message, list):
+            raise ValueError(
+                """system must be a list of SystemMessage, refer to:
+                https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime/client/converse.html
+                """
+            )
+        system_message.append({"text": json_message})
+        new_kwargs["system"] = system_message
+
+    return response_model, new_kwargs
+
+
+def handle_bedrock_tools(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    new_kwargs = _prepare_bedrock_converse_kwargs_internal(new_kwargs)
+    return response_model, new_kwargs

--- a/instructor/client_cerebras.py
+++ b/instructor/client_cerebras.py
@@ -1,6 +1,8 @@
 from __future__ import annotations  # type: ignore
 
-from typing import Any, overload
+from typing import Any, overload, TypeVar
+
+T = TypeVar("T")
 
 import instructor
 from instructor.client import AsyncInstructor, Instructor
@@ -70,3 +72,41 @@ def from_cerebras(
         mode=mode,
         **kwargs,
     )
+
+
+def handle_cerebras_tools(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    if new_kwargs.get("stream", False):
+        raise ValueError("Stream is not supported for Cerebras Tool Calling")
+    new_kwargs["tools"] = [
+        {
+            "type": "function",
+            "function": response_model.openai_schema,
+        }
+    ]
+    new_kwargs["tool_choice"] = {
+        "type": "function",
+        "function": {"name": response_model.openai_schema["name"]},
+    }
+    return response_model, new_kwargs
+
+
+def handle_cerebras_json(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    instruction = f"""
+You are a helpful assistant that excels at following instructions.Your task is to understand the content and provide the parsed objects in json that match the following json_schema:\n
+Here is the relevant JSON schema to adhere to
+
+<schema>
+{response_model.model_json_schema()}
+</schema>
+
+Your response should consist only of a valid JSON object that `{response_model.__name__}.model_validate_json()` can successfully parse.
+"""
+
+    new_kwargs["messages"] = [{"role": "system", "content": instruction}] + new_kwargs[
+        "messages"
+    ]
+    return response_model, new_kwargs

--- a/instructor/client_cohere.py
+++ b/instructor/client_cohere.py
@@ -73,3 +73,54 @@ def from_cohere(
             mode=mode,
             **kwargs,
         )
+
+
+def handle_cohere_modes(new_kwargs: dict[str, Any]) -> tuple[None, dict[str, Any]]:
+    messages = new_kwargs.pop("messages", [])
+    chat_history = []
+    for message in messages[:-1]:
+        chat_history.append(  # type: ignore
+            {
+                "role": message["role"],
+                "message": message["content"],
+            }
+        )
+    new_kwargs["message"] = messages[-1]["content"]
+    new_kwargs["chat_history"] = chat_history
+    if "model_name" in new_kwargs and "model" not in new_kwargs:
+        new_kwargs["model"] = new_kwargs.pop("model_name")
+    new_kwargs.pop("strict", None)
+    return None, new_kwargs
+
+
+def handle_cohere_json_schema(
+    response_model: type[T_Model], new_kwargs: dict[str, Any]
+) -> tuple[type[T_Model], dict[str, Any]]:
+    new_kwargs["response_format"] = {
+        "type": "json_object",
+        "schema": response_model.model_json_schema(),
+    }
+    _, new_kwargs = handle_cohere_modes(new_kwargs)
+
+    return response_model, new_kwargs
+
+
+def handle_cohere_tools(
+    response_model: type[T_Model], new_kwargs: dict[str, Any]
+) -> tuple[type[T_Model], dict[str, Any]]:
+    _, new_kwargs = handle_cohere_modes(new_kwargs)
+
+    instruction = f"""
+Extract a valid {response_model.__name__} object based on the chat history and the json schema below.
+{response_model.model_json_schema()}
+The JSON schema was obtained by running:
+```python
+schema = {response_model.__name__}.model_json_schema()
+```
+
+The output must be a valid JSON object that `{response_model.__name__}.model_validate_json()` can successfully parse.
+"""
+    new_kwargs["chat_history"] = [
+        {"role": "user", "message": instruction}
+    ] + new_kwargs["chat_history"]
+    return response_model, new_kwargs

--- a/instructor/client_fireworks.py
+++ b/instructor/client_fireworks.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, overload
+from typing import Any, overload, TypeVar
+
+from .openai_utils import handle_openai_json_schema, handle_openai_tools
+
+T = TypeVar("T")
 
 import instructor
 from instructor.client import AsyncInstructor, Instructor
@@ -75,3 +79,23 @@ def from_fireworks(
             mode=mode,
             **kwargs,
         )
+
+
+def handle_fireworks_tools(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    if "stream" not in new_kwargs:
+        new_kwargs["stream"] = False
+    response_model, new_kwargs = handle_openai_tools(
+        response_model,
+        new_kwargs,
+    )
+    return response_model, new_kwargs
+
+
+def handle_fireworks_json(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    if "stream" not in new_kwargs:
+        new_kwargs["stream"] = False
+    return handle_openai_json_schema(response_model, new_kwargs)

--- a/instructor/client_gemini.py
+++ b/instructor/client_gemini.py
@@ -1,7 +1,11 @@
 # type: ignore
 from __future__ import annotations
 
-from typing import Any, Literal, overload
+from typing import Any, Literal, overload, TypeVar
+import json
+from textwrap import dedent
+
+T = TypeVar("T")
 
 import google.generativeai as genai
 
@@ -70,3 +74,62 @@ def from_gemini(
         mode=mode,
         **kwargs,
     )
+
+
+def handle_gemini_json(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    if "model" in new_kwargs:
+        from instructor.exceptions import ConfigurationError
+
+        raise ConfigurationError(
+            "Gemini `model` must be set while patching the client, not passed as a parameter to the create method"
+        )
+
+    from .utils import update_gemini_kwargs
+
+    message = dedent(
+        f"""
+        As a genius expert, your task is to understand the content and provide
+        the parsed objects in json that match the following json_schema:\n
+        {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=False)}
+
+        Make sure to return an instance of the JSON, not the schema itself
+        """
+    )
+
+    if new_kwargs["messages"][0]["role"] != "system":
+        new_kwargs["messages"].insert(0, {"role": "system", "content": message})
+    else:
+        new_kwargs["messages"][0]["content"] += f"\n\n{message}"
+
+    new_kwargs["generation_config"] = new_kwargs.get("generation_config", {}) | {
+        "response_mime_type": "application/json"
+    }
+
+    new_kwargs = update_gemini_kwargs(new_kwargs)
+    return response_model, new_kwargs
+
+
+def handle_gemini_tools(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    if "model" in new_kwargs:
+        from instructor.exceptions import ConfigurationError
+
+        raise ConfigurationError(
+            "Gemini `model` must be set while patching the client, not passed as a parameter to the create method"
+        )
+
+    from .utils import update_gemini_kwargs
+
+    new_kwargs["tools"] = [response_model.gemini_schema]
+    new_kwargs["tool_config"] = {
+        "function_calling_config": {
+            "mode": "ANY",
+            "allowed_function_names": [response_model.__name__],
+        },
+    }
+
+    new_kwargs = update_gemini_kwargs(new_kwargs)
+    return response_model, new_kwargs

--- a/instructor/client_genai.py
+++ b/instructor/client_genai.py
@@ -1,8 +1,16 @@
 # type: ignore
 from __future__ import annotations
 
-from typing import Any, Literal, overload
+from typing import Any, Literal, overload, TypeVar
 
+from instructor.utils import (
+    convert_to_genai_messages,
+    extract_genai_system_message,
+    map_to_gemini_function_schema,
+    update_genai_kwargs,
+)
+
+T = TypeVar("T")
 from google.genai import Client
 
 import instructor
@@ -80,3 +88,79 @@ def from_genai(
         mode=mode,
         **kwargs,
     )
+
+
+def handle_genai_structured_outputs(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    from google.genai import types
+
+    if new_kwargs.get("system"):
+        system_message = new_kwargs.pop("system")
+    elif new_kwargs.get("messages"):
+        system_message = extract_genai_system_message(new_kwargs["messages"])
+    else:
+        system_message = None
+
+    new_kwargs["contents"] = convert_to_genai_messages(new_kwargs["messages"])
+
+    # We validate that the schema doesn't contain any Union fields
+    map_to_gemini_function_schema(response_model.model_json_schema())
+
+    base_config = {
+        "system_instruction": system_message,
+        "response_mime_type": "application/json",
+        "response_schema": response_model,
+    }
+
+    generation_config = update_genai_kwargs(new_kwargs, base_config)
+
+    new_kwargs["config"] = types.GenerateContentConfig(**generation_config)
+    new_kwargs.pop("response_model", None)
+    new_kwargs.pop("messages", None)
+    new_kwargs.pop("generation_config", None)
+    new_kwargs.pop("safety_settings", None)
+
+    return response_model, new_kwargs
+
+
+def handle_genai_tools(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    from google.genai import types
+
+    schema = map_to_gemini_function_schema(response_model.model_json_schema())
+    function_definition = types.FunctionDeclaration(
+        name=response_model.__name__,
+        description=response_model.__doc__,
+        parameters=schema,
+    )
+
+    if new_kwargs.get("system"):
+        system_message = new_kwargs.pop("system")
+    elif new_kwargs.get("messages"):
+        system_message = extract_genai_system_message(new_kwargs["messages"])
+    else:
+        system_message = None
+
+    base_config = {
+        "system_instruction": system_message,
+        "tools": [types.Tool(function_declarations=[function_definition])],
+        "tool_config": types.ToolConfig(
+            function_calling_config=types.FunctionCallingConfig(
+                mode="ANY", allowed_function_names=[response_model.__name__]
+            ),
+        ),
+    }
+
+    generation_config = update_genai_kwargs(new_kwargs, base_config)
+
+    new_kwargs["config"] = types.GenerateContentConfig(**generation_config)
+    new_kwargs["contents"] = convert_to_genai_messages(new_kwargs["messages"])
+
+    new_kwargs.pop("response_model", None)
+    new_kwargs.pop("messages", None)
+    new_kwargs.pop("generation_config", None)
+    new_kwargs.pop("safety_settings", None)
+
+    return response_model, new_kwargs

--- a/instructor/client_mistral.py
+++ b/instructor/client_mistral.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from mistralai import Mistral
 import instructor
-from typing import overload, Any, Literal
+from typing import overload, Any, Literal, TypeVar
+
+from .openai_utils import handle_openai_tools
+
+T = TypeVar("T")
 
 
 @overload
@@ -84,3 +88,24 @@ def from_mistral(
         mode=mode,
         **kwargs,
     )
+
+
+def handle_mistral_tools(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    return handle_openai_tools(
+        response_model,
+        new_kwargs,
+        tool_choice="any",
+    )
+
+
+def handle_mistral_structured_outputs(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    from mistralai.extra import response_format_from_pydantic_model
+
+    new_kwargs["response_format"] = response_format_from_pydantic_model(response_model)
+    new_kwargs.pop("tools", None)
+    new_kwargs.pop("response_model", None)
+    return response_model, new_kwargs

--- a/instructor/client_perplexity.py
+++ b/instructor/client_perplexity.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import openai
 import instructor
-from typing import overload, Any
+from typing import overload, Any, TypeVar
+
+from .openai_utils import handle_openai_json_schema
+
+T = TypeVar("T")
 
 
 @overload
@@ -73,3 +77,10 @@ def from_perplexity(
         mode=mode,
         **kwargs,
     )
+
+
+def handle_perplexity_json(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    """Delegate to the generic OpenAI-style JSON handler."""
+    return handle_openai_json_schema(response_model, new_kwargs)

--- a/instructor/client_vertexai.py
+++ b/instructor/client_vertexai.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Union, get_origin
+from typing import Any, Union, get_origin, TypeVar
+from collections.abc import Iterable
 
 from vertexai.preview.generative_models import ToolConfig  # type: ignore
 import vertexai.generative_models as gm  # type: ignore
@@ -8,6 +9,8 @@ from pydantic import BaseModel
 import instructor
 from instructor.dsl.parallel import get_types_array
 import jsonref
+
+T = TypeVar("T")
 
 
 def _create_gemini_json_schema(model: BaseModel):
@@ -193,3 +196,51 @@ def from_vertexai(
         mode=mode,
         **kwargs,
     )
+
+
+def handle_vertexai_parallel_tools(
+    response_model: type[Iterable[T]], new_kwargs: dict[str, Any]
+) -> tuple[VertexAIParallelBase, dict[str, Any]]:
+    if new_kwargs.get("stream", False):
+        from instructor.exceptions import ConfigurationError
+
+        raise ConfigurationError(
+            "stream=True is not supported when using VERTEXAI_PARALLEL_TOOLS mode"
+        )
+
+    from instructor.client_vertexai import vertexai_process_response
+
+    model_types = list(get_types_array(response_model))
+    contents, tools, tool_config = vertexai_process_response(new_kwargs, model_types)
+    new_kwargs["contents"] = contents
+    new_kwargs["tools"] = tools
+    new_kwargs["tool_config"] = tool_config
+
+    return VertexAIParallelModel(typehint=response_model), new_kwargs
+
+
+def handle_vertexai_tools(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    from instructor.client_vertexai import vertexai_process_response
+
+    contents, tools, tool_config = vertexai_process_response(new_kwargs, response_model)
+
+    new_kwargs["contents"] = contents
+    new_kwargs["tools"] = tools
+    new_kwargs["tool_config"] = tool_config
+    return response_model, new_kwargs
+
+
+def handle_vertexai_json(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    from instructor.client_vertexai import vertexai_process_json_response
+
+    contents, generation_config = vertexai_process_json_response(
+        new_kwargs, response_model
+    )
+
+    new_kwargs["contents"] = contents
+    new_kwargs["generation_config"] = generation_config
+    return response_model, new_kwargs

--- a/instructor/client_writer.py
+++ b/instructor/client_writer.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import instructor
 from writerai import AsyncWriter, Writer
-from typing import overload, Any
+from typing import overload, Any, TypeVar
+
+from .openai_utils import handle_openai_json_schema, handle_openai_tools
+
+T = TypeVar("T")
 
 
 @overload
@@ -61,3 +65,19 @@ def from_writer(
         mode=mode,
         **kwargs,
     )
+
+
+def handle_writer_tools(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    return handle_openai_tools(
+        response_model,
+        new_kwargs,
+        tool_choice="auto",
+    )
+
+
+def handle_writer_json(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    return handle_openai_json_schema(response_model, new_kwargs)

--- a/instructor/openai_utils.py
+++ b/instructor/openai_utils.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+
+def handle_openai_tools(
+    response_model: type[T],
+    new_kwargs: dict[str, Any],
+    *,
+    tool_choice: str | dict[str, Any] | None = None,
+) -> tuple[type[T], dict[str, Any]]:
+    """Generic OpenAI-style tools handler."""
+    new_kwargs["tools"] = [
+        {
+            "type": "function",
+            "function": response_model.openai_schema,
+        }
+    ]
+    if tool_choice is None:
+        tool_choice = {
+            "type": "function",
+            "function": {"name": response_model.openai_schema["name"]},
+        }
+    new_kwargs["tool_choice"] = tool_choice
+    return response_model, new_kwargs
+
+
+def handle_openai_json_schema(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    """Generic JSON handler for OpenAI compatible providers."""
+    new_kwargs["response_format"] = {
+        "type": "json_schema",
+        "json_schema": {"schema": response_model.model_json_schema()},
+    }
+    return response_model, new_kwargs

--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -18,8 +18,6 @@ from instructor.dsl.parallel import (
     ParallelBase,
     ParallelModel,
     VertexAIParallelBase,
-    VertexAIParallelModel,
-    get_types_array,
     handle_parallel_model,
 )
 from instructor.dsl.partial import PartialBase
@@ -31,15 +29,56 @@ from instructor.dsl.simple_type import (
 from instructor.function_calls import OpenAISchema, openai_schema
 from instructor.mode import Mode
 from instructor.multimodal import convert_messages, extract_genai_multimodal_content
-from instructor.utils import (
-    combine_system_messages,
-    convert_to_genai_messages,
-    extract_genai_system_message,
-    extract_system_messages,
-    map_to_gemini_function_schema,
-    merge_consecutive_messages,
-    update_genai_kwargs,
-)
+from instructor.utils import extract_system_messages, merge_consecutive_messages
+import importlib.util
+
+if importlib.util.find_spec("anthropic") is not None:
+    from .client_anthropic import (
+        handle_anthropic_json,
+        handle_anthropic_reasoning_tools,
+        handle_anthropic_tools,
+    )
+
+if importlib.util.find_spec("cohere") is not None:
+    from .client_cohere import (
+        handle_cohere_json_schema,
+        handle_cohere_modes,
+        handle_cohere_tools,
+    )
+
+if importlib.util.find_spec("mistralai") is not None:
+    from .client_mistral import (
+        handle_mistral_structured_outputs,
+        handle_mistral_tools,
+    )
+
+if importlib.util.find_spec("fireworks") is not None:
+    from .client_fireworks import handle_fireworks_json, handle_fireworks_tools
+
+if importlib.util.find_spec("google.generativeai") is not None:
+    from .client_gemini import handle_gemini_json, handle_gemini_tools
+
+if importlib.util.find_spec("google.genai") is not None:
+    from .client_genai import handle_genai_structured_outputs, handle_genai_tools
+
+if all(importlib.util.find_spec(pkg) for pkg in ("vertexai", "jsonref")):
+    from .client_vertexai import (
+        handle_vertexai_json,
+        handle_vertexai_parallel_tools,
+        handle_vertexai_tools,
+    )
+
+if importlib.util.find_spec("boto3") is not None:
+    from .client_bedrock import handle_bedrock_json, handle_bedrock_tools
+
+if importlib.util.find_spec("cerebras") is not None:
+    from .client_cerebras import handle_cerebras_json, handle_cerebras_tools
+
+if importlib.util.find_spec("writerai") is not None:
+    from .client_writer import handle_writer_json, handle_writer_tools
+
+if importlib.util.find_spec("openai") is not None:
+    from .client_perplexity import handle_perplexity_json
 
 logger = logging.getLogger("instructor")
 
@@ -327,30 +366,6 @@ def handle_responses_tools_with_inbuilt_tools(
     return response_model, new_kwargs
 
 
-def handle_mistral_tools(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    new_kwargs["tools"] = [
-        {
-            "type": "function",
-            "function": response_model.openai_schema,
-        }
-    ]
-    new_kwargs["tool_choice"] = "any"
-    return response_model, new_kwargs
-
-
-def handle_mistral_structured_outputs(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    from mistralai.extra import response_format_from_pydantic_model
-
-    new_kwargs["response_format"] = response_format_from_pydantic_model(response_model)
-    new_kwargs.pop("tools", None)
-    new_kwargs.pop("response_model", None)
-    return response_model, new_kwargs
-
-
 def handle_json_o1(
     response_model: type[T], new_kwargs: dict[str, Any]
 ) -> tuple[type[T], dict[str, Any]]:
@@ -429,588 +444,6 @@ def handle_json_modes(
         )
 
     return response_model, new_kwargs
-
-
-def handle_anthropic_tools(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    tool_descriptions = response_model.anthropic_schema
-    new_kwargs["tools"] = [tool_descriptions]
-    new_kwargs["tool_choice"] = {
-        "type": "tool",
-        "name": response_model.__name__,
-    }
-
-    system_messages = extract_system_messages(new_kwargs.get("messages", []))
-
-    if system_messages:
-        new_kwargs["system"] = combine_system_messages(
-            new_kwargs.get("system"), system_messages
-        )
-
-    new_kwargs["messages"] = [
-        m for m in new_kwargs.get("messages", []) if m["role"] != "system"
-    ]
-
-    return response_model, new_kwargs
-
-
-def handle_anthropic_reasoning_tools(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    # https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview#forcing-tool-use
-
-    response_model, new_kwargs = handle_anthropic_tools(response_model, new_kwargs)
-
-    # https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview#forcing-tool-use
-    # Reasoning does not allow forced tool use
-    new_kwargs["tool_choice"] = {"type": "auto"}
-
-    # But add a message recommending only to use the tools if they are relevant
-    implict_forced_tool_message = dedent(
-        f"""
-        Return only the tool call and no additional text.
-        """
-    )
-    new_kwargs["system"] = combine_system_messages(
-        new_kwargs.get("system"),
-        [{"type": "text", "text": implict_forced_tool_message}],
-    )
-    return response_model, new_kwargs
-
-
-def handle_anthropic_json(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    system_messages = extract_system_messages(new_kwargs.get("messages", []))
-
-    if system_messages:
-        new_kwargs["system"] = combine_system_messages(
-            new_kwargs.get("system"), system_messages
-        )
-
-    new_kwargs["messages"] = [
-        m for m in new_kwargs.get("messages", []) if m["role"] != "system"
-    ]
-
-    json_schema_message = dedent(
-        f"""
-        As a genius expert, your task is to understand the content and provide
-        the parsed objects in json that match the following json_schema:\n
-
-        {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=False)}
-
-        Make sure to return an instance of the JSON, not the schema itself
-        """
-    )
-
-    new_kwargs["system"] = combine_system_messages(
-        new_kwargs.get("system"),
-        [{"type": "text", "text": json_schema_message}],
-    )
-
-    return response_model, new_kwargs
-
-
-def handle_cohere_modes(new_kwargs: dict[str, Any]) -> tuple[None, dict[str, Any]]:
-    messages = new_kwargs.pop("messages", [])
-    chat_history = []
-    for message in messages[:-1]:
-        chat_history.append(  # type: ignore
-            {
-                "role": message["role"],
-                "message": message["content"],
-            }
-        )
-    new_kwargs["message"] = messages[-1]["content"]
-    new_kwargs["chat_history"] = chat_history
-    if "model_name" in new_kwargs and "model" not in new_kwargs:
-        new_kwargs["model"] = new_kwargs.pop("model_name")
-    new_kwargs.pop("strict", None)
-    return None, new_kwargs
-
-
-def handle_fireworks_tools(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    if "stream" not in new_kwargs:
-        new_kwargs["stream"] = False
-    new_kwargs["tools"] = [
-        {
-            "type": "function",
-            "function": response_model.openai_schema,
-        }
-    ]
-    new_kwargs["tool_choice"] = {
-        "type": "function",
-        "function": {"name": response_model.openai_schema["name"]},
-    }
-    return response_model, new_kwargs
-
-
-def handle_fireworks_json(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    if "stream" not in new_kwargs:
-        new_kwargs["stream"] = False
-
-    new_kwargs["response_format"] = {
-        "type": "json_object",
-        "schema": response_model.model_json_schema(),
-    }
-    return response_model, new_kwargs
-
-
-def handle_gemini_json(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    if "model" in new_kwargs:
-        from instructor.exceptions import ConfigurationError
-
-        raise ConfigurationError(
-            "Gemini `model` must be set while patching the client, not passed as a parameter to the create method"
-        )
-
-    from .utils import update_gemini_kwargs
-
-    message = dedent(
-        f"""
-        As a genius expert, your task is to understand the content and provide
-        the parsed objects in json that match the following json_schema:\n
-
-        {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=False)}
-
-        Make sure to return an instance of the JSON, not the schema itself
-        """
-    )
-
-    if new_kwargs["messages"][0]["role"] != "system":
-        new_kwargs["messages"].insert(0, {"role": "system", "content": message})
-    else:
-        new_kwargs["messages"][0]["content"] += f"\n\n{message}"
-
-    new_kwargs["generation_config"] = new_kwargs.get("generation_config", {}) | {
-        "response_mime_type": "application/json"
-    }
-
-    new_kwargs = update_gemini_kwargs(new_kwargs)
-    return response_model, new_kwargs
-
-
-def handle_gemini_tools(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    if "model" in new_kwargs:
-        from instructor.exceptions import ConfigurationError
-
-        raise ConfigurationError(
-            "Gemini `model` must be set while patching the client, not passed as a parameter to the create method"
-        )
-
-    from .utils import update_gemini_kwargs
-
-    new_kwargs["tools"] = [response_model.gemini_schema]
-    new_kwargs["tool_config"] = {
-        "function_calling_config": {
-            "mode": "ANY",
-            "allowed_function_names": [response_model.__name__],
-        },
-    }
-
-    new_kwargs = update_gemini_kwargs(new_kwargs)
-    return response_model, new_kwargs
-
-
-def handle_genai_structured_outputs(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    from google.genai import types
-
-    if new_kwargs.get("system"):
-        system_message = new_kwargs.pop("system")
-    elif new_kwargs.get("messages"):
-        system_message = extract_genai_system_message(new_kwargs["messages"])
-    else:
-        system_message = None
-
-    new_kwargs["contents"] = convert_to_genai_messages(new_kwargs["messages"])
-
-    # We validate that the schema doesn't contain any Union fields
-    map_to_gemini_function_schema(response_model.model_json_schema())
-
-    base_config = {
-        "system_instruction": system_message,
-        "response_mime_type": "application/json",
-        "response_schema": response_model,
-    }
-
-    generation_config = update_genai_kwargs(new_kwargs, base_config)
-
-    new_kwargs["config"] = types.GenerateContentConfig(**generation_config)
-    new_kwargs.pop("response_model", None)
-    new_kwargs.pop("messages", None)
-    new_kwargs.pop("generation_config", None)
-    new_kwargs.pop("safety_settings", None)
-
-    return response_model, new_kwargs
-
-
-def handle_genai_tools(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    from google.genai import types
-
-    schema = map_to_gemini_function_schema(response_model.model_json_schema())
-    function_definition = types.FunctionDeclaration(
-        name=response_model.__name__,
-        description=response_model.__doc__,
-        parameters=schema,
-    )
-
-    # We support the system message if you declare a system kwarg or if you pass a system message in the messages
-    if new_kwargs.get("system"):
-        system_message = new_kwargs.pop("system")
-    elif new_kwargs.get("messages"):
-        system_message = extract_genai_system_message(new_kwargs["messages"])
-    else:
-        system_message = None
-
-    base_config = {
-        "system_instruction": system_message,
-        "tools": [types.Tool(function_declarations=[function_definition])],
-        "tool_config": types.ToolConfig(
-            function_calling_config=types.FunctionCallingConfig(
-                mode="ANY", allowed_function_names=[response_model.__name__]
-            ),
-        ),
-    }
-
-    generation_config = update_genai_kwargs(new_kwargs, base_config)
-
-    new_kwargs["config"] = types.GenerateContentConfig(**generation_config)
-    new_kwargs["contents"] = convert_to_genai_messages(new_kwargs["messages"])
-
-    new_kwargs.pop("response_model", None)
-    new_kwargs.pop("messages", None)
-    new_kwargs.pop("generation_config", None)
-    new_kwargs.pop("safety_settings", None)
-
-    return response_model, new_kwargs
-
-
-def handle_vertexai_parallel_tools(
-    response_model: type[Iterable[T]], new_kwargs: dict[str, Any]
-) -> tuple[VertexAIParallelBase, dict[str, Any]]:
-    if new_kwargs.get("stream", False):
-        from instructor.exceptions import ConfigurationError
-
-        raise ConfigurationError(
-            "stream=True is not supported when using VERTEXAI_PARALLEL_TOOLS mode"
-        )
-
-    from instructor.client_vertexai import vertexai_process_response
-
-    # Extract concrete types before passing to vertexai_process_response
-    model_types = list(get_types_array(response_model))
-    contents, tools, tool_config = vertexai_process_response(new_kwargs, model_types)
-    new_kwargs["contents"] = contents
-    new_kwargs["tools"] = tools
-    new_kwargs["tool_config"] = tool_config
-
-    return VertexAIParallelModel(typehint=response_model), new_kwargs
-
-
-def handle_vertexai_tools(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    from instructor.client_vertexai import vertexai_process_response
-
-    contents, tools, tool_config = vertexai_process_response(new_kwargs, response_model)
-
-    new_kwargs["contents"] = contents
-    new_kwargs["tools"] = tools
-    new_kwargs["tool_config"] = tool_config
-    return response_model, new_kwargs
-
-
-def handle_vertexai_json(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    from instructor.client_vertexai import vertexai_process_json_response
-
-    contents, generation_config = vertexai_process_json_response(
-        new_kwargs, response_model
-    )
-
-    new_kwargs["contents"] = contents
-    new_kwargs["generation_config"] = generation_config
-    return response_model, new_kwargs
-
-
-def _prepare_bedrock_converse_kwargs_internal(
-    call_kwargs: dict[str, Any],
-) -> dict[str, Any]:
-    """Minimal processing to support `converse` parameters for the Bedrock client
-
-    See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime/client/converse.html
-    """
-    # Bedrock expects 'modelId' over 'model'
-    if "model" in call_kwargs and "modelId" not in call_kwargs:
-        call_kwargs["modelId"] = call_kwargs.pop("model")
-
-    # Prepare inferenceConfig for parameters like temperature, maxTokens, etc.
-    inference_config_params = {}
-
-    # Temperature
-    if "temperature" in call_kwargs:
-        inference_config_params["temperature"] = call_kwargs.pop("temperature")
-
-    # Max Tokens (OpenAI uses max_tokens)
-    if "max_tokens" in call_kwargs:
-        inference_config_params["maxTokens"] = call_kwargs.pop("max_tokens")
-    elif "maxTokens" in call_kwargs:  # If Bedrock-style maxTokens is already top-level
-        inference_config_params["maxTokens"] = call_kwargs.pop("maxTokens")
-
-    # Top P (OpenAI uses top_p)
-    if "top_p" in call_kwargs:
-        inference_config_params["topP"] = call_kwargs.pop("top_p")
-    elif "topP" in call_kwargs:  # If Bedrock-style topP is already top-level
-        inference_config_params["topP"] = call_kwargs.pop("topP")
-
-    # Stop Sequences (OpenAI uses 'stop')
-    # Bedrock 'Converse' API expects 'stopSequences'
-    if "stop" in call_kwargs:
-        stop_val = call_kwargs.pop("stop")
-        if isinstance(stop_val, str):
-            inference_config_params["stopSequences"] = [stop_val]
-        elif isinstance(stop_val, list):
-            inference_config_params["stopSequences"] = stop_val
-    elif "stop_sequences" in call_kwargs:
-        inference_config_params["stopSequences"] = call_kwargs.pop("stop_sequences")
-    elif (
-        "stopSequences" in call_kwargs
-    ):  # If Bedrock-style stopSequences is already top-level
-        inference_config_params["stopSequences"] = call_kwargs.pop("stopSequences")
-
-    # If any inference parameters were collected, add them to inferenceConfig
-    # Merge with existing inferenceConfig if user provided one.
-    # User-provided inferenceConfig keys take precedence over top-level params if conflicts.
-    if inference_config_params:
-        if "inferenceConfig" in call_kwargs:
-            # Merge, giving precedence to what's already in call_kwargs["inferenceConfig"]
-            # This could be more sophisticated, but for now, if inferenceConfig is set, assume it's intentional.
-            existing_inference_config = call_kwargs["inferenceConfig"]
-            for key, value in inference_config_params.items():
-                if key not in existing_inference_config:
-                    existing_inference_config[key] = value
-        else:
-            call_kwargs["inferenceConfig"] = inference_config_params
-
-    # Process messages for Bedrock: separate system prompts and format text content.
-    if "messages" in call_kwargs and isinstance(call_kwargs["messages"], list):
-        original_input_messages = call_kwargs.pop("messages")
-
-        bedrock_system_list: list[dict[str, Any]] = []
-        bedrock_user_assistant_messages_list: list[dict[str, Any]] = []
-
-        for msg_dict in original_input_messages:
-            if not isinstance(msg_dict, dict):
-                # If an item in the messages list is not a dictionary,
-                # pass it through to the user/assistant messages list as is.
-                # This allows non-standard message items to be handled by subsequent Boto3 validation
-                # or if they represent something other than standard role/content messages.
-                bedrock_user_assistant_messages_list.append(msg_dict)
-                continue
-
-            # Make a copy to avoid modifying the original dict if it's part of a larger structure
-            # or if the original list/dicts are expected to remain unchanged by the caller.
-            current_message_for_api = msg_dict.copy()
-            role = current_message_for_api.get("role")
-            content = current_message_for_api.get(
-                "content"
-            )  # content can be None or other types
-
-            if role == "system":
-                if isinstance(content, str):
-                    bedrock_system_list.append({"text": content})
-                else:  # System message content is not a string (could be None, list, int, etc.)
-                    raise ValueError(
-                        "System message content must be a string for Bedrock processing by this handler. "
-                        f"Found type: {type(content)}."
-                    )
-            else:  # For user, assistant, or other roles that go into Bedrock's 'messages' list
-                if "content" in current_message_for_api:
-                    if isinstance(content, str):
-                        current_message_for_api["content"] = [{"text": content}]
-                    else:  # Content is not a string (e.g., None, list, int).
-                        # This matches the original behavior which raised for any non-string content.
-                        raise NotImplementedError(
-                            "Non-text prompts are not currently supported in the Bedrock provider."
-                        )
-                # If 'content' key is not in current_message_for_api, message is added as is (e.g. for tool calls without content)
-                bedrock_user_assistant_messages_list.append(current_message_for_api)
-
-        if bedrock_system_list:
-            call_kwargs["system"] = bedrock_system_list
-
-        # Always re-assign the 'messages' key with the processed list.
-        # If original_input_messages was empty or only contained system messages that were extracted,
-        # bedrock_user_assistant_messages_list will be empty, correctly resulting in `messages: []`.
-        call_kwargs["messages"] = bedrock_user_assistant_messages_list
-    return call_kwargs
-
-
-def handle_bedrock_json(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    new_kwargs = _prepare_bedrock_converse_kwargs_internal(new_kwargs)
-    json_message = dedent(
-        f"""
-        As a genius expert, your task is to understand the content and provide
-        the parsed objects in json that match the following json_schema:\n
-
-        {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=False)}
-
-        Make sure to return an instance of the JSON, not the schema itself
-        and don't include any other text in the response apart from the json
-        """
-    )
-    system_message = new_kwargs.pop("system", None)
-    if not system_message:
-        new_kwargs["system"] = [{"text": json_message}]
-    else:
-        if not isinstance(system_message, list):
-            raise ValueError(
-                """system must be a list of SystemMessage, refer to:
-                https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime/client/converse.html
-                """
-            )
-        system_message.append({"text": json_message})
-        new_kwargs["system"] = system_message
-
-    return response_model, new_kwargs
-
-
-def handle_bedrock_tools(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    new_kwargs = _prepare_bedrock_converse_kwargs_internal(new_kwargs)
-    return response_model, new_kwargs
-
-
-def handle_cohere_json_schema(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    new_kwargs["response_format"] = {
-        "type": "json_object",
-        "schema": response_model.model_json_schema(),
-    }
-    _, new_kwargs = handle_cohere_modes(new_kwargs)
-
-    return response_model, new_kwargs
-
-
-def handle_cerebras_tools(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    if new_kwargs.get("stream", False):
-        raise ValueError("Stream is not supported for Cerebras Tool Calling")
-    new_kwargs["tools"] = [
-        {
-            "type": "function",
-            "function": response_model.openai_schema,
-        }
-    ]
-    new_kwargs["tool_choice"] = {
-        "type": "function",
-        "function": {"name": response_model.openai_schema["name"]},
-    }
-    return response_model, new_kwargs
-
-
-def handle_cerebras_json(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    instruction = f"""
-You are a helpful assistant that excels at following instructions.Your task is to understand the content and provide the parsed objects in json that match the following json_schema:\n
-
-Here is the relevant JSON schema to adhere to
-
-<schema>
-{response_model.model_json_schema()}
-</schema>
-
-Your response should consist only of a valid JSON object that `{response_model.__name__}.model_validate_json()` can successfully parse.
-"""
-
-    new_kwargs["messages"] = [{"role": "system", "content": instruction}] + new_kwargs[
-        "messages"
-    ]
-    return response_model, new_kwargs
-
-
-def handle_cohere_tools(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    _, new_kwargs = handle_cohere_modes(new_kwargs)
-
-    instruction = f"""\
-Extract a valid {response_model.__name__} object based on the chat history and the json schema below.
-{response_model.model_json_schema()}
-The JSON schema was obtained by running:
-```python
-schema = {response_model.__name__}.model_json_schema()
-```
-
-The output must be a valid JSON object that `{response_model.__name__}.model_validate_json()` can successfully parse.
-"""
-    new_kwargs["chat_history"] = [
-        {"role": "user", "message": instruction}
-    ] + new_kwargs["chat_history"]
-    return response_model, new_kwargs
-
-
-def handle_writer_tools(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    new_kwargs["tools"] = [
-        {
-            "type": "function",
-            "function": response_model.openai_schema,
-        }
-    ]
-    new_kwargs["tool_choice"] = "auto"
-    return response_model, new_kwargs
-
-
-def handle_writer_json(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    new_kwargs["response_format"] = {
-        "type": "json_schema",
-        "json_schema": {"schema": response_model.model_json_schema()},
-    }
-
-    return response_model, new_kwargs
-
-
-def handle_perplexity_json(
-    response_model: type[T], new_kwargs: dict[str, Any]
-) -> tuple[type[T], dict[str, Any]]:
-    new_kwargs["response_format"] = {
-        "type": "json_schema",
-        "json_schema": {"schema": response_model.model_json_schema()},
-    }
-
-    return response_model, new_kwargs
-
-
-def is_typed_dict(cls) -> bool:
-    return (
-        isinstance(cls, type)
-        and issubclass(cls, dict)
-        and hasattr(cls, "__annotations__")
-    )
 
 
 def prepare_response_model(response_model: type[T] | None) -> type[T] | None:
@@ -1137,30 +570,90 @@ def handle_response_model(
         Mode.JSON: lambda rm, nk: handle_json_modes(rm, nk, Mode.JSON),  # type: ignore
         Mode.MD_JSON: lambda rm, nk: handle_json_modes(rm, nk, Mode.MD_JSON),  # type: ignore
         Mode.JSON_SCHEMA: lambda rm, nk: handle_json_modes(rm, nk, Mode.JSON_SCHEMA),  # type: ignore
-        Mode.ANTHROPIC_TOOLS: handle_anthropic_tools,
-        Mode.ANTHROPIC_REASONING_TOOLS: handle_anthropic_reasoning_tools,
-        Mode.ANTHROPIC_JSON: handle_anthropic_json,
-        Mode.COHERE_JSON_SCHEMA: handle_cohere_json_schema,
-        Mode.COHERE_TOOLS: handle_cohere_tools,
-        Mode.GEMINI_JSON: handle_gemini_json,
-        Mode.GEMINI_TOOLS: handle_gemini_tools,
-        Mode.GENAI_TOOLS: handle_genai_tools,
-        Mode.GENAI_STRUCTURED_OUTPUTS: handle_genai_structured_outputs,
-        Mode.VERTEXAI_TOOLS: handle_vertexai_tools,
-        Mode.VERTEXAI_JSON: handle_vertexai_json,
-        Mode.CEREBRAS_JSON: handle_cerebras_json,
-        Mode.CEREBRAS_TOOLS: handle_cerebras_tools,
-        Mode.FIREWORKS_JSON: handle_fireworks_json,
-        Mode.FIREWORKS_TOOLS: handle_fireworks_tools,
-        Mode.WRITER_TOOLS: handle_writer_tools,
-        Mode.WRITER_JSON: handle_writer_json,
-        Mode.BEDROCK_JSON: handle_bedrock_json,
-        Mode.BEDROCK_TOOLS: handle_bedrock_tools,
-        Mode.PERPLEXITY_JSON: handle_perplexity_json,
         Mode.OPENROUTER_STRUCTURED_OUTPUTS: handle_openrouter_structured_outputs,
         Mode.RESPONSES_TOOLS: handle_responses_tools,
         Mode.RESPONSES_TOOLS_WITH_INBUILT_TOOLS: handle_responses_tools_with_inbuilt_tools,
     }
+
+    if importlib.util.find_spec("anthropic") is not None:
+        mode_handlers.update(
+            {
+                Mode.ANTHROPIC_TOOLS: handle_anthropic_tools,
+                Mode.ANTHROPIC_REASONING_TOOLS: handle_anthropic_reasoning_tools,
+                Mode.ANTHROPIC_JSON: handle_anthropic_json,
+            }
+        )
+
+    if importlib.util.find_spec("cohere") is not None:
+        mode_handlers.update(
+            {
+                Mode.COHERE_JSON_SCHEMA: handle_cohere_json_schema,
+                Mode.COHERE_TOOLS: handle_cohere_tools,
+            }
+        )
+
+    if importlib.util.find_spec("fireworks") is not None:
+        mode_handlers.update(
+            {
+                Mode.FIREWORKS_JSON: handle_fireworks_json,
+                Mode.FIREWORKS_TOOLS: handle_fireworks_tools,
+            }
+        )
+
+    if importlib.util.find_spec("writerai") is not None:
+        mode_handlers.update(
+            {
+                Mode.WRITER_TOOLS: handle_writer_tools,
+                Mode.WRITER_JSON: handle_writer_json,
+            }
+        )
+
+    if importlib.util.find_spec("openai") is not None:
+        mode_handlers.update({Mode.PERPLEXITY_JSON: handle_perplexity_json})
+
+    if importlib.util.find_spec("mistralai") is not None:
+        pass  # already included above
+
+    if importlib.util.find_spec("google.generativeai") is not None:
+        mode_handlers.update(
+            {
+                Mode.GEMINI_JSON: handle_gemini_json,
+                Mode.GEMINI_TOOLS: handle_gemini_tools,
+            }
+        )
+
+    if importlib.util.find_spec("google.genai") is not None:
+        mode_handlers.update(
+            {
+                Mode.GENAI_TOOLS: handle_genai_tools,
+                Mode.GENAI_STRUCTURED_OUTPUTS: handle_genai_structured_outputs,
+            }
+        )
+
+    if all(importlib.util.find_spec(pkg) for pkg in ("vertexai", "jsonref")):
+        mode_handlers.update(
+            {
+                Mode.VERTEXAI_TOOLS: handle_vertexai_tools,
+                Mode.VERTEXAI_JSON: handle_vertexai_json,
+                Mode.VERTEXAI_PARALLEL_TOOLS: handle_vertexai_parallel_tools,
+            }
+        )
+
+    if importlib.util.find_spec("boto3") is not None:
+        mode_handlers.update(
+            {
+                Mode.BEDROCK_JSON: handle_bedrock_json,
+                Mode.BEDROCK_TOOLS: handle_bedrock_tools,
+            }
+        )
+
+    if importlib.util.find_spec("cerebras") is not None:
+        mode_handlers.update(
+            {
+                Mode.CEREBRAS_JSON: handle_cerebras_json,
+                Mode.CEREBRAS_TOOLS: handle_cerebras_tools,
+            }
+        )
 
     if mode in mode_handlers:
         response_model, new_kwargs = mode_handlers[mode](response_model, new_kwargs)

--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -564,8 +564,6 @@ def handle_response_model(
         Mode.FUNCTIONS: handle_functions,
         Mode.TOOLS_STRICT: handle_tools_strict,
         Mode.TOOLS: handle_tools,
-        Mode.MISTRAL_TOOLS: handle_mistral_tools,
-        Mode.MISTRAL_STRUCTURED_OUTPUTS: handle_mistral_structured_outputs,
         Mode.JSON_O1: handle_json_o1,
         Mode.JSON: lambda rm, nk: handle_json_modes(rm, nk, Mode.JSON),  # type: ignore
         Mode.MD_JSON: lambda rm, nk: handle_json_modes(rm, nk, Mode.MD_JSON),  # type: ignore
@@ -612,7 +610,12 @@ def handle_response_model(
         mode_handlers.update({Mode.PERPLEXITY_JSON: handle_perplexity_json})
 
     if importlib.util.find_spec("mistralai") is not None:
-        pass  # already included above
+        mode_handlers.update(
+            {
+                Mode.MISTRAL_TOOLS: handle_mistral_tools,
+                Mode.MISTRAL_STRUCTURED_OUTPUTS: handle_mistral_structured_outputs,
+            }
+        )
 
     if importlib.util.find_spec("google.generativeai") is not None:
         mode_handlers.update(

--- a/uv.lock
+++ b/uv.lock
@@ -2042,6 +2042,7 @@ requires-dist = [
     { name = "pytest-examples", marker = "extra == 'dev'", specifier = ">=0.0.15" },
     { name = "pytest-examples", marker = "extra == 'docs'", specifier = ">=0.0.15" },
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0.1" },
+    { name = "python-dotenv", marker = "extra == 'xai'", specifier = ">=1.0.0" },
     { name = "redis", marker = "extra == 'test-docs'", specifier = ">=5.0.1,<7.0.0" },
     { name = "requests", specifier = ">=2.32.3,<3.0.0" },
     { name = "rich", specifier = ">=13.7.0,<15.0.0" },


### PR DESCRIPTION
## Summary
- add openai_utils with generic JSON and tools handlers
- reuse these utilities in Writer, Perplexity, Mistral and Fireworks clients
- conditionally import client handlers in `process_response`

## Testing
- `ruff format instructor examples tests`
- `ruff check instructor examples tests`
- `pyright`
- `pytest -k 'not llm and not openai'`


------
https://chatgpt.com/codex/tasks/task_e_686c1f196a488326a935642ce1084e0e
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor to deduplicate OpenAI-style handlers by introducing `openai_utils.py` and updating client files to use these utilities, with conditional imports in `process_response.py`.
> 
>   - **Refactoring**:
>     - Introduce `openai_utils.py` with generic handlers `handle_openai_json_schema` and `handle_openai_tools`.
>     - Update clients (`client_writer.py`, `client_perplexity.py`, `client_mistral.py`, `client_fireworks.py`) to use new utilities.
>     - Remove redundant handler functions from `process_response.py`.
>   - **Conditional Imports**:
>     - Conditionally import client handlers in `process_response.py` based on package availability (e.g., `anthropic`, `cohere`, `mistralai`).
>   - **Testing**:
>     - Run `ruff`, `pyright`, and `pytest` to ensure code quality and functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 27e904ad5b0b15c645a5375a67fa929423fa4e83. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->