### PR TITLE
fix: Add _raw_response to XAI JSON response

### DIFF
--- a/instructor/providers/xai/client.py
+++ b/instructor/providers/xai/client.py
@@ -118,7 +118,8 @@ def from_xai(
             resp = chat.sample()
             return resp
         if mode == instructor.Mode.XAI_JSON:
-            _, parsed = chat.parse(response_model)
+            raw, parsed = chat.parse(response_model) # Get Raw Response too
+            parsed._raw_response = raw
             return parsed
         else:
             tool = xchat.tool(


### PR DESCRIPTION
Fix situations in which I need to get both:

```
res, raw = await client.chat.completions.create_with_completion(
                **params
            )
```
Hopefully it won't break anything else
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `create()` in `client.py` to return both raw and parsed responses when `mode` is `XAI_JSON`.
> 
>   - **Behavior**:
>     - In `create()` in `client.py`, when `mode` is `XAI_JSON`, the function now returns both `raw` and `parsed` responses.
>     - Adds `_raw_response` attribute to `parsed` object to store the raw response.
>   - **Misc**:
>     - Comment added to indicate the retrieval of the raw response.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 5439dea2c4c498a0af24c4fc6c61dbd6747e463c. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->