### PR TITLE
fix: Add _raw_response to AdapterBase

### DIFF
--- a/instructor/processing/response.py
+++ b/instructor/processing/response.py
@@ -251,6 +251,7 @@ async def process_response_async(
 
     if isinstance(model, AdapterBase):
         logger.debug(f"Returning model from AdapterBase")
+        model.content._raw_response = response
         return model.content
 
     model._raw_response = response
@@ -352,6 +353,7 @@ def process_response(
 
     if isinstance(model, AdapterBase):
         logger.debug(f"Returning model from AdapterBase")
+        model.content._raw_response = response
         return model.content
 
     model._raw_response = response


### PR DESCRIPTION
this simple code was failing for me:

```
import instructor
from pydantic import BaseModel

MODEL = "openai/o3"
client = instructor.from_provider(MODEL)


class Name(BaseModel):
    name: str


(completion, raw) = client.chat.completions.create_with_completion(
    model=MODEL.split("/")[-1],
    messages=[
        {"role": "system", "content": "extract info when possible"},
        {"content": "my name is Enrico", "role": "user"},
    ],
    response_model=Name,
    max_retries=3,
)
print(raw.usage)
```