### PR TITLE
split off dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,6 @@ dependencies = [
     "jiter>=0.6.1,<0.11",
     "jinja2<4.0.0,>=3.1.4",
     "requests<3.0.0,>=2.32.3",
-    "pre-commit>=4.2.0",
-    "mkdocs>=1.6.1",
-    "mkdocs-material>=9.5.49",
     "diskcache>=5.6.3",
 ]
 name = "instructor"
@@ -60,6 +57,7 @@ dev = [
     "pytest-examples>=0.0.15",
     "python-dotenv>=1.0.1",
     "pytest-xdist>=3.8.0",
+    "pre-commit>=4.2.0",
 ]
 docs = [
     "mkdocs<2.0.0,>=1.6.1",


### PR DESCRIPTION
`mkdocs` and `mkdocs-material` are already in the `docs` dependency group. Moved `pre-commit` to the `dev` dependency group.

Fixes #1639 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `pre-commit` to `dev` dependencies in `pyproject.toml`.
> 
>   - **Dependencies**:
>     - Move `pre-commit` from main dependencies to `dev` group in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for cd28c00ca2734ba7a0d8d8fbff712fd024095d6e. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->