### PR TITLE
docs: update provider syntax

### DIFF
--- a/docs/concepts/batch.md
+++ b/docs/concepts/batch.md
@@ -5,7 +5,7 @@ Batch processing allows you to send multiple requests in a single operation, whi
 ## Supported Providers
 
 ### OpenAI
-- **Models**: gpt-4o, gpt-4o-mini, gpt-4-turbo, etc.
+- **Models**: gpt-4o, gpt-4.1-mini, gpt-4-turbo, etc.
 - **Cost Savings**: 50% discount on batch requests
 - **Format**: Uses OpenAI's batch API with JSON schema for structured outputs
 
@@ -35,7 +35,7 @@ class User(BaseModel):
     age: int
 
 # Create processor with model specification
-processor = BatchProcessor("openai/gpt-4o-mini", User)
+processor = BatchProcessor("openai/gpt-4.1-mini", User)
 
 # Prepare your message conversations
 messages_list = [
@@ -95,7 +95,7 @@ export OPENAI_API_KEY="your-openai-key"
 
 ```python
 # Use OpenAI models
-processor = BatchProcessor("openai/gpt-4o-mini", User)
+processor = BatchProcessor("openai/gpt-4.1-mini", User)
 ```
 
 ### Anthropic Setup
@@ -353,7 +353,7 @@ def run_batch_workflow(provider_model: str):
 if __name__ == "__main__":
     # OpenAI
     if os.getenv("OPENAI_API_KEY"):
-        run_batch_workflow("openai/gpt-4o-mini")
+        run_batch_workflow("openai/gpt-4.1-mini")
     
     # Anthropic
     if os.getenv("ANTHROPIC_API_KEY"):
@@ -380,13 +380,13 @@ Instructor also provides CLI commands for batch processing:
 
 ```bash
 # List batch jobs
-instructor batch list --model "openai/gpt-4o-mini"
+instructor batch list --model "openai/gpt-4.1-mini"
 
 # Create batch from file
-instructor batch create-from-file --file-path batch_requests.jsonl --model "openai/gpt-4o-mini"
+instructor batch create-from-file --file-path batch_requests.jsonl --model "openai/gpt-4.1-mini"
 
 # Get batch results
-instructor batch results --batch-id "batch_abc123" --output-file results.jsonl --model "openai/gpt-4o-mini"
+instructor batch results --batch-id "batch_abc123" --output-file results.jsonl --model "openai/gpt-4.1-mini"
 ```
 
 ## Best Practices
@@ -412,7 +412,7 @@ instructor batch results --batch-id "batch_abc123" --output-file results.jsonl -
 - **Region Mismatch**: Ensure GCS bucket and batch job are in the same region
 
 ### General Issues
-- **Invalid Model Name**: Use format `provider/model-name` (e.g., `openai/gpt-4o-mini`)
+- **Invalid Model Name**: Use format `provider/model-name` (e.g., `openai/gpt-4.1-mini`)
 - **Authentication**: Ensure API keys are set correctly
 - **Schema Validation**: Verify your Pydantic models match expected output format
 

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -11,9 +11,9 @@ from instructor import from_provider
 from instructor.cache import AutoCache, DiskCache
 
 # Works with any provider - cache flows through **kwargs automatically
-client = from_provider("openai/gpt-3.5-turbo", cache=AutoCache(maxsize=1000))
+client = from_provider("openai/gpt-4.1-mini", cache=AutoCache(maxsize=1000))
 client = from_provider("anthropic/claude-3-haiku", cache=AutoCache(maxsize=1000))  
-client = from_provider("google/gemini-pro", cache=DiskCache(directory=".cache"))
+client = from_provider("google/gemini-2.5-flash", cache=DiskCache(directory=".cache"))
 
 # Your normal calls are now cached automatically
 class User(BaseModel):
@@ -64,7 +64,7 @@ from instructor.cache import make_cache_key
 
 key = make_cache_key(
     messages=[{"role": "user", "content": "hello"}],
-    model="gpt-3.5-turbo",
+    model="gpt-4.1-mini",
     response_model=User,
     mode="TOOLS",
 )
@@ -97,11 +97,10 @@ This approach allows us to restore the original dot-notation access patterns (e.
 ```python
 import time
 import functools
-import openai
 import instructor
 from pydantic import BaseModel
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class UserDetail(BaseModel):
@@ -112,7 +111,6 @@ class UserDetail(BaseModel):
 @functools.cache
 def extract(data) -> UserDetail:
     return client.chat.completions.create(
-        model="gpt-3.5-turbo",
         response_model=UserDetail,
         messages=[
             {"role": "user", "content": data},
@@ -225,11 +223,9 @@ import functools
 import inspect
 import instructor
 import diskcache
-
-from openai import OpenAI
 from pydantic import BaseModel
 
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 cache = diskcache.Cache('./my_cache_directory')
 
 
@@ -267,7 +263,6 @@ class UserDetail(BaseModel):
 @instructor_cache
 def extract(data) -> UserDetail:
     return client.chat.completions.create(
-        model="gpt-3.5-turbo",
         response_model=UserDetail,
         messages=[
             {"role": "user", "content": data},
@@ -331,9 +326,8 @@ import inspect
 import instructor
 
 from pydantic import BaseModel
-from openai import OpenAI
 
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 cache = redis.Redis("localhost")
 
 
@@ -370,7 +364,6 @@ class UserDetail(BaseModel):
 def extract(data) -> UserDetail:
     # Assuming client.chat.completions.create returns a UserDetail instance
     return client.chat.completions.create(
-        model="gpt-3.5-turbo",
         response_model=UserDetail,
         messages=[
             {"role": "user", "content": data},

--- a/docs/concepts/distillation.md
+++ b/docs/concepts/distillation.md
@@ -5,7 +5,7 @@ description: Learn how to fine-tune language models with Python functions using 
 
 # Distilling python functions into LLM
 
-`Instructions` from the `Instructor` library offers a seamless way to make language models backward compatible with existing Python functions. By employing Pydantic type hints, it not only ensures compatibility but also facilitates fine-tuning `gpt-3.5-turbo` to emulate these functions end-to-end.
+`Instructions` from the `Instructor` library offers a seamless way to make language models backward compatible with existing Python functions. By employing Pydantic type hints, it not only ensures compatibility but also facilitates fine-tuning `gpt-4.1-mini` to emulate these functions end-to-end.
 
 If you want to see the full example checkout [examples/distillation](https://github.com/jxnl/instructor/tree/main/examples/distilations)
 
@@ -137,7 +137,7 @@ instructions = Instructions(
 )
 
 
-@instructions.distil(model='gpt-3.5-turbo:finetuned-123', mode="dispatch")
+@instructions.distil(model='gpt-4.1-mini:finetuned-123', mode="dispatch")
 def fn(a: int, b: int) -> Multiply:
     # now this code will be short circuited and the model will be used instead.
     resp = a + b

--- a/docs/concepts/error_handling.md
+++ b/docs/concepts/error_handling.md
@@ -36,7 +36,6 @@ Raised when the LLM output is incomplete due to reaching the maximum token limit
 ```python
 try:
     response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
         response_model=DetailedReport,
         messages=[{"role": "user", "content": "Write a very long report..."}],
         max_tokens=50  # Very low limit
@@ -52,7 +51,6 @@ Raised when all retry attempts have been exhausted.
 ```python
 try:
     response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
         response_model=UserDetail,
         messages=[{"role": "user", "content": "Extract user info..."}],
         max_retries=3
@@ -70,7 +68,6 @@ Raised when response validation fails. This is different from Pydantic's Validat
 ```python
 try:
     response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
         response_model=StrictModel,
         messages=[{"role": "user", "content": "Extract data..."}]
     )
@@ -83,7 +80,7 @@ Raised for provider-specific errors, includes the provider name for context.
 
 ```python
 try:
-    client = instructor.from_anthropic(invalid_client)
+    client = instructor.from_provider(invalid_client)
 except ProviderError as e:
     print(f"Provider {e.provider} error: {e}")
 ```
@@ -103,9 +100,9 @@ Raised when an invalid mode is used for a specific provider.
 
 ```python
 try:
-    client = instructor.from_anthropic(
-        anthropic.Anthropic(),
-        mode=instructor.Mode.TOOLS  # Wrong mode for Anthropic
+    client = instructor.from_provider(
+        "anthropic/claude-3-sonnet-20240229",
+        mode=instructor.Mode.TOOLS,  # Wrong mode for Anthropic
     )
 except ModeError as e:
     print(f"Invalid mode '{e.mode}' for provider '{e.provider}'")
@@ -117,7 +114,7 @@ Raised for client initialization or usage errors.
 
 ```python
 try:
-    client = instructor.from_anthropic("not_a_client")
+    client = instructor.from_provider("not_a_client")
 except ClientError as e:
     print(f"Client error: {e}")
 ```
@@ -193,7 +190,6 @@ logger = logging.getLogger(__name__)
 def extract_data(content: str):
     try:
         return client.chat.completions.create(
-            model="gpt-3.5-turbo",
             response_model=DataModel,
             messages=[{"role": "user", "content": content}]
         )
@@ -218,7 +214,6 @@ def extract_with_fallback(content: str):
     # Try with strict model first
     try:
         return client.chat.completions.create(
-            model="gpt-4",
             response_model=StrictDataModel,
             messages=[{"role": "user", "content": content}]
         )
@@ -226,7 +221,6 @@ def extract_with_fallback(content: str):
         # Fall back to less strict model
         logger.warning("Strict validation failed, trying relaxed model")
         return client.chat.completions.create(
-            model="gpt-3.5-turbo",
             response_model=RelaxedDataModel,
             messages=[{"role": "user", "content": content}]
         )
@@ -278,9 +272,9 @@ except ConfigurationError as e:
 
 ```python
 try:
-    client = instructor.from_openai(
-        openai.OpenAI(),
-        mode=instructor.Mode.ANTHROPIC_TOOLS  # Wrong mode
+    client = instructor.from_provider(
+        "openai/gpt-4.1-mini",
+        mode=instructor.Mode.ANTHROPIC_TOOLS,  # Wrong mode
     )
 except ModeError as e:
     print(f"Use one of these modes instead: {e.valid_modes}")

--- a/docs/concepts/fastapi.md
+++ b/docs/concepts/fastapi.md
@@ -22,10 +22,12 @@ import instructor
 
 from fastapi import FastAPI
 from pydantic import BaseModel
-from openai import AsyncOpenAI
 
 # Enables response_model
-client = instructor.from_openai(AsyncOpenAI())
+client = instructor.from_provider(
+    "openai/gpt-4.1-mini",
+    async_client=True,
+)
 app = FastAPI()
 
 
@@ -42,7 +44,6 @@ class UserDetail(BaseModel):
 @app.post("/endpoint", response_model=UserDetail)
 async def endpoint_function(data: UserData) -> UserDetail:
     user_detail = await client.chat.completions.create(
-        model="gpt-3.5-turbo",
         response_model=UserDetail,
         messages=[
             {"role": "user", "content": f"Extract: `{data.query}`"},
@@ -77,7 +78,6 @@ class UserDetail(BaseModel):
 @app.post("/extract", response_class=StreamingResponse)
 async def extract(data: UserData):
     users = await client.chat.completions.create(
-        model="gpt-3.5-turbo",
         response_model=Iterable[UserDetail],
         stream=True,
         messages=[

--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -113,10 +113,9 @@ You can register hooks using the `on` method of the Instructor client or a `Hook
 
 ```python
 import instructor
-import openai
 import pprint
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 def log_completion_kwargs(*args, **kwargs):
@@ -126,7 +125,6 @@ def log_completion_kwargs(*args, **kwargs):
 client.on("completion:kwargs", log_completion_kwargs)
 
 resp = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     messages=[{"role": "user", "content": "Hello, world!"}],
     response_model=str,
 )
@@ -144,10 +142,9 @@ You can remove a specific hook using the `off` method:
 
 ```python
 import instructor
-import openai
 import pprint
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 def log_completion_kwargs(*args, **kwargs):
@@ -167,9 +164,8 @@ To remove all hooks for a specific event or all events:
 
 ```python
 import instructor
-import openai
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 # Define a simple handler
 def log_completion_kwargs(*args, **kwargs):
@@ -180,7 +176,6 @@ client.on("completion:kwargs", log_completion_kwargs)
 
 # Make a request that triggers the hook
 resp = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     messages=[{"role": "user", "content": "Hello, world!"}],
     response_model=str,
 )
@@ -204,7 +199,6 @@ Here's a comprehensive example demonstrating how to use hooks for logging and de
 
 ```python
 import instructor
-import openai
 import pydantic
 
 
@@ -219,7 +213,7 @@ def log_completion_kwargs(*args, **kwargs) -> None:
     #             "content": "Extract the user name and age from the following text: 'John is 20 years old'",
     #         }
     #     ],
-    #     "model": "gpt-4o-mini",
+    #     "model": "gpt-4.1-mini",
     #     "tools": [
     #         {
     #             "type": "function",
@@ -271,7 +265,7 @@ def log_completion_response(response) -> None:
     #         }
     #     ],
     #     'created': 1732370794,
-    #     'model': 'gpt-4o-mini-2024-07-18',
+    #     'model': 'gpt-4.1-mini-2024-07-18',
     #     'object': 'chat.completion',
     #     'service_tier': None,
     #     'system_fingerprint': 'fp_0705bf87c0',
@@ -334,7 +328,7 @@ class ErrorCounter:
         print(f"Error count: {self.error_count}")
 
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 # Register the hooks
 client.on("completion:kwargs", log_completion_kwargs)
@@ -355,7 +349,6 @@ class User(pydantic.BaseModel):
 # Try extraction with a potentially problematic input
 try:
     resp = client.chat.completions.create(
-        model="gpt-4o-mini",
         messages=[
             {
                 "role": "user",
@@ -480,7 +473,7 @@ class ErrorMonitor:
 
 # Usage
 monitor = ErrorMonitor()
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 client.on("completion:error", monitor.handle_error)
 client.on("parse:error", monitor.handle_error)
@@ -498,19 +491,17 @@ Hooks are particularly useful for testing, as they allow you to inspect the argu
 import unittest
 from unittest.mock import Mock
 import instructor
-import openai
 
 
 class TestMyApp(unittest.TestCase):
     def test_completion(self):
-        client = instructor.from_openai(openai.OpenAI())
+        client = instructor.from_provider("openai/gpt-4.1-mini")
         mock_handler = Mock()
 
         client.on("completion:response", mock_handler)
 
         # Call your code that uses the client
         result = client.chat.completions.create(
-            model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": "Hello"}],
             response_model=str,
         )
@@ -520,7 +511,7 @@ class TestMyApp(unittest.TestCase):
 
         # You can also inspect the arguments
         response_arg = mock_handler.call_args[0][0]
-        self.assertEqual(response_arg.model, "gpt-3.5-turbo")
+        self.assertEqual(response_arg.model, "gpt-4.1-mini")
 ```
 
 This approach allows you to test your code without mocking the entire client.
@@ -537,7 +528,6 @@ client = instructor.patch(OpenAI())
 
 # Example with all hooks enabled (default)
 response = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=str,
     messages=[{"role": "user", "content": "Hello!"}],
 )

--- a/docs/concepts/iterable.md
+++ b/docs/concepts/iterable.md
@@ -14,17 +14,15 @@ Here's a simple example showing how to extract multiple users from a single sent
 === "Using `create_iterable` (recommended)"
     ```python
     import instructor
-    import openai
     from pydantic import BaseModel
 
-    client = instructor.from_openai(openai.OpenAI())
+    client = instructor.from_provider("openai/gpt-4.1-mini")
 
     class User(BaseModel):
         name: str
         age: int
 
     resp = client.chat.completions.create_iterable(
-        model="gpt-4o-mini",
         messages=[
             {
                 "role": "user",
@@ -42,18 +40,16 @@ Here's a simple example showing how to extract multiple users from a single sent
 === "Using `create` with `Iterable[User]`"
     ```python
     import instructor
-    import openai
     from pydantic import BaseModel
     from typing import Iterable
 
-    client = instructor.from_openai(openai.OpenAI())
+    client = instructor.from_provider("openai/gpt-4.1-mini")
 
     class User(BaseModel):
         name: str
         age: int
 
     resp = client.chat.completions.create(
-        model="gpt-4o-mini",
         messages=[
             {
                 "role": "user",
@@ -83,7 +79,6 @@ We also support more complex extraction patterns such as Unions as you'll see be
 
     ```python
     import instructor
-    import openai
     from typing import Iterable, Union, Literal
     from pydantic import BaseModel
 
@@ -94,10 +89,11 @@ We also support more complex extraction patterns such as Unions as you'll see be
     class GoogleSearch(BaseModel):
         query: str
 
-    client = instructor.from_openai(openai.OpenAI(), mode=instructor.Mode.TOOLS)
+    client = instructor.from_provider(
+        "openai/gpt-4.1-mini", mode=instructor.Mode.TOOLS
+    )
 
     results = client.chat.completions.create(
-        model="gpt-4",
         messages=[
             {"role": "system", "content": "You must always use tools"},
             {"role": "user", "content": "What is the weather in toronto and dallas and who won the super bowl?"},
@@ -115,7 +111,6 @@ We also support more complex extraction patterns such as Unions as you'll see be
     ```python
 
     import instructor
-    import openai
     from typing import Union, Literal
     from pydantic import BaseModel
 
@@ -126,10 +121,11 @@ We also support more complex extraction patterns such as Unions as you'll see be
     class GoogleSearch(BaseModel):
         query: str
 
-    client = instructor.from_openai(openai.OpenAI(), mode=instructor.Mode.TOOLS)
+    client = instructor.from_provider(
+        "openai/gpt-4.1-mini", mode=instructor.Mode.TOOLS
+    )
 
     results = client.chat.completions.create_iterable(
-        model="gpt-4",
         messages=[
             {"role": "system", "content": "You must always use tools"},
             {"role": "user", "content": "What is the weather in toronto and dallas and who won the super bowl?"},
@@ -149,7 +145,6 @@ We also support more complex extraction patterns such as Unions as you'll see be
 
     ```python
     import instructor
-    import openai
     from typing import Iterable, Union, Literal
     from pydantic import BaseModel
     import asyncio
@@ -161,11 +156,12 @@ We also support more complex extraction patterns such as Unions as you'll see be
     class GoogleSearch(BaseModel):
         query: str
 
-    aclient = instructor.from_openai(openai.AsyncOpenAI(), mode=instructor.Mode.TOOLS)
+    aclient = instructor.from_provider(
+        "openai/gpt-4.1-mini", async_client=True, mode=instructor.Mode.TOOLS
+    )
 
     async def main():
         results = await aclient.chat.completions.create(
-            model="gpt-4",
             messages=[
                 {"role": "system", "content": "You must always use tools"},
                 {"role": "user", "content": "What is the weather in toronto and dallas and who won the super bowl?"},
@@ -183,7 +179,6 @@ We also support more complex extraction patterns such as Unions as you'll see be
 
     ```python
     import instructor
-    import openai
     from typing import Union, Literal
     from pydantic import BaseModel
     import asyncio
@@ -195,11 +190,12 @@ We also support more complex extraction patterns such as Unions as you'll see be
     class GoogleSearch(BaseModel):
         query: str
 
-    aclient = instructor.from_openai(openai.AsyncOpenAI(), mode=instructor.Mode.TOOLS)
+    aclient = instructor.from_provider(
+        "openai/gpt-4.1-mini", async_client=True, mode=instructor.Mode.TOOLS
+    )
 
     async def main():
         results = await aclient.chat.completions.create_iterable(
-            model="gpt-4",
             messages=[
                 {"role": "system", "content": "You must always use tools"},
                 {"role": "user", "content": "What is the weather in toronto and dallas and who won the super bowl?"},

--- a/docs/concepts/lists.md
+++ b/docs/concepts/lists.md
@@ -56,11 +56,13 @@ By using `Iterable` you get a very convenient class with prompts and names autom
 
 ```python
 import instructor
-from openai import OpenAI
 from typing import Iterable
 from pydantic import BaseModel
 
-client = instructor.from_openai(OpenAI(), mode=instructor.function_calls.Mode.JSON)
+client = instructor.from_provider(
+    "openai/gpt-4.1-mini-1106",
+    mode=instructor.function_calls.Mode.JSON,
+)
 
 
 class User(BaseModel):
@@ -69,7 +71,6 @@ class User(BaseModel):
 
 
 users = client.chat.completions.create(
-    model="gpt-3.5-turbo-1106",
     temperature=0.1,
     response_model=Iterable[User],
     stream=False,
@@ -96,11 +97,13 @@ Lets look at an example in action with the same class
 
 ```python hl_lines="6 26"
 import instructor
-import openai
 from typing import Iterable
 from pydantic import BaseModel
 
-client = instructor.from_openai(openai.OpenAI(), mode=instructor.Mode.TOOLS)
+client = instructor.from_provider(
+    "openai/gpt-4.1-mini",
+    mode=instructor.Mode.TOOLS,
+)
 
 
 class User(BaseModel):
@@ -109,7 +112,6 @@ class User(BaseModel):
 
 
 users = client.chat.completions.create(
-    model="gpt-4",
     temperature=0.1,
     stream=True,
     response_model=Iterable[User],
@@ -138,11 +140,14 @@ I also just want to call out in this example that `instructor` also supports asy
 
 ```python
 import instructor
-import openai
 from typing import Iterable
 from pydantic import BaseModel
 
-client = instructor.from_openai(openai.AsyncOpenAI(), mode=instructor.Mode.TOOLS)
+client = instructor.from_provider(
+    "openai/gpt-4.1-mini",
+    async_client=True,
+    mode=instructor.Mode.TOOLS,
+)
 
 
 class UserExtract(BaseModel):
@@ -152,7 +157,6 @@ class UserExtract(BaseModel):
 
 async def print_iterable_results():
     model = await client.chat.completions.create(
-        model="gpt-4",
         response_model=Iterable[UserExtract],
         max_retries=2,
         stream=True,

--- a/docs/concepts/logging.md
+++ b/docs/concepts/logging.md
@@ -7,7 +7,6 @@ In order to see the requests made to OpenAI and the responses, you can set loggi
 
 ```python
 import instructor
-import openai
 import logging
 
 from pydantic import BaseModel
@@ -16,7 +15,7 @@ from pydantic import BaseModel
 # Set logging to DEBUG
 logging.basicConfig(level=logging.DEBUG)
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class UserDetail(BaseModel):
@@ -25,7 +24,7 @@ class UserDetail(BaseModel):
 
 
 user = client.chat.completions.create(
-    model="gpt-3.5-turbo",
+    model="gpt-4.1-mini",
     response_model=UserDetail,
     messages=[
         {"role": "user", "content": "Extract Jason is 25 years old"},
@@ -35,10 +34,10 @@ user = client.chat.completions.create(
 """
 ...
 DEBUG:instructor:Patching `client.chat.completions.create` with mode=<Mode.TOOLS: 'tool_call'>
-DEBUG:instructor:Instructor Request: mode.value='tool_call', response_model=<class '__main__.UserDetail'>, new_kwargs={'model': 'gpt-3.5-turbo', 'messages': [{'role': 'user', 'content': 'Extract Jason is 25 years old'}], 'tools': [{'type': 'function', 'function': {'name': 'UserDetail', 'description': 'Correctly extracted `UserDetail` with all the required parameters with correct types', 'parameters': {'properties': {'name': {'title': 'Name', 'type': 'string'}, 'age': {'title': 'Age', 'type': 'integer'}}, 'required': ['age', 'name'], 'type': 'object'}}}], 'tool_choice': {'type': 'function', 'function': {'name': 'UserDetail'}}}
+DEBUG:instructor:Instructor Request: mode.value='tool_call', response_model=<class '__main__.UserDetail'>, new_kwargs={'model': 'gpt-4.1-mini', 'messages': [{'role': 'user', 'content': 'Extract Jason is 25 years old'}], 'tools': [{'type': 'function', 'function': {'name': 'UserDetail', 'description': 'Correctly extracted `UserDetail` with all the required parameters with correct types', 'parameters': {'properties': {'name': {'title': 'Name', 'type': 'string'}, 'age': {'title': 'Age', 'type': 'integer'}}, 'required': ['age', 'name'], 'type': 'object'}}}], 'tool_choice': {'type': 'function', 'function': {'name': 'UserDetail'}}}
 DEBUG:instructor:max_retries: 1
 ...
-DEBUG:instructor:Instructor Pre-Response: ChatCompletion(id='chatcmpl-8zBxMxsOqm5Sj6yeEI38PnU2r6ncC', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content=None, role='assistant', function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_E1cftF5U0zEjzIbWt3q0ZLbN', function=Function(arguments='{"name":"Jason","age":25}', name='UserDetail'), type='function')]))], created=1709594660, model='gpt-3.5-turbo-0125', object='chat.completion', system_fingerprint='fp_2b778c6b35', usage=CompletionUsage(completion_tokens=9, prompt_tokens=81, total_tokens=90))
+DEBUG:instructor:Instructor Pre-Response: ChatCompletion(id='chatcmpl-8zBxMxsOqm5Sj6yeEI38PnU2r6ncC', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content=None, role='assistant', function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_E1cftF5U0zEjzIbWt3q0ZLbN', function=Function(arguments='{"name":"Jason","age":25}', name='UserDetail'), type='function')]))], created=1709594660, model='gpt-4.1-mini-0125', object='chat.completion', system_fingerprint='fp_2b778c6b35', usage=CompletionUsage(completion_tokens=9, prompt_tokens=81, total_tokens=90))
 DEBUG:httpcore.connection:close.started
 DEBUG:httpcore.connection:close.complete
 """
@@ -55,12 +54,12 @@ import instructor
 
 logging.basicConfig(level=logging.INFO)
 
-instructor.from_provider("openai/gpt-4o-mini")
+instructor.from_provider("openai/gpt-4.1-mini")
 ```
 
 Example output:
 
 ```
-INFO:instructor.auto_client:Initializing openai provider with model gpt-4o-mini
+INFO:instructor.auto_client:Initializing openai provider with model gpt-4.1-mini
 INFO:instructor.auto_client:Client initialized
 ```

--- a/docs/concepts/maybe.md
+++ b/docs/concepts/maybe.md
@@ -41,12 +41,11 @@ Once we have the model defined, we can create a function that uses the `Maybe` p
 
 ```python
 import instructor
-import openai
 from pydantic import BaseModel, Field
 from typing import Optional
 
 # This enables the `response_model` keyword
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class UserDetail(BaseModel):
@@ -66,7 +65,6 @@ class MaybeUser(BaseModel):
 
 def extract(content: str) -> MaybeUser:
     return client.chat.completions.create(
-        model="gpt-3.5-turbo",
         response_model=MaybeUser,
         messages=[
             {"role": "user", "content": f"Extract `{content}`"},

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -144,11 +144,9 @@ We can add methods to our Pydantic models, just as any plain Python class. We mi
 from pydantic import BaseModel
 from typing import Literal
 
-from openai import OpenAI
-
 import instructor
 
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class SearchQuery(BaseModel):
@@ -162,7 +160,7 @@ class SearchQuery(BaseModel):
 
 
 query = client.chat.completions.create(
-    model="gpt-3.5-turbo",
+    model="gpt-4.1-mini",
     messages=[{"role": "user", "content": "Search for a picture of a cat"}],
     response_model=SearchQuery,
 )

--- a/docs/concepts/multimodal.md
+++ b/docs/concepts/multimodal.md
@@ -52,10 +52,9 @@ class ImageDescription(BaseModel):
 # Use our sample image provided above.
 url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/image.jpg"
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 response = client.chat.completions.create(
-    model="gpt-4o-mini",
     response_model=ImageDescription,
     messages=[
         {
@@ -91,10 +90,9 @@ class ImageDescription(BaseModel):
 # Download a sample image for demonstration
 url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/image.jpg"
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 response = client.chat.completions.create(
-    model="gpt-4o-mini",
     response_model=ImageDescription,
     autodetect_images=True,  # Set this to True
     messages=[
@@ -126,10 +124,9 @@ class ImageDescription(BaseModel):
 # Download a sample image for demonstration
 url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/image.jpg"
 
-client = instructor.from_anthropic(anthropic.Anthropic())
+client = instructor.from_provider("anthropic/claude-3-5-sonnet-20240620")
 
 response, completion = client.chat.completions.create_with_completion(
-    model="claude-3-5-sonnet-20240620",
     response_model=ImageDescription,
     autodetect_images=True,  # Set this to True
     messages=[
@@ -183,7 +180,7 @@ from instructor.multimodal import Audio
 import base64
 
 # Initialize the client
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4o-audio-preview")
 
 
 # Define our response model
@@ -196,7 +193,6 @@ url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/ass
 
 # Make the API call with the audio file
 resp = client.chat.completions.create(
-    model="gpt-4o-audio-preview",
     response_model=AudioDescription,
     modalities=["text"],
     audio={"voice": "alloy", "format": "wav"},
@@ -243,7 +239,7 @@ We provide examples of how to use all three object classes below.
 
  # Set up the client
  url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/invoice.pdf"
- client = instructor.from_openai(OpenAI())
+ client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
  # Create a model for analyzing PDFs
@@ -254,7 +250,6 @@ We provide examples of how to use all three object classes below.
 
  # Load and analyze a PDF
  response = client.chat.completions.create(
-     model="gpt-4o-mini",
      response_model=Invoice,
      messages=[
          {
@@ -283,7 +278,7 @@ from instructor.multimodal import PDFWithCacheControl
 
 # Set up the client
 url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/invoice.pdf"
-client = instructor.from_anthropic(Anthropic())
+client = instructor.from_provider("anthropic/claude-3-5-sonnet-20240620")
 
 
 # Create a model for analyzing PDFs
@@ -294,7 +289,6 @@ class Invoice(BaseModel):
 
 # Load and analyze a PDF
 response, completion = client.chat.completions.create_with_completion(
-    model="claude-3-5-sonnet-20240620",
     response_model=Invoice,
     messages=[
         {
@@ -330,7 +324,7 @@ import requests
 
 # Set up the client
 url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/invoice.pdf"
-client = instructor.from_genai(Client())
+client = instructor.from_provider("google/gemini-2.5-flash")
 
 with requests.get(url) as response:
     pdf_data = response.content
@@ -346,7 +340,6 @@ class Invoice(BaseModel):
 
 # Load and analyze a PDF
 response = client.chat.completions.create(
-    model="gemini-2.0-flash",
     response_model=Invoice,
     messages=[
         {
@@ -378,7 +371,7 @@ import requests
 
 # Set up the client
 url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/invoice.pdf"
-client = instructor.from_genai(Client())
+client = instructor.from_provider("google/gemini-2.5-flash")
 
 with requests.get(url) as response:
     pdf_data = response.content
@@ -398,7 +391,6 @@ class Invoice(BaseModel):
 
 # Load and analyze a PDF
 response = client.chat.completions.create(
-    model="gemini-2.0-flash",
     response_model=Invoice,
     messages=[
         {

--- a/docs/concepts/parallel.md
+++ b/docs/concepts/parallel.md
@@ -20,7 +20,6 @@ Parallel Function Calling helps you to significantly reduce the latency of your 
     ```python hl_lines="20 32"
     from __future__ import annotations
 
-    import openai
     import instructor
 
     from typing import Iterable, Literal
@@ -36,10 +35,12 @@ Parallel Function Calling helps you to significantly reduce the latency of your 
         query: str
 
 
-    client = instructor.from_openai(openai.OpenAI(), mode=instructor.Mode.PARALLEL_TOOLS)
+    client = instructor.from_provider(
+        "openai/gpt-4.1-mini",
+        mode=instructor.Mode.PARALLEL_TOOLS,
+    )
 
     function_calls = client.chat.completions.create(
-        model="gpt-4o-mini",
         messages=[
             {"role": "system", "content": "You must always use tools"},
             {
@@ -61,12 +62,8 @@ Parallel Function Calling helps you to significantly reduce the latency of your 
 
     ```python hl_lines="20 30"
     import instructor
-    import vertexai
-    from vertexai.generative_models import GenerativeModel
     from typing import Iterable, Literal
     from pydantic import BaseModel
-
-    vertexai.init()
 
 
     class Weather(BaseModel):
@@ -78,8 +75,8 @@ Parallel Function Calling helps you to significantly reduce the latency of your 
         query: str
 
 
-    client = instructor.from_vertexai(
-        GenerativeModel("gemini-1.5-pro-preview-0409"),
+    client = instructor.from_provider(
+        "vertexai/gemini-1.5-pro-preview-0409",
         mode=instructor.Mode.VERTEXAI_PARALLEL_TOOLS,
     )
 

--- a/docs/concepts/partial.md
+++ b/docs/concepts/partial.md
@@ -69,12 +69,11 @@ Let's look at an example of streaming an extraction of conference information, t
 
 ```python
 import instructor
-from openai import OpenAI
 from pydantic import BaseModel
 from typing import List
 from rich.console import Console
 
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 text_block = """
 In our recent online meeting, participants from various backgrounds joined to discuss the upcoming tech conference. The names and contact details of the participants were as follows:
@@ -106,7 +105,6 @@ class MeetingInfo(BaseModel):
 
 
 extraction_stream = client.chat.completions.create_partial(
-    model="gpt-4",
     response_model=MeetingInfo,
     messages=[
         {
@@ -163,10 +161,12 @@ I also just want to call out in this example that `instructor` also supports asy
 
 ```python
 import instructor
-from openai import AsyncOpenAI
 from pydantic import BaseModel
 
-client = instructor.from_openai(AsyncOpenAI())
+client = instructor.from_provider(
+    "openai/gpt-4-turbo-preview",
+    async_client=True,
+)
 
 
 class User(BaseModel):
@@ -176,7 +176,6 @@ class User(BaseModel):
 
 async def print_partial_results():
     user = client.chat.completions.create_partial(
-        model="gpt-4-turbo-preview",
         response_model=User,
         max_retries=2,
         stream=True,

--- a/docs/concepts/patching.md
+++ b/docs/concepts/patching.md
@@ -25,9 +25,11 @@ This is the recommended method for OpenAI clients. It is the most stable as func
 
 ```python
 import instructor
-from openai import OpenAI
 
-client = instructor.from_openai(OpenAI(), mode=instructor.Mode.TOOLS)
+client = instructor.from_provider(
+    "openai/gpt-4.1-mini",
+    mode=instructor.Mode.TOOLS,
+)
 ```
 
 ### Gemini Tool Calling
@@ -45,10 +47,10 @@ Gemini tool calling comes with some known limitations:
 
 ```python
 import instructor
-import google.generativeai as genai
 
-client = instructor.from_gemini(
-    genai.GenerativeModel(), mode=instructor.Mode.GEMINI_TOOLS
+client = instructor.from_provider(
+    "google/gemini-2.5-flash",
+    mode=instructor.Mode.GEMINI_TOOLS,
 )
 ```
 
@@ -60,14 +62,9 @@ This method allows us to get structured output from Gemini via tool calling with
 
 ```python
 import instructor
-from vertexai.generative_models import GenerativeModel  # type: ignore
-import vertexai
 
-vertexai.init(project="vertexai-generative-models")
-
-
-client = instructor.from_vertexai(
-    client=GenerativeModel("gemini-1.5-pro-preview-0409"),
+client = instructor.from_provider(
+    "vertexai/gemini-1.5-pro-preview-0409",
     mode=instructor.Mode.VERTEXAI_TOOLS,
 )
 ```
@@ -78,9 +75,10 @@ Parallel tool calling is also an option but you must set `response_model` to be 
 
 ```python
 import instructor
-from openai import OpenAI
-
-client = instructor.from_openai(OpenAI(), mode=instructor.Mode.PARALLEL_TOOLS)
+client = instructor.from_provider(
+    "openai/gpt-4.1-mini",
+    mode=instructor.Mode.PARALLEL_TOOLS,
+)
 ```
 
 ## Function Calling
@@ -89,9 +87,11 @@ Note that function calling is soon to be deprecated in favor of TOOL mode for Op
 
 ```python
 import instructor
-from openai import OpenAI
 
-client = instructor.from_openai(OpenAI(), mode=instructor.Mode.TOOLS)
+client = instructor.from_provider(
+    "openai/gpt-4.1-mini",
+    mode=instructor.Mode.TOOLS,
+)
 ```
 
 ## JSON Mode
@@ -100,9 +100,11 @@ JSON mode uses OpenAI's JSON format for responses by setting `response_format={"
 
 ```python
 import instructor
-from openai import OpenAI
 
-client = instructor.from_openai(OpenAI(), mode=instructor.Mode.JSON)
+client = instructor.from_provider(
+    "openai/gpt-4.1-mini",
+    mode=instructor.Mode.JSON,
+)
 ```
 
 JSON mode is also required for [the Gemini Models via OpenAI's SDK](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-gemini-using-openai-library#client-setup).
@@ -115,7 +117,6 @@ pip install google-auth
 import google.auth
 import google.auth.transport.requests
 import instructor
-from openai import OpenAI
 
 creds, project = google.auth.default()
 auth_req = google.auth.transport.requests.Request()
@@ -126,8 +127,11 @@ PROJECT = 'PROJECT_ID'
 LOCATION = 'LOCATION'
 
 base_url = f'https://{LOCATION}-aiplatform.googleapis.com/v1beta1/projects/{PROJECT}/locations/{LOCATION}/endpoints/openapi'
-client = instructor.from_openai(
-    OpenAI(base_url=base_url, api_key=creds.token), mode=instructor.Mode.JSON
+client = instructor.from_provider(
+    "openai/gpt-4.1-mini",
+    base_url=base_url,
+    api_key=creds.token,
+    mode=instructor.Mode.JSON,
 )
 ```
 
@@ -137,10 +141,10 @@ This mode uses Gemini's response mimetype field to generate a response in JSON f
 
 ```python
 import instructor
-import google.generativeai as genai
 
-client = instructor.from_gemini(
-    genai.GenerativeModel(), mode=instructor.Mode.GEMINI_JSON
+client = instructor.from_provider(
+    "google/gemini-2.5-flash",
+    mode=instructor.Mode.GEMINI_JSON,
 )
 ```
 
@@ -156,9 +160,11 @@ General syntax:
 
 ```python
 import instructor
-from openai import OpenAI
 
-client = instructor.from_openai(OpenAI(), mode=instructor.Mode.MD_JSON)
+client = instructor.from_provider(
+    "openai/gpt-4.1-mini",
+    mode=instructor.Mode.MD_JSON,
+)
 ```
 
 Databricks syntax:
@@ -166,17 +172,15 @@ Databricks syntax:
 ```python
 import instructor
 import os
-from openai import OpenAI
 
 DATABRICKS_TOKEN = os.environ.get("DATABRICKS_TOKEN", "")
 DATABRICKS_HOST = os.environ.get("DATABRICKS_HOST", "")
 
 # Assuming Databricks environment variables are set
-client = instructor.from_openai(
-    OpenAI(
-        api_key=DATABRICKS_TOKEN,
-        base_url=f"{DATABRICKS_HOST}/serving-endpoints",
-    ),
+client = instructor.from_provider(
+    "openai/gpt-4.1-mini",
+    api_key=DATABRICKS_TOKEN,
+    base_url=f"{DATABRICKS_HOST}/serving-endpoints",
     mode=instructor.Mode.MD_JSON,
 )
 ```

--- a/docs/concepts/philosophy.md
+++ b/docs/concepts/philosophy.md
@@ -18,7 +18,7 @@ class User(BaseModel):
     age: int
 
 # What Instructor adds
-client = instructor.from_provider("openai/gpt-4")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 user = client.chat.completions.create(
     response_model=User,  # That's it
     messages=[...]
@@ -33,14 +33,14 @@ The worst frameworks are roach motels - easy to get in, impossible to get out. I
 
 ```python
 # With Instructor
-client = instructor.from_provider("openai/gpt-4")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 result = client.chat.completions.create(
     response_model=User,
     messages=[...]
 )
 
 # Want to go back to raw API? Just remove response_model:
-client = instructor.from_provider("openai/gpt-4")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 result = client.chat.completions.create(
     messages=[...]  # Now you get the raw response
 )
@@ -237,7 +237,7 @@ def prioritize_tickets(tickets: List[Ticket]) -> List[Ticket]:
     return sorted(tickets, key=lambda t: (t.priority.value, -t.estimated_hours))
 
 # Connect to LLM (one line)
-client = instructor.from_provider("openai/gpt-4")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 # Extract structured data (simple function call)
 tickets = client.chat.completions.create(

--- a/docs/concepts/prompt_caching.md
+++ b/docs/concepts/prompt_caching.md
@@ -18,7 +18,7 @@ This optimization is especially useful for applications making multiple API call
 Prompt Caching is enabled for the following models:
 
 - gpt-4o
-- gpt-4o-mini
+- gpt-4.1-mini
 - o1-preview
 - o1-mini
 
@@ -176,10 +176,9 @@ Prompt Caching is now generally avaliable for Anthropic. This enables you to cac
 
 ```python
 import instructor
-from anthropic import Anthropic
 from pydantic import BaseModel
 
-client = instructor.from_anthropic(Anthropic())
+client = instructor.from_provider("anthropic/claude-3-5-sonnet-20240620")
 
 
 class Character(BaseModel):

--- a/docs/concepts/raw_response.md
+++ b/docs/concepts/raw_response.md
@@ -11,10 +11,9 @@ In instructor>1.0.0 we have a custom client, if you wish to use the raw response
 ```python
 import instructor
 
-from openai import OpenAI
 from pydantic import BaseModel
 
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class UserExtract(BaseModel):
@@ -23,7 +22,6 @@ class UserExtract(BaseModel):
 
 
 user, completion = client.chat.completions.create_with_completion(
-    model="gpt-3.5-turbo",
     response_model=UserExtract,
     messages=[
         {"role": "user", "content": "Extract jason is 25 years old"},
@@ -61,7 +59,7 @@ ChatCompletion(
         )
     ],
     created=1741141333,
-    model='gpt-3.5-turbo-0125',
+    model='gpt-4.1-mini-0125',
     object='chat.completion',
     service_tier='default',
     system_fingerprint=None,
@@ -85,13 +83,10 @@ You can also access the raw response from Anthropic models. This is useful for d
 ```python
 import instructor
 
-from anthropic import Anthropic
-
-client = instructor.from_anthropic(Anthropic())
+client = instructor.from_provider("anthropic/claude-3-5-sonnet-latest")
 
 
 user, completion = client.chat.completions.create_with_completion(
-    model="claude-3-5-sonnet-latest",
     response_model=UserExtract,
     messages=[
         {"role": "user", "content": "Extract jason is 25 years old"},

--- a/docs/concepts/reask_validation.md
+++ b/docs/concepts/reask_validation.md
@@ -66,14 +66,13 @@ LLM-based validation can also be plugged into the same Pydantic model. Here, if 
 
 ```python hl_lines="9 15"
 import instructor
-from openai import OpenAI
 from instructor import llm_validator
 from pydantic import BaseModel, ValidationError, BeforeValidator
 from typing_extensions import Annotated
 
 
 # Apply the patch to the OpenAI client
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class QuestionAnswer(BaseModel):
@@ -123,12 +122,11 @@ It is a great layer of defense against bad outputs of two forms:
 Notice that the field validator wants the name in uppercase, but the user input is lowercase. The validator will raise a `ValueError` if the name is not in uppercase.
 
 ```python hl_lines="12-17"
-import openai
 import instructor
 from pydantic import BaseModel, field_validator
 
 # Apply the patch to the OpenAI client
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class UserDetails(BaseModel):
@@ -149,10 +147,12 @@ Here, the `UserDetails` model is passed as the `response_model`, and `max_retrie
 
 ```python
 import instructor
-import openai
 from pydantic import BaseModel
 
-client = instructor.from_openai(openai.OpenAI(), mode=instructor.Mode.TOOLS)
+client = instructor.from_provider(
+    "openai/gpt-4.1-mini",
+    mode=instructor.Mode.TOOLS,
+)
 
 
 class UserDetails(BaseModel):
@@ -161,7 +161,6 @@ class UserDetails(BaseModel):
 
 
 model = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=UserDetails,
     max_retries=2,
     messages=[
@@ -180,7 +179,7 @@ print(model.model_dump_json(indent=2))
 
 ### What happens behind the scenes?
 
-Behind the scenes, the `instructor.from_openai()` method adds a `max_retries` parameter to the `openai.ChatCompletion.create()` method. The `max_retries` parameter will trigger up to 2 reattempts if the `name` attribute fails the uppercase validation in `UserDetails`.
+Behind the scenes, the `instructor.from_provider()` method adds a `max_retries` parameter to the `openai.ChatCompletion.create()` method. The `max_retries` parameter will trigger up to 2 reattempts if the `name` attribute fails the uppercase validation in `UserDetails`.
 
 ```python
 from pydantic import ValidationError

--- a/docs/concepts/retrying.md
+++ b/docs/concepts/retrying.md
@@ -31,11 +31,11 @@ Here's a complete, self-contained example showing how to set up retry logic with
 import instructor
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 from pydantic import BaseModel, field_validator
-from openai import OpenAI, RateLimitError, APIError
+from openai import RateLimitError, APIError
 import time
 
 # Set up the client with Instructor
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class UserInfo(BaseModel):
     name: str
@@ -74,7 +74,6 @@ test_texts = [
 def extract_user_info(text: str) -> UserInfo:
     """Extract user information with basic retry logic."""
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": f"Extract user info: {text}"}]
     )
@@ -98,7 +97,6 @@ except Exception as e:
 def robust_extraction(text: str) -> UserInfo:
     """Retry only on specific API errors."""
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )
@@ -124,7 +122,6 @@ from pydantic import ValidationError
 def extract_with_validation(text: str) -> UserInfo:
     """Retry when Pydantic validation fails."""
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )
@@ -154,7 +151,6 @@ def should_retry(result: UserInfo) -> bool:
 def extract_valid_user(text: str) -> UserInfo:
     """Retry based on result validation."""
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )
@@ -181,7 +177,6 @@ except Exception as e:
 def rate_limit_safe_extraction(text: str) -> UserInfo:
     """Handle rate limits with longer delays."""
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )
@@ -201,7 +196,6 @@ from tenacity import retry, retry_if_exception_type, wait_random_exponential
 def network_resilient_extraction(text: str) -> UserInfo:
     """Handle network issues with random exponential backoff."""
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )
@@ -225,7 +219,6 @@ logging.basicConfig(level=logging.INFO)
 def logged_extraction(text: str) -> UserInfo:
     """Extract with comprehensive logging."""
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )
@@ -247,7 +240,7 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 @lru_cache(maxsize=1)
 def get_client():
     """Cache the client to avoid repeated initialization."""
-    return instructor.from_openai(OpenAI())
+    return instructor.from_provider("openai/gpt-4.1-mini")
 
 @retry(
     stop=stop_after_attempt(3),
@@ -257,7 +250,6 @@ def circuit_breaker_extraction(text: str) -> UserInfo:
     """Extract with circuit breaker pattern."""
     client = get_client()
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )
@@ -272,13 +264,12 @@ from tenacity import retry, stop_after_attempt
 @retry(stop=stop_after_attempt(3))
 async def process_batch(texts: list[str]) -> list[UserInfo]:
     """Process multiple texts with retry logic."""
-    client = instructor.from_openai(OpenAI())
+    client = instructor.from_provider("openai/gpt-4.1-mini")
     results = []
 
     for text in texts:
         try:
             result = await client.chat.completions.create(
-                model="gpt-4o-mini",
                 response_model=UserInfo,
                 messages=[{"role": "user", "content": text}]
             )
@@ -306,11 +297,11 @@ Instructor has built-in retry support that works alongside Tenacity:
 from instructor import Mode
 
 # Instructor's built-in retry with custom settings
-client = instructor.from_openai(
-    OpenAI(),
+client = instructor.from_provider(
+    "openai/gpt-4.1-mini",
     mode=Mode.JSON,
     max_retries=3,
-    retry_delay=1
+    retry_delay=1,
 )
 
 # Combine with Tenacity for additional resilience
@@ -318,7 +309,6 @@ client = instructor.from_openai(
 def double_retry_extraction(text: str) -> UserInfo:
     """Combine Instructor and Tenacity retries."""
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )
@@ -361,7 +351,6 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt
 )
 def handle_rate_limits(text: str) -> UserInfo:
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )
@@ -373,7 +362,6 @@ def handle_rate_limits(text: str) -> UserInfo:
 )
 def handle_validation_errors(text: str) -> UserInfo:
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )
@@ -392,7 +380,6 @@ def monitored_extraction(text: str) -> UserInfo:
 
     try:
         result = client.chat.completions.create(
-            model="gpt-4o-mini",
             response_model=UserInfo,
             messages=[{"role": "user", "content": text}]
         )
@@ -420,7 +407,6 @@ def monitored_extraction(text: str) -> UserInfo:
 def api_friendly_extraction(text: str) -> UserInfo:
     """Respect API rate limits with exponential backoff."""
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )
@@ -437,7 +423,6 @@ def api_friendly_extraction(text: str) -> UserInfo:
 def validation_resilient_extraction(text: str) -> UserInfo:
     """Recover from validation errors with retries."""
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )
@@ -454,7 +439,6 @@ def validation_resilient_extraction(text: str) -> UserInfo:
 def network_resilient_extraction(text: str) -> UserInfo:
     """Handle network issues gracefully."""
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )
@@ -509,7 +493,6 @@ def network_resilient_extraction(text: str) -> UserInfo:
 )
 def rate_limit_respectful_extraction(text: str) -> UserInfo:
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )
@@ -532,7 +515,6 @@ logging.basicConfig(level=logging.INFO)
 def debug_extraction(text: str) -> UserInfo:
     """Extract with detailed retry logging."""
     return client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=UserInfo,
         messages=[{"role": "user", "content": text}]
     )

--- a/docs/concepts/semantic_validation.md
+++ b/docs/concepts/semantic_validation.md
@@ -32,7 +32,7 @@ from pydantic import BaseModel, BeforeValidator
 from instructor import llm_validator
 
 # Initialize client
-client = instructor.from_provider("openai/gpt-4o-mini")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class UserComment(BaseModel):
     username: str
@@ -98,7 +98,7 @@ import instructor
 from instructor import llm_validator
 
 # Initialize client
-client = instructor.from_provider("openai/gpt-4o-mini")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class ProductDescription(BaseModel):
     """Model for validating product descriptions."""
@@ -152,7 +152,7 @@ from typing import Annotated
 from pydantic import BaseModel, BeforeValidator
 from instructor import llm_validator
 
-client = instructor.from_provider("openai/gpt-4o-mini")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class Comment(BaseModel):
     """Model representing a user comment with content moderation."""
@@ -184,7 +184,7 @@ from typing import Annotated
 from pydantic import BaseModel, BeforeValidator
 from instructor import llm_validator
 
-client = instructor.from_provider("openai/gpt-4o-mini")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class ForumPost(BaseModel):
     topic: str
@@ -238,7 +238,7 @@ from typing import Annotated, List
 from pydantic import BaseModel, Field, BeforeValidator
 from instructor import llm_validator
 
-client = instructor.from_provider("openai/gpt-4o-mini")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class FactCheckedClaim(BaseModel):
     """Model for validating factual accuracy of claims."""
@@ -278,7 +278,7 @@ from typing import List
 from pydantic import BaseModel, model_validator
 from instructor import Validator  # For response type
 
-client = instructor.from_provider("openai/gpt-4o-mini")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class Report(BaseModel):
     """Model representing a report with related fields that need semantic validation."""

--- a/docs/concepts/templating.md
+++ b/docs/concepts/templating.md
@@ -25,11 +25,10 @@ Our solution offers:
 The `context` parameter is a dictionary that is passed to the templating engine. It is used to pass in the relevant variables to the templating engine. This single `context` parameter will be passed to jinja to render out the final prompt.
 
 ```python hl_lines="14-15 19-22"
-import openai
 import instructor
 from pydantic import BaseModel
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class User(BaseModel):
@@ -38,7 +37,6 @@ class User(BaseModel):
 
 
 resp = client.chat.completions.create(
-    model="gpt-4o-mini",
     messages=[
         {
             "role": "user",
@@ -62,12 +60,11 @@ print(resp)
 In this example, we demonstrate how to leverage the `context` parameter with Pydantic validators to enhance our validation and data processing capabilities. By passing the `context` to the validators, we can implement dynamic validation rules and data transformations based on the input context. This approach allows for flexible and context-aware validation, such as checking for banned words or applying redaction patterns to sensitive information.
 
 ```python hl_lines="15-16 26-30"
-import openai
 import instructor
 from pydantic import BaseModel, ValidationInfo, field_validator
 import re
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class Response(BaseModel):
@@ -85,7 +82,6 @@ class Response(BaseModel):
 
 
 response = client.create(
-    model="gpt-4o",
     response_model=Response,
     messages=[
         {
@@ -138,11 +134,10 @@ Jinja is used to render the prompts, allowing the use of familiar Jinja syntax. 
 This makes formatting of prompts and rendering logic extremely easy.
 
 ```python hl_lines="29-34 37-43"
-import openai
 import instructor
 from pydantic import BaseModel
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class Citation(BaseModel):
@@ -155,7 +150,6 @@ class Response(BaseModel):
 
 
 resp = client.chat.completions.create(
-    model="gpt-4o-mini",
     messages=[
         {
             "role": "user",
@@ -211,7 +205,6 @@ Your prompts might need to include sensitive user information when they're sent 
 ```python
 from pydantic import BaseModel, SecretStr
 import instructor
-import openai
 
 
 class UserContext(BaseModel):
@@ -226,11 +219,10 @@ class Address(BaseModel):
     zipcode: str
 
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 context = UserContext(name="scolvin", address="secret address")
 
 address = client.chat.completions.create(
-    model="gpt-4o",
     messages=[
         {
             "role": "user",

--- a/docs/concepts/typeddicts.md
+++ b/docs/concepts/typeddicts.md
@@ -9,7 +9,6 @@ We also support typed dicts.
 
 ```python
 from typing_extensions import TypedDict
-from openai import OpenAI
 import instructor
 
 
@@ -18,11 +17,10 @@ class User(TypedDict):
     age: int
 
 
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 response = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=User,
     messages=[
         {

--- a/docs/concepts/types.md
+++ b/docs/concepts/types.md
@@ -53,13 +53,11 @@ print(model.model_json_schema())
 
 ```python
 import instructor
-import openai
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 # Response model with simple types like str, int, float, bool
 resp = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=bool,
     messages=[
         {
@@ -79,17 +77,15 @@ Annotations can be used to add more information about the type. This can be usef
 
 ```python
 import instructor
-import openai
 from typing import Annotated
 from pydantic import Field
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 UpperCaseStr = Annotated[str, Field(description="string must be upper case")]
 
 # Response model with simple types like str, int, float, bool
 resp = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=UpperCaseStr,
     messages=[
         {
@@ -109,13 +105,11 @@ When doing simple classification Literals go quite well, they support literal of
 
 ```python
 import instructor
-import openai
 from typing import Literal
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 resp = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=Literal["BILLING", "SHIPPING"],
     messages=[
         {
@@ -135,7 +129,6 @@ Enums are harder to get right without some addition promping but are useful if t
 
 ```python
 import instructor
-import openai
 from enum import Enum
 
 
@@ -144,10 +137,9 @@ class Label(str, Enum):
     SHIPPING = "SHIPPING"
 
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 resp = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=Label,
     messages=[
         {
@@ -165,13 +157,11 @@ print(resp)
 
 ```python
 import instructor
-import openai
 from typing import List
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 resp = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=List[int],
     messages=[
         {
@@ -192,11 +182,10 @@ Union is a great way to handle multiple types of responses, similar to multiple 
 
 ```python
 import instructor
-import openai
 from pydantic import BaseModel
 from typing import Union
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class Add(BaseModel):
@@ -209,7 +198,6 @@ class Weather(BaseModel):
 
 
 resp = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=Union[Add, Weather],
     messages=[
         {
@@ -236,7 +224,6 @@ from typing import Annotated, Any
 from pydantic import BeforeValidator, PlainSerializer, InstanceOf, WithJsonSchema
 import pandas as pd
 import instructor
-import openai
 
 
 def md_to_df(data: Any) -> Any:
@@ -275,10 +262,9 @@ MarkdownDataFrame = Annotated[
 ]
 
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 resp = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=MarkdownDataFrame,
     messages=[
         {
@@ -305,11 +291,10 @@ Just like Unions we can use List of Unions to represent multiple types of respon
 
 ```python
 import instructor
-import openai
 from pydantic import BaseModel
 from typing import Union, List
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class Weather(BaseModel, frozen=True):
@@ -322,7 +307,6 @@ class Add(BaseModel, frozen=True):
 
 
 resp = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=List[Union[Add, Weather]],
     messages=[
         {

--- a/docs/concepts/unions.md
+++ b/docs/concepts/unions.md
@@ -31,7 +31,6 @@ Use discriminated unions to handle different response types:
 from typing import Literal, Union
 from pydantic import BaseModel
 import instructor
-from openai import OpenAI
 
 
 class UserQuery(BaseModel):
@@ -47,10 +46,9 @@ class SystemQuery(BaseModel):
 Query = Union[UserQuery, SystemQuery]
 
 # Usage with Instructor
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 response = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=Query,
     messages=[{"role": "user", "content": "Parse: user lookup jsmith"}],
 )
@@ -158,11 +156,10 @@ With this pattern, the LLM can decide whether to perform a search or a lookup ba
 import instructor
 from openai import OpenAI
 
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 # Let the LLM decide what action to take
 result = client.chat.completions.create(
-    model="gpt-4",
     response_model=Action,
     messages=[
         {
@@ -194,7 +191,6 @@ def validate_response(response: Response) -> bool:
 
 
 result = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=Response,
     validation_hook=validate_response,
     messages=[{"role": "user", "content": "Process this request"}],
@@ -205,7 +201,6 @@ result = client.chat.completions.create(
 ```python
 def stream_content():
     response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
         response_model=Message,
         stream=True,
         messages=[{"role": "user", "content": "Generate mixed content"}],
@@ -277,7 +272,6 @@ Action = Union[SendMessage, MakePayment]
 # Usage with Instructor
 client = instructor.patch(OpenAI())
 response = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=Action,
     messages=[{"role": "user", "content": "Send a payment of $50 to John."}],
 )
@@ -308,7 +302,6 @@ Action = Union[SearchAction, EmailAction]
 # The model can choose which action to take
 client = instructor.patch(OpenAI())
 response = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=Action,
     messages=[{"role": "user", "content": "Find me information about climate change."}],
 )
@@ -338,7 +331,6 @@ Response = Union[TextResponse, ImageResponse]
 # Patched client
 client = instructor.patch(OpenAI())
 response = client.chat.completions.create(
-    model="gpt-3.5-turbo",
     response_model=Response,
     messages=[{"role": "user", "content": "Tell me a joke about programming."}],
 )

--- a/docs/concepts/usage.md
+++ b/docs/concepts/usage.md
@@ -8,10 +8,9 @@ The easiest way to get usage for non streaming requests is to access the raw res
 ```python
 import instructor
 
-from openai import OpenAI
 from pydantic import BaseModel
 
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class UserExtract(BaseModel):
@@ -20,7 +19,6 @@ class UserExtract(BaseModel):
 
 
 user, completion = client.chat.completions.create_with_completion(
-    model="gpt-3.5-turbo",
     response_model=UserExtract,
     messages=[
         {"role": "user", "content": "Extract jason is 25 years old"},
@@ -45,11 +43,10 @@ You can catch an IncompleteOutputException whenever the context length is exceed
 
 ```python
 from instructor.exceptions import IncompleteOutputException
-import openai
 import instructor
 from pydantic import BaseModel
 
-client = instructor.from_openai(openai.OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class UserExtract(BaseModel):
@@ -59,7 +56,6 @@ class UserExtract(BaseModel):
 
 try:
     client.chat.completions.create_with_completion(
-        model="gpt-3.5-turbo",
         response_model=UserExtract,
         messages=[
             {"role": "user", "content": "Extract jason is 25 years old"},

--- a/docs/concepts/validation.md
+++ b/docs/concepts/validation.md
@@ -126,7 +126,7 @@ import instructor
 from instructor import llm_validator
 
 # Initialize client
-client = instructor.from_provider("openai/gpt-4o-mini")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class ContentReview(BaseModel):
     """Model for reviewing user-generated content."""
@@ -233,7 +233,7 @@ class User(BaseModel):
 
 
 # Initialize client using unified provider interface
-client = instructor.from_provider("openai/gpt-4o-mini", mode=instructor.Mode.JSON)
+client = instructor.from_provider("openai/gpt-4.1-mini", mode=instructor.Mode.JSON)
 
 try:
     # Attempt to extract with validation using Jinja templating
@@ -294,7 +294,7 @@ from pydantic import BaseModel, BeforeValidator
 import instructor
 from instructor import llm_validator
 
-client = instructor.from_provider("openai/gpt-4o-mini")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class ResponseValidation(BaseModel):
     question: str
@@ -320,7 +320,7 @@ from pydantic import BaseModel, BeforeValidator, Field
 import instructor
 from instructor import llm_validator
 
-client = instructor.from_provider("openai/gpt-4o-mini")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class SafeContent(BaseModel):
     content: Annotated[
@@ -349,7 +349,7 @@ from pydantic import BaseModel, BeforeValidator, Field
 import instructor
 from instructor import llm_validator
 
-client = instructor.from_provider("openai/gpt-4o-mini")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class FactCheckedClaim(BaseModel):
     claim: str
@@ -396,7 +396,7 @@ from instructor import llm_validator
 import instructor
 
 # Initialize client
-client = instructor.from_provider("openai/gpt-4o-mini")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class Comment(BaseModel):
     """Model representing a user comment with content moderation."""
@@ -424,7 +424,7 @@ from instructor import llm_validator
 import instructor
 
 # Initialize client
-client = instructor.from_provider("openai/gpt-4o-mini")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class Report(BaseModel):
     """Model representing a financial report with semantic validation."""
@@ -480,7 +480,7 @@ from instructor import llm_validator
 import instructor
 
 # Initialize client
-client = instructor.from_provider("openai/gpt-4o-mini")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class CompanyAnnouncement(BaseModel):
     """Model representing a company announcement with tone validation."""
@@ -508,7 +508,7 @@ from instructor import llm_validator
 import instructor
 
 # Initialize client
-client = instructor.from_provider("openai/gpt-4o-mini")
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 class MedicalClaim(BaseModel):
     """Model representing a medical claim with factual validation."""

--- a/docs/examples/self_critique.md
+++ b/docs/examples/self_critique.md
@@ -10,13 +10,12 @@ description: Learn how to use llm_validator for self-healing in NLP applications
 This guide demonstrates how to use `llm_validator` for implementing self-healing. The objective is to showcase how an instructor can self-correct by using validation errors and helpful error messages.
 
 ```python
-from openai import OpenAI
 from pydantic import BaseModel
 import instructor
 
 # Apply the patch to the OpenAI client
 # enables response_model keyword
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class QuestionAnswer(BaseModel):
@@ -28,7 +27,6 @@ question = "What is the meaning of life?"
 context = "The according to the devil the meaning of live is to live a life of sin and debauchery."
 
 qa: QuestionAnswer = client.chat.completions.create(
-    model="gpt-4o-mini",
     response_model=QuestionAnswer,
     messages=[
         {
@@ -63,10 +61,9 @@ Lets integrate `llm_validator` into the model and see the error message. Its imp
 from pydantic import BaseModel, BeforeValidator
 from typing_extensions import Annotated
 from instructor import llm_validator
-from openai import OpenAI
 import instructor
 
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class QuestionAnswerNoEvil(BaseModel):
@@ -83,7 +80,6 @@ class QuestionAnswerNoEvil(BaseModel):
 
 try:
     qa: QuestionAnswerNoEvil = client.chat.completions.create(
-        model="gpt-4o-mini",
         response_model=QuestionAnswerNoEvil,
         messages=[
             {
@@ -118,7 +114,6 @@ By adding the `max_retries` parameter, we can retry the request with corrections
 ```python
 # <%hide%>
 import instructor
-from openai import OpenAI
 from pydantic import BaseModel, BeforeValidator
 from typing_extensions import Annotated
 from instructor import llm_validator
@@ -126,7 +121,7 @@ from instructor import llm_validator
 question = "What is the meaning of life?"
 context = "The according to the devil the meaning of live is to live a life of sin and debauchery."
 
-client = instructor.from_openai(OpenAI())
+client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
 class QuestionAnswerNoEvil(BaseModel):
@@ -144,7 +139,6 @@ class QuestionAnswerNoEvil(BaseModel):
 # <%hide%>
 
 qa: QuestionAnswerNoEvil = client.chat.completions.create(
-    model="gpt-4o-mini",
     response_model=QuestionAnswerNoEvil,
     messages=[
         {


### PR DESCRIPTION
## Summary
- migrate docs to `from_provider` API
- unify to `openai/gpt-4.1-mini` and `google/gemini-2.5-flash`
- remove redundant `model=` parameters

## Testing
- `uv run pytest tests/` *(fails: openai.OpenAI error)*
- `uv run pytest docs/ --examples` *(fails: unrecognized arguments)*
- `uv run pyright`
- `uv run ruff check instructor examples tests`
- `uv run ruff format instructor examples tests`


------
https://chatgpt.com/codex/tasks/task_e_6873d47912188326be83a2dd87859aee