### PR TITLE
Update contributing docs for provider utilities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ Key Poetry commands:
 
 ### Working with Optional Dependencies
 
-Instructor uses optional dependencies to support different LLM providers. When adding integration for a new provider:
+Instructor uses optional dependencies to support different LLM providers. Provider-specific utilities live under `instructor/utils`. When adding integration for a new provider:
 
 1. **Update pyproject.toml**: Add your provider's dependencies to both `[project.optional-dependencies]` and `[dependency-groups]`:
 
@@ -177,6 +177,22 @@ Instructor uses optional dependencies to support different LLM providers. When a
    # or
    poetry install --with my-provider
    ```
+
+5. **Create Provider Utilities and Handlers**:
+   - Add a new module at `instructor/utils/myprovider.py`
+   - Implement `reask` functions for validation errors and `handle_*` functions
+     for formatting requests
+   - Define `MYPROVIDER_HANDLERS` mapping `Mode` values to these functions
+
+6. **Register the Provider**:
+   - Add a value in `instructor/utils/providers.py` to the `Provider` enum
+   - Extend `get_provider` with detection logic for your base URL
+
+7. **Update `process_response.py`**:
+   - Import your handler functions and include them in the `mode_handlers`
+     dictionary so the library can route requests to your provider
+   - `process_response.py` relies on these handlers to format arguments and
+     parse results for each `Mode`
 
 ## How to Contribute
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -120,7 +120,7 @@ Poetry provides comprehensive dependency management and packaging.
 
 ## Adding Support for New LLM Providers
 
-Instructor uses optional dependencies to support different LLM providers. To add a new provider:
+Instructor uses optional dependencies to support different LLM providers. Provider-specific utilities live in the `instructor/utils` directory. To add a new provider:
 
 1. **Add Dependencies to pyproject.toml**:
    ```toml
@@ -147,7 +147,19 @@ Instructor uses optional dependencies to support different LLM providers. To add
    poetry install --with my-provider
    ```
 
-5. **Write Documentation**:
+5. **Create Provider Utilities and Handlers**:
+   - Add `instructor/utils/myprovider.py` with `reask` and `handle_*` helpers
+   - Define `MYPROVIDER_HANDLERS` mapping `Mode` values to these functions
+
+6. **Register the Provider**:
+   - Update `instructor/utils/providers.py` with your provider enum value
+   - Extend `get_provider` detection for your base URL
+
+7. **Update `process_response.py`**:
+   - Import your handlers and add them to `mode_handlers`
+   - This script uses the handlers to prepare kwargs and parse results
+
+8. **Write Documentation**:
    - Add a new markdown file in `docs/integrations/` for your provider
    - Update `mkdocs.yml` to include your new page
    - Make sure to include a complete example


### PR DESCRIPTION
## Summary
- document provider utils directory and handler registries
- explain how process_response uses these handlers

## Testing
- `uv run ruff format instructor examples tests`
- `uv run ruff check instructor examples tests`
- `uv run pyright`
- `uv run pytest tests/ -k 'not llm and not openai'` *(fails: ValueError: Project ID is required for Vertex AI)*

------
https://chatgpt.com/codex/tasks/task_e_687abb49286c8326965a98a496b906d0
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update contributing docs to include provider utilities, handler registries, and their integration with `process_response.py`.
> 
>   - **Documentation**:
>     - Update `CONTRIBUTING.md` and `docs/contributing.md` to document provider utilities and handler registries.
>     - Explain how `process_response.py` uses these handlers.
>   - **Testing**:
>     - Commands for code formatting and checks: `uv run ruff format`, `uv run ruff check`, `uv run pyright`, `uv run pytest tests/ -k 'not llm and not openai'`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 8eda18bef4f013dc27d4d6e35e4ca05fa5c17520. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->