### PR TITLE
Add GCS URI support for Audio and PDFs with google-genai

### DIFF
--- a/docs/integrations/genai.md
+++ b/docs/integrations/genai.md
@@ -379,7 +379,7 @@ Instructor makes it easy to analyse and extract semantic information from PDFs u
 
 Let's see an example below with the sample PDF above where we'll load it in using our `from_url` method. With this integration that we're passing in the raw bytes to gemini itself, we also support using the Files api with the `PDFWithGenaiFile` class.
 
-Note that we support local files and base64 strings using this method too with the `from_path` and the `from_base64` class methods.
+Note that we support local files, base64 strings, and Google Cloud Storage URIs (`gs://`) using this method too with the `from_path`, `from_base64`, and `from_url` class methods respectively.
 
 ```python
 from instructor.processing.multimodal import PDF
@@ -405,11 +405,13 @@ response = client.chat.completions.create(
                 "Extract out the total and line items from the invoice",
                 # Option 1: Direct URL
                 PDF.from_url(url),
-                # Option 2: Local file
+                # Option 2: GCS URI
+                # PDF.from_url("gs://bucket-name/path/to/file.pdf"),
+                # Option 3: Local file
                 # PDF.from_path("path/to/local/invoice.pdf"),
-                # Option 3: Base64 string
-                # PDF.from_base64("base64_encoded_string_here")
-                # Option 4: Autodetect
+                # Option 4: Base64 string
+                # PDF.from_base64("base64_encoded_string_here"),
+                # Option 5: Autodetect
                 # PDF.autodetect(<url|path|base64>)
             ],
         },

--- a/docs/integrations/genai.md
+++ b/docs/integrations/genai.md
@@ -333,7 +333,7 @@ print(response)
 
 Instructor makes it easy to analyse and extract semantic information from Audio files using the Gemini series of models. Let's see an example below with the sample Audio file above where we'll load it in using our `from_url` method.
 
-Note that we support local files and base64 strings too with the `from_path`
+Note that we support local files, base64 strings, and Google Cloud Storage URIs too with the `from_path` and `from_url` methods
 
 ```python
 from instructor.processing.multimodal import Audio
@@ -364,6 +364,8 @@ response = client.chat.completions.create(
                 Audio.from_url(url),
                 # Option 2: Local file
                 # Audio.from_path("path/to/local/audio.mp3")
+                # Option 3: Google Cloud Storage URI
+                # Audio.from_url("gs://cloud-samples-data/speech/brooklyn_bridge.flac")
             ],
         },
     ],

--- a/instructor/processing/multimodal.py
+++ b/instructor/processing/multimodal.py
@@ -168,6 +168,9 @@ class Image(BaseModel):
         if cls.is_base64(url):
             return cls.from_base64(url)
 
+        if url.startswith("gs://"):
+            return cls.from_gs_url(url)
+
         parsed_url = urlparse(url)
         media_type, _ = mimetypes.guess_type(parsed_url.path)
 

--- a/instructor/processing/multimodal.py
+++ b/instructor/processing/multimodal.py
@@ -84,10 +84,8 @@ class Image(BaseModel):
 
             return cls.from_raw_base64(source)
 
-        if isinstance(source, Path):
+        elif isinstance(source, Path):
             return cls.from_path(source)
-
-        raise ValueError("Unable to determine image type or unsupported image format")
 
     @classmethod
     def autodetect_safely(cls, source: Union[str, Path]) -> Union[Image, str]:  # noqa: UP007
@@ -434,8 +432,6 @@ class PDF(BaseModel):
             return cls.from_raw_base64(source)
         elif isinstance(source, Path):
             return cls.from_path(source)
-
-        raise ValueError("Unable to determine PDF type or unsupported PDF format")
 
     @classmethod
     def is_base64(cls, s: str) -> bool:


### PR DESCRIPTION
PR adds support for Google Cloud Storage (GCS) URIs (gs://) for PDFs when using the `google-genai` provider.


```python
import instructor
from pydantic import BaseModel
from instructor.processing.multimodal import PDF
from google.genai import Client

class DocumentSummary(BaseModel):
    summary: str

uri = "gs://cloud-samples-data/generative-ai/pdf/2403.05530.pdf"

client = instructor.from_genai(Client())
response = client.chat.completions.create(
    model="gemini-2.5-pro",
    messages=[
        {
            "role": "user",
            "content": [
                "Summarize this document",
                PDF.from_url(uri),
            ],  
        }
    ],
    autodetect_images=True,
    response_model=DocumentSummary,
)

print(response.summary)
```

This also includes a minor chore commit to remove unreachable raise statements.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for GCS URIs for PDFs in `google-genai` and removes unreachable raise statements in `autodetect` methods.
> 
>   - **Behavior**:
>     - Adds support for GCS URIs (gs://) in `PDF.from_url()` and `PDF.to_genai()` to fetch PDFs from Google Cloud Storage.
>     - Converts GCS URI to public URL and fetches content in `PDF.to_genai()`.
>   - **Code Quality**:
>     - Removes unreachable `raise ValueError` statements in `autodetect()` methods of `Image` and `PDF` classes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for c206a1f18f94a26e83f5159ad60bc3494d0c89f8. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->