### PR TITLE
Implement provider adapter pattern

### DIFF
--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -17,6 +17,11 @@ from .schema_utils import (
     generate_gemini_schema,
 )
 from .patch import apatch, patch
+from .provider_adapter import (
+    ProviderAdapter,
+    OPENAI_ADAPTER,
+    ADAPTER_REGISTRY,
+)
 from .client import (
     Instructor,
     AsyncInstructor,
@@ -47,6 +52,9 @@ __all__ = [
     "generate_anthropic_schema",
     "generate_gemini_schema",
     "Mode",
+    "ProviderAdapter",
+    "OPENAI_ADAPTER",
+    "ADAPTER_REGISTRY",
     "patch",
     "apatch",
     "FinetuneFormat",

--- a/instructor/client.py
+++ b/instructor/client.py
@@ -781,6 +781,7 @@ def from_openai(
                 }
                 else partial(map_chat_completion_to_response, client=client),
                 mode=mode,
+                adapter=instructor.OPENAI_ADAPTER,
             ),
             mode=mode,
             provider=provider,
@@ -799,6 +800,7 @@ def from_openai(
                 }
                 else partial(async_map_chat_completion_to_response, client=client),
                 mode=mode,
+                adapter=instructor.OPENAI_ADAPTER,
             ),
             mode=mode,
             provider=provider,

