### PR TITLE
Fix batch request parsing

### DIFF
--- a/instructor/cli/batch.py
+++ b/instructor/cli/batch.py
@@ -3,6 +3,7 @@ from rich.table import Table
 from rich.live import Live
 import typer
 import time
+import json
 from typing import Any
 
 app = typer.Typer()
@@ -100,7 +101,7 @@ def create_from_file(
             "[bold green]Creating Anthropic batch job...", spinner="dots"
         ):
             with open(file_path) as file:
-                requests = [eval(line) for line in file]
+                requests = [json.loads(line) for line in file]
 
             batch = client.beta.messages.batches.create(requests=requests)
         console.print(f"Anthropic batch job created with ID: {batch.id}")


### PR DESCRIPTION
## Summary
- parse Anthropics batch job files using `json.loads`
- add missing `json` import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel', 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_686c4ff2afa88326b1de2a4619ccc06c
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix batch job file parsing in `batch.py` by using `json.loads` and add missing `json` import.
> 
>   - **Behavior**:
>     - Replace `eval` with `json.loads` for parsing batch job files in `create_from_file()` in `batch.py`.
>     - Add missing `json` import in `batch.py`.
>   - **Testing**:
>     - `pytest -q` fails due to missing `sqlmodel` and `openai` modules, unrelated to this PR.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 9dc4fe076517f31ac4f83bd94609df93a0ccda7a. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->