### PR TITLE
refactor: move provider-specific message conversion to handlers

### DIFF
--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -260,63 +260,6 @@ def handle_response_model(
     # print(f"instructor.process_response.py: new_kwargs -> {new_kwargs}")
     autodetect_images = new_kwargs.pop("autodetect_images", False)
 
-    if response_model is None:
-        if mode in {Mode.COHERE_JSON_SCHEMA, Mode.COHERE_TOOLS}:
-            # This is cause cohere uses 'message' and 'chat_history' instead of 'messages'
-            return handle_cohere_modes(new_kwargs)
-        # Handle images without a response model
-        if "messages" in new_kwargs:
-            messages = convert_messages(
-                new_kwargs["messages"],
-                mode,
-                autodetect_images=autodetect_images,
-            )
-            if mode in {Mode.ANTHROPIC_JSON, Mode.ANTHROPIC_TOOLS}:
-                # Handle OpenAI style or Anthropic style messages
-                new_kwargs["messages"] = [m for m in messages if m["role"] != "system"]
-                if "system" not in new_kwargs:
-                    system_message = extract_system_messages(messages)
-                    if system_message:
-                        new_kwargs["system"] = system_message
-
-            elif mode in {Mode.GENAI_TOOLS, Mode.GENAI_STRUCTURED_OUTPUTS}:
-                # Handle GenAI mode - convert messages to contents and extract system message
-                from instructor.utils.google import (
-                    convert_to_genai_messages,
-                    extract_genai_system_message,
-                )
-
-                # Convert OpenAI-style messages to GenAI-style contents
-                new_kwargs["contents"] = convert_to_genai_messages(messages)
-
-                # Extract multimodal content for GenAI
-                new_kwargs["contents"] = extract_genai_multimodal_content(
-                    new_kwargs["contents"], autodetect_images
-                )
-
-                # Handle system message for GenAI
-                if "system" not in new_kwargs:
-                    system_message = extract_genai_system_message(messages)
-                    if system_message:
-                        from google.genai import types
-
-                        new_kwargs["config"] = types.GenerateContentConfig(
-                            system_instruction=system_message
-                        )
-
-                # Remove messages since we converted to contents
-                new_kwargs.pop("messages", None)
-
-            else:
-                if mode in {
-                    Mode.RESPONSES_TOOLS,
-                    Mode.RESPONSES_TOOLS_WITH_INBUILT_TOOLS,
-                } and new_kwargs.get("max_tokens"):
-                    new_kwargs["max_output_tokens"] = new_kwargs.pop("max_tokens")
-
-                new_kwargs["messages"] = messages
-        return None, new_kwargs
-
     if mode in {Mode.PARALLEL_TOOLS}:
         return handle_parallel_tools(response_model, new_kwargs)
     elif mode in {Mode.VERTEXAI_PARALLEL_TOOLS}:
@@ -324,7 +267,9 @@ def handle_response_model(
     elif mode in {Mode.ANTHROPIC_PARALLEL_TOOLS}:
         return handle_anthropic_parallel_tools(response_model, new_kwargs)
 
-    response_model = prepare_response_model(response_model)
+    # Only prepare response_model if it's not None
+    if response_model is not None:
+        response_model = prepare_response_model(response_model)
 
     mode_handlers = {  # type: ignore
         Mode.FUNCTIONS: handle_functions,
@@ -366,7 +311,15 @@ def handle_response_model(
     else:
         raise ValueError(f"Invalid patch mode: {mode}")
 
+    # Handle message conversion for modes that don't already handle it
     if "messages" in new_kwargs:
+        # Handle special case for RESPONSES_TOOLS modes
+        if response_model is None and mode in {
+            Mode.RESPONSES_TOOLS,
+            Mode.RESPONSES_TOOLS_WITH_INBUILT_TOOLS,
+        } and new_kwargs.get("max_tokens"):
+            new_kwargs["max_output_tokens"] = new_kwargs.pop("max_tokens")
+        
         new_kwargs["messages"] = convert_messages(
             new_kwargs["messages"],
             mode,

--- a/instructor/utils/anthropic.py
+++ b/instructor/utils/anthropic.py
@@ -209,9 +209,29 @@ def reask_anthropic_json(
     return kwargs
 
 
+def handle_anthropic_message_conversion(new_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Handle message conversion for Anthropic modes when response_model is None."""
+    messages = new_kwargs.get("messages", [])
+    
+    # Handle Anthropic style messages
+    new_kwargs["messages"] = [m for m in messages if m["role"] != "system"]
+    
+    if "system" not in new_kwargs:
+        system_messages = extract_system_messages(messages)
+        if system_messages:
+            new_kwargs["system"] = system_messages
+    
+    return new_kwargs
+
+
 def handle_anthropic_tools(
-    response_model: type[Any], new_kwargs: dict[str, Any]
-) -> tuple[type[Any], dict[str, Any]]:
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
+    if response_model is None:
+        # Just handle message conversion
+        new_kwargs = handle_anthropic_message_conversion(new_kwargs)
+        return None, new_kwargs
+    
     tool_descriptions = generate_anthropic_schema(response_model)
     new_kwargs["tools"] = [tool_descriptions]
     new_kwargs["tool_choice"] = {
@@ -234,11 +254,15 @@ def handle_anthropic_tools(
 
 
 def handle_anthropic_reasoning_tools(
-    response_model: type[Any], new_kwargs: dict[str, Any]
-) -> tuple[type[Any], dict[str, Any]]:
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
     # https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview#forcing-tool-use
 
     response_model, new_kwargs = handle_anthropic_tools(response_model, new_kwargs)
+
+    if response_model is None:
+        # Just handle message conversion - already done by handle_anthropic_tools
+        return None, new_kwargs
 
     # https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview#forcing-tool-use
     # Reasoning does not allow forced tool use
@@ -258,8 +282,8 @@ def handle_anthropic_reasoning_tools(
 
 
 def handle_anthropic_json(
-    response_model: type[Any], new_kwargs: dict[str, Any]
-) -> tuple[type[Any], dict[str, Any]]:
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
     import json
 
     system_messages = extract_system_messages(new_kwargs.get("messages", []))
@@ -272,6 +296,10 @@ def handle_anthropic_json(
     new_kwargs["messages"] = [
         m for m in new_kwargs.get("messages", []) if m["role"] != "system"
     ]
+
+    if response_model is None:
+        # Just handle message conversion - already done above
+        return None, new_kwargs
 
     json_schema_message = dedent(
         f"""

--- a/instructor/utils/cohere.py
+++ b/instructor/utils/cohere.py
@@ -54,8 +54,23 @@ def handle_cohere_modes(new_kwargs: dict[str, Any]) -> tuple[None, dict[str, Any
 
 
 def handle_cohere_json_schema(
-    response_model: type[Any], new_kwargs: dict[str, Any]
-) -> tuple[type[Any], dict[str, Any]]:
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
+    """
+    Handle Cohere JSON schema mode.
+    
+    When response_model is None:
+        - Converts messages from OpenAI format to Cohere format (message + chat_history)
+        - No schema is added to the request
+        
+    When response_model is provided:
+        - Converts messages from OpenAI format to Cohere format
+        - Adds the model's JSON schema to response_format
+    """
+    if response_model is None:
+        # Just handle message conversion
+        return handle_cohere_modes(new_kwargs)
+    
     new_kwargs["response_format"] = {
         "type": "json_object",
         "schema": response_model.model_json_schema(),
@@ -66,8 +81,12 @@ def handle_cohere_json_schema(
 
 
 def handle_cohere_tools(
-    response_model: type[Any], new_kwargs: dict[str, Any]
-) -> tuple[type[Any], dict[str, Any]]:
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
+    if response_model is None:
+        # Just handle message conversion
+        return handle_cohere_modes(new_kwargs)
+    
     _, new_kwargs = handle_cohere_modes(new_kwargs)
 
     instruction = f"""\

--- a/instructor/utils/google.py
+++ b/instructor/utils/google.py
@@ -601,13 +601,41 @@ def reask_genai_structured_outputs(
 
 
 # Response handlers
+def handle_genai_message_conversion(new_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Handle message conversion for GenAI modes when response_model is None."""
+    from google.genai import types
+    
+    messages = new_kwargs.get("messages", [])
+    
+    # Convert OpenAI-style messages to GenAI-style contents
+    new_kwargs["contents"] = convert_to_genai_messages(messages)
+    
+    # Handle system message for GenAI
+    if "system" not in new_kwargs:
+        system_message = extract_genai_system_message(messages)
+        if system_message:
+            new_kwargs["config"] = types.GenerateContentConfig(
+                system_instruction=system_message
+            )
+    
+    # Remove messages since we converted to contents
+    new_kwargs.pop("messages", None)
+    
+    return new_kwargs
+
+
 def handle_gemini_json(
-    response_model: type[Any], new_kwargs: dict[str, Any]
-) -> tuple[type[Any], dict[str, Any]]:
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
     if "model" in new_kwargs:
         raise ConfigurationError(
             "Gemini `model` must be set while patching the client, not passed as a parameter to the create method"
         )
+
+    if response_model is None:
+        # Just handle message conversion
+        new_kwargs = update_gemini_kwargs(new_kwargs)
+        return None, new_kwargs
 
     message = dedent(
         f"""
@@ -634,12 +662,17 @@ def handle_gemini_json(
 
 
 def handle_gemini_tools(
-    response_model: type[Any], new_kwargs: dict[str, Any]
-) -> tuple[type[Any], dict[str, Any]]:
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
     if "model" in new_kwargs:
         raise ConfigurationError(
             "Gemini `model` must be set while patching the client, not passed as a parameter to the create method"
         )
+
+    if response_model is None:
+        # Just handle message conversion
+        new_kwargs = update_gemini_kwargs(new_kwargs)
+        return None, new_kwargs
 
     new_kwargs["tools"] = [response_model.gemini_schema]
     new_kwargs["tool_config"] = {
@@ -654,9 +687,14 @@ def handle_gemini_tools(
 
 
 def handle_genai_structured_outputs(
-    response_model: type[Any], new_kwargs: dict[str, Any]
-) -> tuple[type[Any], dict[str, Any]]:
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
     from google.genai import types
+
+    if response_model is None:
+        # Just handle message conversion
+        new_kwargs = handle_genai_message_conversion(new_kwargs)
+        return None, new_kwargs
 
     # Automatically wrap regular models with Partial when streaming is enabled
     if new_kwargs.get("stream", False) and not issubclass(response_model, PartialBase):
@@ -692,9 +730,14 @@ def handle_genai_structured_outputs(
 
 
 def handle_genai_tools(
-    response_model: type[Any], new_kwargs: dict[str, Any]
-) -> tuple[type[Any], dict[str, Any]]:
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
     from google.genai import types
+
+    if response_model is None:
+        # Just handle message conversion
+        new_kwargs = handle_genai_message_conversion(new_kwargs)
+        return None, new_kwargs
 
     # Automatically wrap regular models with Partial when streaming is enabled
     if new_kwargs.get("stream", False) and not issubclass(response_model, PartialBase):
@@ -762,9 +805,13 @@ def handle_vertexai_parallel_tools(
 
 
 def handle_vertexai_tools(
-    response_model: type[Any], new_kwargs: dict[str, Any]
-) -> tuple[type[Any], dict[str, Any]]:
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
     from instructor.client_vertexai import vertexai_process_response
+
+    if response_model is None:
+        # Just handle message conversion - keep the messages as they are
+        return None, new_kwargs
 
     contents, tools, tool_config = vertexai_process_response(new_kwargs, response_model)
 
@@ -775,9 +822,13 @@ def handle_vertexai_tools(
 
 
 def handle_vertexai_json(
-    response_model: type[Any], new_kwargs: dict[str, Any]
-) -> tuple[type[Any], dict[str, Any]]:
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
     from instructor.client_vertexai import vertexai_process_json_response
+
+    if response_model is None:
+        # Just handle message conversion - keep the messages as they are
+        return None, new_kwargs
 
     contents, generation_config = vertexai_process_json_response(
         new_kwargs, response_model


### PR DESCRIPTION
## Summary
- Refactored provider-specific message conversion logic out of the main `handle_response_model` function
- Modified handlers for Cohere, Google/GenAI, and Anthropic to accept `None` response_model
- Created a cleaner, more maintainable architecture where all mode-specific logic is centralized in handlers

## Changes Made

### Cohere
- Modified `handle_cohere_json_schema` and `handle_cohere_tools` to accept `None` response_model
- When response_model is None, these handlers now just call `handle_cohere_modes` for message conversion

### Google/GenAI
- Added `handle_genai_message_conversion` helper function for GenAI message conversion
- Modified all Google handlers (`handle_gemini_json`, `handle_gemini_tools`, `handle_genai_tools`, `handle_genai_structured_outputs`, `handle_vertexai_tools`, `handle_vertexai_json`) to accept `None` response_model
- When response_model is None, handlers return early with converted messages

### Anthropic
- Added `handle_anthropic_message_conversion` helper function
- Modified all Anthropic handlers (`handle_anthropic_tools`, `handle_anthropic_reasoning_tools`, `handle_anthropic_json`) to accept `None` response_model
- System message extraction logic is preserved

### Core Changes
- Removed the large if-else block in `handle_response_model` that handled provider-specific message conversion
- Now all modes go through the unified handler registry
- Special case for `RESPONSES_TOOLS` modes is preserved for max_tokens → max_output_tokens conversion

## Test plan
- [ ] Run tests for Cohere modes
- [ ] Run tests for Google/GenAI modes  
- [ ] Run tests for Anthropic modes
- [ ] Verify no regression in message conversion behavior

🤖 Generated with [Claude Code](https://claude.ai/code)