### PR TITLE
Fix create_with_completion for list responses

### DIFF
--- a/instructor/client.py
+++ b/instructor/client.py
@@ -518,7 +518,10 @@ class Instructor:
             hooks=self.hooks,
             **kwargs,
         )
-        return model, model._raw_response
+        raw_response = getattr(model, "_raw_response", None)
+        if raw_response is None and isinstance(model, list) and model:
+            raw_response = getattr(model[0], "_raw_response", None)
+        return model, raw_response
 
     def handle_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
         """
@@ -683,7 +686,10 @@ class AsyncInstructor(Instructor):
             hooks=self.hooks,
             **kwargs,
         )
-        return response, response._raw_response
+        raw_response = getattr(response, "_raw_response", None)
+        if raw_response is None and isinstance(response, list) and response:
+            raw_response = getattr(response[0], "_raw_response", None)
+        return response, raw_response
 
 
 @overload

--- a/tests/llm/test_genai/test_create_with_completion.py
+++ b/tests/llm/test_genai/test_create_with_completion.py
@@ -1,0 +1,27 @@
+import pytest
+from pydantic import BaseModel
+import instructor
+
+from .util import models, modes
+
+
+class Listing(BaseModel):
+    title: str
+    url: str
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize("mode", modes)
+def test_create_with_completion_list(client, model, mode):
+    inst = instructor.from_genai(client, mode=mode)
+    items, raw = inst.chat.completions.create_with_completion(
+        model=model,
+        messages=[
+            {"role": "user", "content": "Give two blog post titles with URLs about AI"}
+        ],
+        response_model=list[Listing],
+    )
+    assert isinstance(items, list)
+    assert len(items) == 2
+    assert all(isinstance(i, Listing) for i in items)
+    assert raw is not None


### PR DESCRIPTION
## Summary
- handle list responses in `create_with_completion`
- add regression test using the genai library

## Testing
- `uv run ruff format instructor examples tests`
- `uv run ruff check instructor examples tests`
- `uv run pyright`
- `uv run pytest tests/ -k 'not llm and not openai'` *(fails: openai tests require network)*

------
https://chatgpt.com/codex/tasks/task_e_6873d34e04e08326a7886e250895720c