### PR TITLE
only use thinking_config in GenerateContentConfig

### DIFF
--- a/instructor/providers/gemini/utils.py
+++ b/instructor/providers/gemini/utils.py
@@ -824,6 +824,7 @@ def handle_genai_structured_outputs(
     new_kwargs.pop("messages", None)
     new_kwargs.pop("generation_config", None)
     new_kwargs.pop("safety_settings", None)
+    new_kwargs.pop("thinking_config", None)
 
     return response_model, new_kwargs
 


### PR DESCRIPTION
If "thinking_config" is not removed from kwargs, the genai
Models.generate_content_stream() function call will raise an
"an unexpected keyword argument" exception.

After making this change, code like the following succeeds:

```
client.chat.completions.create_iterable(
    messages=…,
    response_model=…,
    thinking_config=types.ThinkingConfig(thinking_budget=0),
)
```