### PR TITLE
Add Azure AD token provider support

### DIFF
--- a/docs/integrations/azure.md
+++ b/docs/integrations/azure.md
@@ -32,8 +32,13 @@ If you see an error like the one above, make sure you've set the correct endpoin
 To use Azure OpenAI, you'll need:
 
 1. Azure OpenAI endpoint
-2. API key
+2. API key **or** a Microsoft Entra ID token
 3. Deployment name
+
+The client reads these from the environment variables
+`AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, and
+`AZURE_OPENAI_AD_TOKEN` respectively, but you can also pass them
+directly when constructing the client.
 
 ```python
 import os
@@ -49,6 +54,26 @@ client = AzureOpenAI(
 
 # Patch the client with instructor
 client = instructor.from_provider("azure_openai/gpt-4o-mini")
+```
+
+You can also authenticate using Microsoft Entra ID tokens:
+
+```python
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from openai import AzureOpenAI
+import instructor
+import os
+
+token_provider = get_bearer_token_provider(
+    DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+)
+
+client = AzureOpenAI(
+    azure_ad_token_provider=token_provider,
+    api_version="2024-07-01-preview",
+    azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+)
+client = instructor.from_openai(client, model="gpt-4o-mini")
 ```
 
 ## Using Auto Client (Recommended)
@@ -70,6 +95,23 @@ client = instructor.from_provider("azure_openai/gpt-4o-mini")
 async_client = instructor.from_provider("azure_openai/gpt-4o-mini", async_client=True)
 ```
 
+If you prefer Microsoft Entra ID authentication, supply `azure_ad_token_provider`:
+
+```python
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+import instructor
+
+token_provider = get_bearer_token_provider(
+    DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+)
+
+client = instructor.from_provider(
+    "azure_openai/gpt-4o-mini",
+    azure_ad_token_provider=token_provider,
+    azure_endpoint="https://your-resource.openai.azure.com/",
+)
+```
+
 You can also pass credentials as parameters:
 
 ```python
@@ -77,7 +119,7 @@ import instructor
 
 client = instructor.from_provider(
     "azure_openai/gpt-4o-mini",
-    api_key="your-api-key",
+    api_key="your-api-key",  # or azure_ad_token_provider=token_provider,
     azure_endpoint="https://your-resource.openai.azure.com/",
     api_version="2024-02-01"  # Optional, defaults to 2024-02-01
 )

--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -155,18 +155,14 @@ def from_provider(
 
             # Get required Azure OpenAI configuration from environment
             api_key = kwargs.pop("api_key", os.environ.get("AZURE_OPENAI_API_KEY"))
+            azure_ad_token = kwargs.pop(
+                "azure_ad_token", os.environ.get("AZURE_OPENAI_AD_TOKEN")
+            )
+            azure_ad_token_provider = kwargs.pop("azure_ad_token_provider", None)
             azure_endpoint = kwargs.pop(
                 "azure_endpoint", os.environ.get("AZURE_OPENAI_ENDPOINT")
             )
             api_version = kwargs.pop("api_version", "2024-02-01")
-
-            if not api_key:
-                from instructor.exceptions import ConfigurationError
-
-                raise ConfigurationError(
-                    "AZURE_OPENAI_API_KEY is not set. "
-                    "Set it with `export AZURE_OPENAI_API_KEY=<your-api-key>` or pass it as kwarg api_key=<your-api-key>"
-                )
 
             if not azure_endpoint:
                 from instructor.exceptions import ConfigurationError
@@ -176,18 +172,21 @@ def from_provider(
                     "Set it with `export AZURE_OPENAI_ENDPOINT=<your-endpoint>` or pass it as kwarg azure_endpoint=<your-endpoint>"
                 )
 
-            client = (
-                AsyncAzureOpenAI(
-                    api_key=api_key,
-                    api_version=api_version,
-                    azure_endpoint=azure_endpoint,
+            if not any([api_key, azure_ad_token, azure_ad_token_provider]):
+                from instructor.exceptions import ConfigurationError
+
+                raise ConfigurationError(
+                    "Missing credentials for Azure OpenAI. "
+                    "Provide api_key, azure_ad_token, or azure_ad_token_provider."
                 )
-                if async_client
-                else AzureOpenAI(
-                    api_key=api_key,
-                    api_version=api_version,
-                    azure_endpoint=azure_endpoint,
-                )
+
+            client_cls = AsyncAzureOpenAI if async_client else AzureOpenAI
+            client = client_cls(
+                api_key=api_key,
+                azure_ad_token=azure_ad_token,
+                azure_ad_token_provider=azure_ad_token_provider,
+                api_version=api_version,
+                azure_endpoint=azure_endpoint,
             )
             return from_openai(
                 client,


### PR DESCRIPTION
## Summary
- support `azure_ad_token_provider` in `auto_client.from_provider`
- document Microsoft Entra ID authentication in Azure integration guide

## Testing
- `uv run ruff check instructor examples tests`
- `uv run pyright`
- `uv run pytest tests/ -k 'not llm and not openai' -q` *(fails: Could not resolve authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68717f89fe008326af04366b2801c649
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Azure AD token provider support in `from_provider()` and update Azure integration guide for Microsoft Entra ID authentication.
> 
>   - **Behavior**:
>     - Add support for `azure_ad_token_provider` in `from_provider()` in `auto_client.py` for Azure OpenAI authentication.
>     - Update Azure integration guide in `azure.md` to document Microsoft Entra ID token authentication.
>   - **Error Handling**:
>     - Raise `ConfigurationError` in `from_provider()` if neither `api_key`, `azure_ad_token`, nor `azure_ad_token_provider` is provided.
>   - **Testing**:
>     - Commands provided for `ruff`, `pyright`, and `pytest`, with a note on authentication failure in `pytest`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 8d7db07b4eb508982b2a10e2c4154ecd9cfc1410. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->