--- a/instructor/client_anthropic.py
+++ b/instructor/client_anthropic.py
@@ -102,7 +102,11 @@ def from_anthropic(
     ):
         return instructor.Instructor(
             client=client,
-            create=instructor.patch(create=create, mode=mode),
+            create=instructor.patch(
+                create=create,
+                mode=mode,
+                adapter=instructor.ANTHROPIC_ADAPTER,
+            ),
             provider=instructor.Provider.ANTHROPIC,
             mode=mode,
             **kwargs,
@@ -111,7 +115,11 @@ def from_anthropic(
     else:
         return instructor.AsyncInstructor(
             client=client,
-            create=instructor.patch(create=create, mode=mode),
+            create=instructor.patch(
+                create=create,
+                mode=mode,
+                adapter=instructor.ANTHROPIC_ADAPTER,
+            ),
             provider=instructor.Provider.ANTHROPIC,
             mode=mode,
             **kwargs,

--- a/instructor/client_bedrock.py
+++ b/instructor/client_bedrock.py
@@ -90,7 +90,11 @@ def from_bedrock(
     if use_async:
         return AsyncInstructor(
             client=client,
-            create=instructor.patch(create=async_wrapper, mode=mode),
+            create=instructor.patch(
+                create=async_wrapper,
+                mode=mode,
+                adapter=instructor.BEDROCK_ADAPTER,
+            ),
             provider=instructor.Provider.BEDROCK,
             mode=mode,
             **kwargs,
@@ -98,7 +102,11 @@ def from_bedrock(
     else:
         return Instructor(
             client=client,
-            create=instructor.patch(create=create, mode=mode),
+            create=instructor.patch(
+                create=create,
+                mode=mode,
+                adapter=instructor.BEDROCK_ADAPTER,
+            ),
             provider=instructor.Provider.BEDROCK,
             mode=mode,
             **kwargs,

--- a/instructor/client_cerebras.py
+++ b/instructor/client_cerebras.py
@@ -56,7 +56,11 @@ def from_cerebras(
         create = client.chat.completions.create
         return AsyncInstructor(
             client=client,
-            create=instructor.patch(create=create, mode=mode),
+            create=instructor.patch(
+                create=create,
+                mode=mode,
+                adapter=instructor.CEREBRAS_ADAPTER,
+            ),
             provider=instructor.Provider.CEREBRAS,
             mode=mode,
             **kwargs,
@@ -65,7 +69,11 @@ def from_cerebras(
     create = client.chat.completions.create
     return Instructor(
         client=client,
-        create=instructor.patch(create=create, mode=mode),
+        create=instructor.patch(
+            create=create,
+            mode=mode,
+            adapter=instructor.CEREBRAS_ADAPTER,
+        ),
         provider=instructor.Provider.CEREBRAS,
         mode=mode,
         **kwargs,

--- a/instructor/client_cohere.py
+++ b/instructor/client_cohere.py
@@ -59,7 +59,11 @@ def from_cohere(
     if isinstance(client, cohere.Client):
         return instructor.Instructor(
             client=client,
-            create=instructor.patch(create=client.chat, mode=mode),
+            create=instructor.patch(
+                create=client.chat,
+                mode=mode,
+                adapter=instructor.COHERE_ADAPTER,
+            ),
             provider=instructor.Provider.COHERE,
             mode=mode,
             **kwargs,
@@ -68,7 +72,11 @@ def from_cohere(
     if isinstance(client, cohere.AsyncClient):
         return instructor.AsyncInstructor(
             client=client,
-            create=instructor.patch(create=client.chat, mode=mode),
+            create=instructor.patch(
+                create=client.chat,
+                mode=mode,
+                adapter=instructor.COHERE_ADAPTER,
+            ),
             provider=instructor.Provider.COHERE,
             mode=mode,
             **kwargs,

--- a/instructor/client_fireworks.py
+++ b/instructor/client_fireworks.py
@@ -61,7 +61,11 @@ def from_fireworks(
 
         return AsyncInstructor(
             client=client,
-            create=instructor.patch(create=async_wrapper, mode=mode),
+            create=instructor.patch(
+                create=async_wrapper,
+                mode=mode,
+                adapter=instructor.FIREWORKS_ADAPTER,
+            ),
             provider=instructor.Provider.FIREWORKS,
             mode=mode,
             **kwargs,
@@ -70,7 +74,11 @@ def from_fireworks(
     if isinstance(client, Fireworks):
         return Instructor(
             client=client,
-            create=instructor.patch(create=client.chat.completions.create, mode=mode),  # type: ignore
+            create=instructor.patch(
+                create=client.chat.completions.create,  # type: ignore
+                mode=mode,
+                adapter=instructor.FIREWORKS_ADAPTER,
+            ),
             provider=instructor.Provider.FIREWORKS,
             mode=mode,
             **kwargs,

--- a/instructor/client_gemini.py
+++ b/instructor/client_gemini.py
@@ -77,7 +77,11 @@ def from_gemini(
         create = client.generate_content_async
         return instructor.AsyncInstructor(
             client=client,
-            create=instructor.patch(create=create, mode=mode),
+            create=instructor.patch(
+                create=create,
+                mode=mode,
+                adapter=instructor.GOOGLE_ADAPTER,
+            ),
             provider=instructor.Provider.GEMINI,
             mode=mode,
             **kwargs,
@@ -86,7 +90,11 @@ def from_gemini(
     create = client.generate_content
     return instructor.Instructor(
         client=client,
-        create=instructor.patch(create=create, mode=mode),
+        create=instructor.patch(
+            create=create,
+            mode=mode,
+            adapter=instructor.GOOGLE_ADAPTER,
+        ),
         provider=instructor.Provider.GEMINI,
         mode=mode,
         **kwargs,

--- a/instructor/client_genai.py
+++ b/instructor/client_genai.py
@@ -61,7 +61,11 @@ def from_genai(
 
         return instructor.AsyncInstructor(
             client=client,
-            create=instructor.patch(create=async_wrapper, mode=mode),
+            create=instructor.patch(
+                create=async_wrapper,
+                mode=mode,
+                adapter=instructor.GOOGLE_ADAPTER,
+            ),
             provider=instructor.Provider.GENAI,
             mode=mode,
             **kwargs,
@@ -75,7 +79,11 @@ def from_genai(
 
     return instructor.Instructor(
         client=client,
-        create=instructor.patch(create=sync_wrapper, mode=mode),
+        create=instructor.patch(
+            create=sync_wrapper,
+            mode=mode,
+            adapter=instructor.GOOGLE_ADAPTER,
+        ),
         provider=instructor.Provider.GENAI,
         mode=mode,
         **kwargs,

--- a/instructor/client_groq.py
+++ b/instructor/client_groq.py
@@ -50,7 +50,11 @@ def from_groq(
     if isinstance(client, groq.Groq):
         return instructor.Instructor(
             client=client,
-            create=instructor.patch(create=client.chat.completions.create, mode=mode),
+            create=instructor.patch(
+                create=client.chat.completions.create,
+                mode=mode,
+                adapter=instructor.OPENAI_ADAPTER,
+            ),
             provider=instructor.Provider.GROQ,
             mode=mode,
             **kwargs,
@@ -59,7 +63,11 @@ def from_groq(
     else:
         return instructor.AsyncInstructor(
             client=client,
-            create=instructor.patch(create=client.chat.completions.create, mode=mode),
+            create=instructor.patch(
+                create=client.chat.completions.create,
+                mode=mode,
+                adapter=instructor.OPENAI_ADAPTER,
+            ),
             provider=instructor.Provider.GROQ,
             mode=mode,
             **kwargs,

--- a/instructor/client_mistral.py
+++ b/instructor/client_mistral.py
@@ -64,7 +64,11 @@ def from_mistral(
 
         return instructor.AsyncInstructor(
             client=client,
-            create=instructor.patch(create=async_wrapper, mode=mode),
+            create=instructor.patch(
+                create=async_wrapper,
+                mode=mode,
+                adapter=instructor.MISTRAL_ADAPTER,
+            ),
             provider=instructor.Provider.MISTRAL,
             mode=mode,
             **kwargs,
@@ -79,7 +83,11 @@ def from_mistral(
 
     return instructor.Instructor(
         client=client,
-        create=instructor.patch(create=sync_wrapper, mode=mode),
+        create=instructor.patch(
+            create=sync_wrapper,
+            mode=mode,
+            adapter=instructor.MISTRAL_ADAPTER,
+        ),
         provider=instructor.Provider.MISTRAL,
         mode=mode,
         **kwargs,

--- a/instructor/client_perplexity.py
+++ b/instructor/client_perplexity.py
@@ -59,7 +59,11 @@ def from_perplexity(
         create = client.chat.completions.create
         return instructor.AsyncInstructor(
             client=client,
-            create=instructor.patch(create=create, mode=mode),
+            create=instructor.patch(
+                create=create,
+                mode=mode,
+                adapter=instructor.PERPLEXITY_ADAPTER,
+            ),
             provider=instructor.Provider.PERPLEXITY,
             mode=mode,
             **kwargs,
@@ -68,7 +72,11 @@ def from_perplexity(
     create = client.chat.completions.create
     return instructor.Instructor(
         client=client,
-        create=instructor.patch(create=create, mode=mode),
+        create=instructor.patch(
+            create=create,
+            mode=mode,
+            adapter=instructor.PERPLEXITY_ADAPTER,
+        ),
         provider=instructor.Provider.PERPLEXITY,
         mode=mode,
         **kwargs,

--- a/instructor/client_vertexai.py
+++ b/instructor/client_vertexai.py
@@ -209,7 +209,11 @@ def from_vertexai(
 
     return instructor.Instructor(
         client=client,
-        create=instructor.patch(create=create, mode=mode),
+        create=instructor.patch(
+            create=create,
+            mode=mode,
+            adapter=instructor.GOOGLE_ADAPTER,
+        ),
         provider=instructor.Provider.VERTEXAI,
         mode=mode,
         **kwargs,

--- a/instructor/client_writer.py
+++ b/instructor/client_writer.py
@@ -48,7 +48,11 @@ def from_writer(
     if isinstance(client, Writer):
         return instructor.Instructor(
             client=client,
-            create=instructor.patch(create=client.chat.chat, mode=mode),
+            create=instructor.patch(
+                create=client.chat.chat,
+                mode=mode,
+                adapter=instructor.WRITER_ADAPTER,
+            ),
             provider=instructor.Provider.WRITER,
             mode=mode,
             **kwargs,
@@ -56,7 +60,11 @@ def from_writer(
 
     return instructor.AsyncInstructor(
         client=client,
-        create=instructor.patch(create=client.chat.chat, mode=mode),
+        create=instructor.patch(
+            create=client.chat.chat,
+            mode=mode,
+            adapter=instructor.WRITER_ADAPTER,
+        ),
         provider=instructor.Provider.WRITER,
         mode=mode,
         **kwargs,

--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -13,8 +13,8 @@ from typing_extensions import ParamSpec
 from openai import AsyncOpenAI, OpenAI  # type: ignore[import-not-found]
 from pydantic import BaseModel  # type: ignore[import-not-found]
 
-from instructor.process_response import handle_response_model
 from instructor.retry import retry_async, retry_sync
+from instructor.provider_adapter import ProviderAdapter, OPENAI_ADAPTER
 from instructor.utils import is_async
 from instructor.hooks import Hooks
 from instructor.templating import handle_templating
@@ -90,6 +90,7 @@ def handle_context(
 def patch(
     client: OpenAI,
     mode: Mode = Mode.TOOLS,
+    adapter: ProviderAdapter = OPENAI_ADAPTER,
 ) -> OpenAI: ...
 
 
@@ -97,6 +98,7 @@ def patch(
 def patch(
     client: AsyncOpenAI,
     mode: Mode = Mode.TOOLS,
+    adapter: ProviderAdapter = OPENAI_ADAPTER,
 ) -> AsyncOpenAI: ...
 
 
@@ -104,6 +106,7 @@ def patch(
 def patch(
     create: Callable[T_ParamSpec, T_Retval],
     mode: Mode = Mode.TOOLS,
+    adapter: ProviderAdapter = OPENAI_ADAPTER,
 ) -> InstructorChatCompletionCreate: ...
 
 
@@ -111,6 +114,7 @@ def patch(
 def patch(
     create: Awaitable[T_Retval],
     mode: Mode = Mode.TOOLS,
+    adapter: ProviderAdapter = OPENAI_ADAPTER,
 ) -> InstructorChatCompletionCreate: ...
 
 
@@ -118,6 +122,7 @@ def patch(  # type: ignore
     client: OpenAI | AsyncOpenAI | None = None,
     create: Callable[T_ParamSpec, T_Retval] | None = None,
     mode: Mode = Mode.TOOLS,
+    adapter: ProviderAdapter = OPENAI_ADAPTER,
 ) -> OpenAI | AsyncOpenAI:
     """
     Patch the `client.chat.completions.create` method
@@ -166,9 +171,9 @@ def patch(  # type: ignore
 
         context = handle_context(context, validation_context)
 
-        response_model, new_kwargs = handle_response_model(
-            response_model=response_model, mode=mode, **kwargs
-        )  # type: ignore
+        response_model, new_kwargs = adapter.prepare_request(
+            response_model=response_model, kwargs=kwargs, mode=mode
+        )
         new_kwargs = handle_templating(new_kwargs, mode=mode, context=context)
 
         # Attempt cache lookup **before** hitting retry layer
@@ -195,6 +200,7 @@ def patch(  # type: ignore
             strict=strict,
             mode=mode,
             hooks=hooks,
+            adapter=adapter,
         )
 
         # Store in cache *after* successful call
@@ -235,9 +241,9 @@ def patch(  # type: ignore
 
         context = handle_context(context, validation_context)
         # print(f"instructor.patch: patched_function {func.__name__}")
-        response_model, new_kwargs = handle_response_model(
-            response_model=response_model, mode=mode, **kwargs
-        )  # type: ignore
+        response_model, new_kwargs = adapter.prepare_request(
+            response_model=response_model, kwargs=kwargs, mode=mode
+        )
 
         new_kwargs = handle_templating(new_kwargs, mode=mode, context=context)
 
@@ -265,6 +271,7 @@ def patch(  # type: ignore
             strict=strict,
             kwargs=new_kwargs,
             mode=mode,
+            adapter=adapter,
         )
 
         # Save to cache

--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -304,7 +304,9 @@ def handle_response_model(
         Mode.GEMINI_JSON: handle_gemini_json,
         Mode.GEMINI_TOOLS: handle_gemini_tools,
         Mode.GENAI_TOOLS: lambda rm, nk: handle_genai_tools(rm, nk, autodetect_images),
-        Mode.GENAI_STRUCTURED_OUTPUTS: lambda rm, nk: handle_genai_structured_outputs(rm, nk, autodetect_images),
+        Mode.GENAI_STRUCTURED_OUTPUTS: lambda rm, nk: handle_genai_structured_outputs(
+            rm, nk, autodetect_images
+        ),
         Mode.VERTEXAI_TOOLS: handle_vertexai_tools,
         Mode.VERTEXAI_JSON: handle_vertexai_json,
         Mode.CEREBRAS_JSON: handle_cerebras_json,

--- a/instructor/provider_adapter.py
+++ b/instructor/provider_adapter.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol
+
+from pydantic import BaseModel
+
+from .mode import Mode
+from .process_response import process_response, process_response_async
+
+
+class ProviderAdapter(Protocol):
+    """Interface for provider-specific adapters."""
+
+    def prepare_request(
+        self,
+        response_model: type[BaseModel] | None,
+        kwargs: dict[str, Any],
+        mode: Mode,
+    ) -> tuple[type[BaseModel] | None, dict[str, Any]]: ...
+
+    def reask(
+        self,
+        kwargs: dict[str, Any],
+        response: Any,
+        exception: Exception,
+        mode: Mode,
+    ) -> dict[str, Any]: ...
+
+    def parse_response(
+        self,
+        response: Any,
+        response_model: type[BaseModel] | None,
+        context: dict[str, Any] | None,
+        strict: bool | None,
+        mode: Mode,
+        *,
+        stream: bool,
+    ) -> BaseModel | Any: ...
+
+    async def parse_response_async(
+        self,
+        response: Any,
+        response_model: type[BaseModel] | None,
+        context: dict[str, Any] | None,
+        strict: bool | None,
+        mode: Mode,
+        *,
+        stream: bool,
+    ) -> BaseModel | Any: ...
+
+
+class RegistryProviderAdapter:
+    """Adapter implementation backed by a handler registry."""
+
+    def __init__(self, handlers: dict[Mode, dict[str, Callable]]):
+        self.handlers = handlers
+
+    def _get(self, mode: Mode, key: str) -> Callable:
+        try:
+            return self.handlers[mode][key]
+        except KeyError as e:
+            raise ValueError(f"Unsupported mode {mode}") from e
+
+    def prepare_request(
+        self,
+        response_model: type[BaseModel] | None,
+        kwargs: dict[str, Any],
+        mode: Mode,
+    ) -> tuple[type[BaseModel] | None, dict[str, Any]]:
+        handler = self._get(mode, "response")
+        return handler(response_model, kwargs)
+
+    def reask(
+        self,
+        kwargs: dict[str, Any],
+        response: Any,
+        exception: Exception,
+        mode: Mode,
+    ) -> dict[str, Any]:
+        handler = self._get(mode, "reask")
+        return handler(kwargs, response, exception)
+
+    def parse_response(
+        self,
+        response: Any,
+        response_model: type[BaseModel] | None,
+        context: dict[str, Any] | None,
+        strict: bool | None,
+        mode: Mode,
+        *,
+        stream: bool,
+    ) -> BaseModel | Any:
+        return process_response(
+            response=response,
+            response_model=response_model,
+            validation_context=context,
+            strict=strict,
+            mode=mode,
+            stream=stream,
+        )
+
+    async def parse_response_async(
+        self,
+        response: Any,
+        response_model: type[BaseModel] | None,
+        context: dict[str, Any] | None,
+        strict: bool | None,
+        mode: Mode,
+        *,
+        stream: bool,
+    ) -> BaseModel | Any:
+        return await process_response_async(
+            response=response,
+            response_model=response_model,
+            validation_context=context,
+            strict=strict,
+            mode=mode,
+            stream=stream,
+        )
+
+
+from .utils.anthropic import ANTHROPIC_HANDLERS
+from .utils.openai import OPENAI_HANDLERS
+from .utils.google import GOOGLE_HANDLERS
+from .utils.cohere import COHERE_HANDLERS
+from .utils.mistral import MISTRAL_HANDLERS
+from .utils.bedrock import BEDROCK_HANDLERS
+from .utils.fireworks import FIREWORKS_HANDLERS
+from .utils.cerebras import CEREBRAS_HANDLERS
+from .utils.writer import WRITER_HANDLERS
+from .utils.perplexity import PERPLEXITY_HANDLERS
+from .utils.providers import Provider
+
+OPENAI_ADAPTER = RegistryProviderAdapter(OPENAI_HANDLERS)
+ANTHROPIC_ADAPTER = RegistryProviderAdapter(ANTHROPIC_HANDLERS)
+GOOGLE_ADAPTER = RegistryProviderAdapter(GOOGLE_HANDLERS)
+COHERE_ADAPTER = RegistryProviderAdapter(COHERE_HANDLERS)
+MISTRAL_ADAPTER = RegistryProviderAdapter(MISTRAL_HANDLERS)
+BEDROCK_ADAPTER = RegistryProviderAdapter(BEDROCK_HANDLERS)
+FIREWORKS_ADAPTER = RegistryProviderAdapter(FIREWORKS_HANDLERS)
+CEREBRAS_ADAPTER = RegistryProviderAdapter(CEREBRAS_HANDLERS)
+WRITER_ADAPTER = RegistryProviderAdapter(WRITER_HANDLERS)
+PERPLEXITY_ADAPTER = RegistryProviderAdapter(PERPLEXITY_HANDLERS)
+
+ADAPTER_REGISTRY: dict[Provider, RegistryProviderAdapter] = {
+    Provider.OPENAI: OPENAI_ADAPTER,
+    Provider.ANTHROPIC: ANTHROPIC_ADAPTER,
+    Provider.GEMINI: GOOGLE_ADAPTER,
+    Provider.GENAI: GOOGLE_ADAPTER,
+    Provider.VERTEXAI: GOOGLE_ADAPTER,
+    Provider.COHERE: COHERE_ADAPTER,
+    Provider.MISTRAL: MISTRAL_ADAPTER,
+    Provider.BEDROCK: BEDROCK_ADAPTER,
+    Provider.FIREWORKS: FIREWORKS_ADAPTER,
+    Provider.CEREBRAS: CEREBRAS_ADAPTER,
+    Provider.WRITER: WRITER_ADAPTER,
+    Provider.PERPLEXITY: PERPLEXITY_ADAPTER,
+    Provider.GROQ: OPENAI_ADAPTER,
+    Provider.OPENROUTER: OPENAI_ADAPTER,
+    Provider.XAI: OPENAI_ADAPTER,
+}

--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -9,11 +9,8 @@ from typing import Any, Callable, TypeVar
 from instructor.exceptions import InstructorRetryException
 from instructor.hooks import Hooks
 from instructor.mode import Mode
-from instructor.reask import handle_reask_kwargs
-from instructor.process_response import (
-    process_response,
-    process_response_async,
-)
+from instructor.provider_adapter import ProviderAdapter, OPENAI_ADAPTER
+from instructor.provider_adapter import ProviderAdapter, OPENAI_ADAPTER
 from instructor.utils import update_total_usage
 from instructor.validators import AsyncValidationError
 from openai.types.chat import ChatCompletion
@@ -146,6 +143,7 @@ def retry_sync(
     strict: bool | None = None,
     mode: Mode = Mode.TOOLS,
     hooks: Hooks | None = None,
+    adapter: ProviderAdapter = OPENAI_ADAPTER,
 ) -> T_Model | None:
     """
     Retry a synchronous function upon specified exceptions.
@@ -189,10 +187,10 @@ def retry_sync(
                         response=response, total_usage=total_usage
                     )
 
-                    return process_response(  # type: ignore
+                    return adapter.parse_response(  # type: ignore
                         response=response,
                         response_model=response_model,
-                        validation_context=context,
+                        context=context,
                         strict=strict,
                         mode=mode,
                         stream=stream,
@@ -200,11 +198,11 @@ def retry_sync(
                 except (ValidationError, JSONDecodeError) as e:
                     logger.debug(f"Parse error: {e}")
                     hooks.emit_parse_error(e)
-                    kwargs = handle_reask_kwargs(
+                    kwargs = adapter.reask(
                         kwargs=kwargs,
-                        mode=mode,
                         response=response,
                         exception=e,
+                        mode=mode,
                     )
                     raise e
     except RetryError as e:
@@ -232,6 +230,7 @@ async def retry_async(
     strict: bool | None = None,
     mode: Mode = Mode.TOOLS,
     hooks: Hooks | None = None,
+    adapter: ProviderAdapter = OPENAI_ADAPTER,
 ) -> T_Model | None:
     """
     Retry an asynchronous function upon specified exceptions.
@@ -275,10 +274,10 @@ async def retry_async(
                         response=response, total_usage=total_usage
                     )
 
-                    return await process_response_async(
+                    return await adapter.parse_response_async(
                         response=response,
                         response_model=response_model,
-                        validation_context=context,
+                        context=context,
                         strict=strict,
                         mode=mode,
                         stream=stream,
@@ -290,11 +289,11 @@ async def retry_async(
                 ) as e:
                     logger.debug(f"Parse error: {e}")
                     hooks.emit_parse_error(e)
-                    kwargs = handle_reask_kwargs(
+                    kwargs = adapter.reask(
                         kwargs=kwargs,
-                        mode=mode,
                         response=response,
                         exception=e,
+                        mode=mode,
                     )
                     raise e
     except RetryError as e:

--- a/instructor/utils/anthropic.py
+++ b/instructor/utils/anthropic.py
@@ -463,3 +463,12 @@ ANTHROPIC_HANDLERS = {
         "response": handle_anthropic_parallel_tools,
     },
 }
+
+# Allow generic mode names for Anthropic by duplicating handler mappings.
+ANTHROPIC_HANDLERS.update(
+    {
+        Mode.TOOLS: ANTHROPIC_HANDLERS[Mode.ANTHROPIC_TOOLS],
+        Mode.JSON: ANTHROPIC_HANDLERS[Mode.ANTHROPIC_JSON],
+        Mode.PARALLEL_TOOLS: ANTHROPIC_HANDLERS[Mode.ANTHROPIC_PARALLEL_TOOLS],
+    }
+)

--- a/instructor/utils/bedrock.py
+++ b/instructor/utils/bedrock.py
@@ -247,3 +247,11 @@ BEDROCK_HANDLERS = {
         "response": handle_bedrock_tools,
     },
 }
+
+# Support generic mode names for Bedrock
+BEDROCK_HANDLERS.update(
+    {
+        Mode.JSON: BEDROCK_HANDLERS[Mode.BEDROCK_JSON],
+        Mode.TOOLS: BEDROCK_HANDLERS[Mode.BEDROCK_TOOLS],
+    }
+)

--- a/instructor/utils/cerebras.py
+++ b/instructor/utils/cerebras.py
@@ -105,3 +105,11 @@ CEREBRAS_HANDLERS = {
         "response": handle_cerebras_json,
     },
 }
+
+# Generic mode aliases for Cerebras
+CEREBRAS_HANDLERS.update(
+    {
+        Mode.TOOLS: CEREBRAS_HANDLERS[Mode.CEREBRAS_TOOLS],
+        Mode.JSON: CEREBRAS_HANDLERS[Mode.CEREBRAS_JSON],
+    }
+)

--- a/instructor/utils/cohere.py
+++ b/instructor/utils/cohere.py
@@ -159,3 +159,11 @@ COHERE_HANDLERS = {
         "response": handle_cohere_json_schema,
     },
 }
+
+# Generic mode aliases for Cohere
+COHERE_HANDLERS.update(
+    {
+        Mode.TOOLS: COHERE_HANDLERS[Mode.COHERE_TOOLS],
+        Mode.JSON_SCHEMA: COHERE_HANDLERS[Mode.COHERE_JSON_SCHEMA],
+    }
+)

--- a/instructor/utils/fireworks.py
+++ b/instructor/utils/fireworks.py
@@ -117,3 +117,11 @@ FIREWORKS_HANDLERS = {
         "response": handle_fireworks_json,
     },
 }
+
+# Generic mode aliases for Fireworks
+FIREWORKS_HANDLERS.update(
+    {
+        Mode.TOOLS: FIREWORKS_HANDLERS[Mode.FIREWORKS_TOOLS],
+        Mode.JSON: FIREWORKS_HANDLERS[Mode.FIREWORKS_JSON],
+    }
+)

--- a/instructor/utils/mistral.py
+++ b/instructor/utils/mistral.py
@@ -120,3 +120,6 @@ MISTRAL_HANDLERS = {
         "response": handle_mistral_structured_outputs,
     },
 }
+
+# Generic mode aliases for Mistral
+MISTRAL_HANDLERS.update({Mode.TOOLS: MISTRAL_HANDLERS[Mode.MISTRAL_TOOLS]})

--- a/instructor/utils/perplexity.py
+++ b/instructor/utils/perplexity.py
@@ -59,3 +59,6 @@ PERPLEXITY_HANDLERS = {
         "response": handle_perplexity_json,
     },
 }
+
+# Allow using generic JSON mode for Perplexity
+PERPLEXITY_HANDLERS.update({Mode.JSON: PERPLEXITY_HANDLERS[Mode.PERPLEXITY_JSON]})

--- a/instructor/utils/writer.py
+++ b/instructor/utils/writer.py
@@ -114,3 +114,11 @@ WRITER_HANDLERS = {
         "response": handle_writer_json,
     },
 }
+
+# Support generic mode names for Writer
+WRITER_HANDLERS.update(
+    {
+        Mode.TOOLS: WRITER_HANDLERS[Mode.WRITER_TOOLS],
+        Mode.JSON: WRITER_HANDLERS[Mode.WRITER_JSON],
+    }
+)


### PR DESCRIPTION
## Summary
- add `ProviderAdapter` interface with `RegistryProviderAdapter` implementation
- register adapters for each provider
- use adapters in `patch` and `retry` to streamline provider-specific logic
- update all client modules to pass their adapter
- allow generic `Mode.JSON` and `Mode.TOOLS` with provider-specific handlers

## Testing
- `uv run ruff check instructor examples tests`
- `uv run pyright`
- `uv run pytest tests/ -k 'not llm and not openai'` *(fails: openai API errors)*

------
https://chatgpt.com/codex/tasks/task_e_687abb6d490c8326b60b1ec7dc740b8a
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implements a provider adapter pattern to streamline provider-specific logic across client modules, allowing for generic handling of JSON and TOOLS modes with provider-specific handlers.
> 
>   - **Provider Adapter Pattern**:
>     - Introduces `ProviderAdapter` interface and `RegistryProviderAdapter` implementation in `provider_adapter.py`.
>     - Registers adapters for each provider in `provider_adapter.py`.
>     - Updates `patch` and `retry` functions in `patch.py` and `retry.py` to use adapters.
>   - **Client Module Updates**:
>     - Updates all client modules (e.g., `client.py`, `client_anthropic.py`, `client_bedrock.py`) to pass their specific adapter.
>     - Allows generic `Mode.JSON` and `Mode.TOOLS` with provider-specific handlers.
>   - **Handler Registrations**:
>     - Registers handlers for various providers in their respective utility files (e.g., `anthropic.py`, `bedrock.py`, `cerebras.py`).
>     - Adds support for generic mode names by updating handler mappings in utility files.
>   - **Testing**:
>     - Commands used: `uv run ruff check instructor examples tests`, `uv run pyright`, `uv run pytest tests/ -k 'not llm and not openai'`.
>     - Some tests fail due to OpenAI API errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for d3e354263986566400ef9541bb720b90db7f8cdf. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->