### PR TITLE
feat(auto_client): add comprehensive api_key parameter support for all providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ client = instructor.from_provider("google/gemini-pro")
 # Ollama (local)
 client = instructor.from_provider("ollama/llama3.2")
 
+# With API keys directly (no environment variables needed)
+client = instructor.from_provider("openai/gpt-4o", api_key="sk-...")
+client = instructor.from_provider("anthropic/claude-3-5-sonnet", api_key="sk-ant-...")
+client = instructor.from_provider("groq/llama-3.1-8b-instant", api_key="gsk_...")
+
 # All use the same API!
 user = client.chat.completions.create(
     response_model=User,

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,11 @@ client = instructor.from_provider("google/gemini-pro")  # Google
 client = instructor.from_provider("ollama/llama3")  # Ollama (local)
 client = instructor.from_provider("deepseek/deepseek-chat")  # DeepSeek
 
+# Pass API keys directly (no environment variables needed)
+client = instructor.from_provider("openai/gpt-4", api_key="sk-...")
+client = instructor.from_provider("anthropic/claude-3", api_key="sk-ant-...")
+client = instructor.from_provider("groq/llama-3.1-8b-instant", api_key="gsk_...")
+
 # Same extraction code works with all providers
 user = client.chat.completions.create(
     response_model=UserInfo,

--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -141,13 +141,26 @@ def from_provider(
         mode,
         extra=provider_info,
     )
+    api_key = None
+    if "api_key" in kwargs:
+        api_key = kwargs.pop("api_key")
+        if api_key:
+            logger.debug(
+                "API key provided for %s provider",
+                provider,
+                extra=provider_info,
+            )
 
     if provider == "openai":
         try:
             import openai
             from instructor import from_openai
 
-            client = openai.AsyncOpenAI() if async_client else openai.OpenAI()
+            client = (
+                openai.AsyncOpenAI(api_key=api_key)
+                if async_client
+                else openai.OpenAI(api_key=api_key)
+            )
             result = from_openai(
                 client,
                 model=model_name,
@@ -183,7 +196,7 @@ def from_provider(
             from instructor import from_openai
 
             # Get required Azure OpenAI configuration from environment
-            api_key = kwargs.pop("api_key", os.environ.get("AZURE_OPENAI_API_KEY"))
+            api_key = api_key or os.environ.get("AZURE_OPENAI_API_KEY")
             azure_endpoint = kwargs.pop(
                 "azure_endpoint", os.environ.get("AZURE_OPENAI_ENDPOINT")
             )
@@ -252,7 +265,9 @@ def from_provider(
             from instructor import from_anthropic
 
             client = (
-                anthropic.AsyncAnthropic() if async_client else anthropic.Anthropic()
+                anthropic.AsyncAnthropic(api_key=api_key)
+                if async_client
+                else anthropic.Anthropic(api_key=api_key)
             )
             max_tokens = kwargs.pop("max_tokens", 4096)
             result = from_anthropic(
@@ -294,7 +309,7 @@ def from_provider(
             vertexai_flag = kwargs.pop("vertexai", False)
 
             # Get API key from kwargs or environment
-            api_key = kwargs.pop("api_key", os.environ.get("GOOGLE_API_KEY"))
+            api_key = api_key or os.environ.get("GOOGLE_API_KEY")
 
             # Extract client-specific parameters
             client_kwargs = {}
@@ -345,8 +360,10 @@ def from_provider(
             from instructor import from_mistral
             import os
 
-            if os.environ.get("MISTRAL_API_KEY"):
-                client = Mistral(api_key=os.environ.get("MISTRAL_API_KEY"))
+            api_key = api_key or os.environ.get("MISTRAL_API_KEY")
+
+            if api_key:
+                client = Mistral(api_key=api_key)
             else:
                 raise ValueError(
                     "MISTRAL_API_KEY is not set. "
@@ -386,7 +403,11 @@ def from_provider(
             import cohere
             from instructor import from_cohere
 
-            client = cohere.AsyncClient() if async_client else cohere.Client()
+            client = (
+                cohere.AsyncClient(api_key=api_key)
+                if async_client
+                else cohere.Client(api_key=api_key)
+            )
             result = from_cohere(client, **kwargs)
             logger.info(
                 "Client initialized",
@@ -416,11 +437,8 @@ def from_provider(
             from instructor import from_perplexity
             import os
 
-            if os.environ.get("PERPLEXITY_API_KEY"):
-                api_key = os.environ.get("PERPLEXITY_API_KEY")
-            elif kwargs.get("api_key"):
-                api_key = kwargs.get("api_key")
-            else:
+            api_key = api_key or os.environ.get("PERPLEXITY_API_KEY")
+            if not api_key:
                 raise ValueError(
                     "PERPLEXITY_API_KEY is not set. "
                     "Set it with `export PERPLEXITY_API_KEY=<your-api-key>` or pass it as a kwarg api_key=<your-api-key>"
@@ -463,7 +481,11 @@ def from_provider(
             import groq
             from instructor import from_groq
 
-            client = groq.AsyncGroq() if async_client else groq.Groq()
+            client = (
+                groq.AsyncGroq(api_key=api_key)
+                if async_client
+                else groq.Groq(api_key=api_key)
+            )
             result = from_groq(client, model=model_name, **kwargs)
             logger.info(
                 "Client initialized",
@@ -492,7 +514,11 @@ def from_provider(
             from writerai import AsyncWriter, Writer
             from instructor import from_writer
 
-            client = AsyncWriter() if async_client else Writer()
+            client = (
+                AsyncWriter(api_key=api_key)
+                if async_client
+                else Writer(api_key=api_key)
+            )
             result = from_writer(client, model=model_name, **kwargs)
             logger.info(
                 "Client initialized",
@@ -597,7 +623,11 @@ def from_provider(
             from cerebras.cloud.sdk import AsyncCerebras, Cerebras
             from instructor import from_cerebras
 
-            client = AsyncCerebras() if async_client else Cerebras()
+            client = (
+                AsyncCerebras(api_key=api_key)
+                if async_client
+                else Cerebras(api_key=api_key)
+            )
             result = from_cerebras(client, model=model_name, **kwargs)
             logger.info(
                 "Client initialized",
@@ -626,7 +656,11 @@ def from_provider(
             from fireworks.client import AsyncFireworks, Fireworks
             from instructor import from_fireworks
 
-            client = AsyncFireworks() if async_client else Fireworks()
+            client = (
+                AsyncFireworks(api_key=api_key)
+                if async_client
+                else Fireworks(api_key=api_key)
+            )
             result = from_fireworks(client, model=model_name, **kwargs)
             logger.info(
                 "Client initialized",
@@ -721,7 +755,7 @@ def from_provider(
             import os
 
             # Get API key from kwargs or environment
-            api_key = kwargs.pop("api_key", os.environ.get("GOOGLE_API_KEY"))
+            api_key = api_key or os.environ.get("GOOGLE_API_KEY")
 
             client = genai.Client(vertexai=False, api_key=api_key)
             if async_client:
@@ -824,8 +858,8 @@ def from_provider(
             import os
 
             # Get API key from kwargs or environment
-            api_key = kwargs.pop("api_key", os.environ.get("DEEPSEEK_API_KEY"))
-            
+            api_key = api_key or os.environ.get("DEEPSEEK_API_KEY")
+
             if not api_key:
                 from instructor.exceptions import ConfigurationError
 
@@ -836,13 +870,13 @@ def from_provider(
 
             # DeepSeek uses OpenAI-compatible API
             base_url = kwargs.pop("base_url", "https://api.deepseek.com")
-            
+
             client = (
                 openai.AsyncOpenAI(api_key=api_key, base_url=base_url)
                 if async_client
                 else openai.OpenAI(api_key=api_key, base_url=base_url)
             )
-            
+
             result = from_openai(
                 client,
                 model=model_name,
@@ -877,7 +911,11 @@ def from_provider(
             from xai_sdk.aio.client import Client as AsyncClient
             from instructor import from_xai
 
-            client = AsyncClient() if async_client else SyncClient()
+            client = (
+                AsyncClient(api_key=api_key)
+                if async_client
+                else SyncClient(api_key=api_key)
+            )
             result = from_xai(
                 client,
                 mode=mode if mode else instructor.Mode.JSON,

--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -146,8 +146,9 @@ def from_provider(
         api_key = kwargs.pop("api_key")
         if api_key:
             logger.debug(
-                "API key provided for %s provider",
+                "API key provided for %s provider (length: %d characters)",
                 provider,
+                len(api_key),
                 extra=provider_info,
             )
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive `api_key` parameter support for all providers in the `from_provider` function, resolving issue #1542.

## Changes

### Core Implementation
- **Unified API key extraction**: Extract `api_key` from kwargs early in the `from_provider` function
- **Consistent parameter passing**: All providers now accept `api_key` parameter directly
- **Security-conscious logging**: Log API key length (not the actual key) for debugging purposes
- **Environment variable fallback**: Maintain existing fallback behavior to environment variables

### Updated Providers
- ✅ **openai**: Updated `OpenAI()` and `AsyncOpenAI()` to accept `api_key` parameter
- ✅ **anthropic**: Updated `Anthropic()` and `AsyncAnthropic()` to accept `api_key` parameter  
- ✅ **mistral**: Improved `api_key` handling with proper fallback to environment
- ✅ **cohere**: Updated `Client()` and `AsyncClient()` to accept `api_key` parameter
- ✅ **perplexity**: Simplified `api_key` handling logic for better consistency
- ✅ **groq**: Updated `Groq()` and `AsyncGroq()` to accept `api_key` parameter
- ✅ **writer**: Updated `Writer()` and `AsyncWriter()` to accept `api_key` parameter
- ✅ **cerebras**: Updated `Cerebras()` and `AsyncCerebras()` to accept `api_key` parameter
- ✅ **fireworks**: Updated `Fireworks()` and `AsyncFireworks()` to accept `api_key` parameter
- ✅ **xai**: Updated `SyncClient()` and `AsyncClient()` to accept `api_key` parameter
- ✅ **google**: Updated existing `api_key` handling to use new unified pattern
- ✅ **deepseek**: Updated new provider to use unified `api_key` pattern
- ✅ **generative-ai**: Updated deprecated provider to use new pattern

### Test Coverage
Added comprehensive test suite with 5 new test functions:
- `test_api_key_parameter_extraction`: Verify `api_key` is properly extracted and passed to clients
- `test_api_key_parameter_with_environment_fallback`: Test fallback to environment variables
- `test_api_key_parameter_with_async_client`: Verify `api_key` works with async clients
- `test_api_key_parameter_not_passed_when_none`: Test handling when `api_key` is `None`
- `test_api_key_logging`: Verify secure logging of API key length

## Usage Examples

```python
import instructor

# Direct API key parameter
client = instructor.from_provider("openai/gpt-4", api_key="sk-...")
client = instructor.from_provider("anthropic/claude-3-sonnet", api_key="sk-ant-...")
client = instructor.from_provider("groq/llama-3.1-8b-instant", api_key="gsk_...")

# Async clients
async_client = instructor.from_provider("openai/gpt-4", async_client=True, api_key="sk-...")

# Still works with environment variables as fallback
client = instructor.from_provider("openai/gpt-4")  # Uses OPENAI_API_KEY env var
```

## Security

- **No sensitive data logging**: API keys are never logged, only their length
- **Secure parameter extraction**: API keys are properly extracted from kwargs early
- **Environment variable fallback**: Maintains existing security patterns

## Test Results

All new tests pass:
```
tests/test_auto_client.py::test_api_key_parameter_extraction PASSED
tests/test_auto_client.py::test_api_key_parameter_with_environment_fallback PASSED  
tests/test_auto_client.py::test_api_key_parameter_with_async_client PASSED
tests/test_auto_client.py::test_api_key_parameter_not_passed_when_none PASSED
tests/test_auto_client.py::test_api_key_logging PASSED
```

## Breaking Changes

None. All existing functionality continues to work unchanged.

## Fixes

Closes #1542

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds comprehensive `api_key` parameter support for all providers in `from_provider`, with unified extraction, logging, and environment fallback.
> 
>   - **Behavior**:
>     - Unified `api_key` extraction from `kwargs` in `from_provider()`.
>     - All providers now accept `api_key` directly.
>     - Logs API key length for debugging, not the key itself.
>     - Maintains fallback to environment variables for `api_key`.
>   - **Providers Updated**:
>     - `openai`, `anthropic`, `mistral`, `cohere`, `perplexity`, `groq`, `writer`, `cerebras`, `fireworks`, `xai`, `google`, `deepseek`, `generative-ai` updated to accept `api_key`.
>   - **Tests**:
>     - Added tests in `test_auto_client.py` for `api_key` extraction, environment fallback, async client support, handling `None`, and logging.
>   - **Security**:
>     - Ensures no sensitive data logging, only logs API key length.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 0e5e9da476f9dac42341238be15461aadac1d460. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->