### PR TITLE
feat(xai): add streaming support for xAI provider

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -53,7 +53,6 @@ unfixable = [
   "T201",
   "T203",
 ]
-ignore-init-module-imports = true
 
 [lint.extend-per-file-ignores]
 "instructor/distil.py" = ["ARG002"]

--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -920,7 +920,7 @@ def from_provider(
             )
             result = from_xai(
                 client,
-                mode=mode if mode else instructor.Mode.JSON,
+                mode=mode if mode else instructor.Mode.XAI_JSON,
                 model=model_name,
                 **kwargs,
             )

--- a/tests/llm/test_xai/test_stream.py
+++ b/tests/llm/test_xai/test_stream.py
@@ -1,0 +1,158 @@
+import os
+from typing import Literal, Union
+from pydantic import BaseModel
+import pytest
+import instructor
+
+from .util import modes
+
+
+class UserExtract(BaseModel):
+    name: str
+    age: int
+
+
+@pytest.mark.parametrize("mode", modes)
+@pytest.mark.skipif(
+    not os.environ.get("XAI_API_KEY") or os.environ.get("XAI_API_KEY") == "test",
+    reason="XAI_API_KEY not set or invalid",
+)
+def test_iterable_model(mode):
+    client = instructor.from_provider("xai/grok-3-mini", mode=mode)
+    model = client.chat.create_iterable(
+        response_model=UserExtract,
+        max_retries=2,
+        messages=[
+            {"role": "user", "content": "Make two up people"},
+        ],
+    )
+    count = 0
+    for m in model:
+        assert isinstance(m, UserExtract)
+        count += 1
+    assert count == 2
+
+
+@pytest.mark.parametrize("mode", modes)
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("XAI_API_KEY") or os.environ.get("XAI_API_KEY") == "test",
+    reason="XAI_API_KEY not set or invalid",
+)
+async def test_iterable_model_async(mode):
+    client = instructor.from_provider("xai/grok-3-mini", mode=mode, async_client=True)
+    model = client.chat.create_iterable(
+        response_model=UserExtract,
+        max_retries=2,
+        messages=[
+            {"role": "user", "content": "Make two up people"},
+        ],
+    )
+    count = 0
+    async for m in model:
+        assert isinstance(m, UserExtract)
+        count += 1
+    assert count == 2
+
+
+@pytest.mark.parametrize("mode", modes)
+@pytest.mark.skipif(
+    not os.environ.get("XAI_API_KEY") or os.environ.get("XAI_API_KEY") == "test",
+    reason="XAI_API_KEY not set or invalid",
+)
+def test_partial_model(mode):
+    client = instructor.from_provider("xai/grok-3-mini", mode=mode)
+    model = client.chat.create_partial(
+        response_model=UserExtract,
+        max_retries=2,
+        messages=[
+            {"role": "user", "content": "Jason Liu is 12 years old"},
+        ],
+    )
+    count = 0
+    for m in model:
+        assert isinstance(m, UserExtract)
+        count += 1
+    assert count >= 1
+
+
+@pytest.mark.parametrize("mode", modes)
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("XAI_API_KEY") or os.environ.get("XAI_API_KEY") == "test",
+    reason="XAI_API_KEY not set or invalid",
+)
+async def test_partial_model_async(mode):
+    client = instructor.from_provider("xai/grok-3-mini", mode=mode, async_client=True)
+    model = client.chat.create_partial(
+        response_model=UserExtract,
+        max_retries=2,
+        messages=[
+            {"role": "user", "content": "Jason Liu is 12 years old"},
+        ],
+    )
+    count = 0
+    async for m in model:
+        assert isinstance(m, UserExtract)
+        count += 1
+    assert count >= 1
+
+
+class Weather(BaseModel):
+    location: str
+    units: Literal["imperial", "metric"]
+
+
+class GoogleSearch(BaseModel):
+    query: str
+
+
+@pytest.mark.parametrize("mode", modes)
+@pytest.mark.skipif(
+    not os.environ.get("XAI_API_KEY") or os.environ.get("XAI_API_KEY") == "test",
+    reason="XAI_API_KEY not set or invalid",
+)
+def test_iterable_create_union_model(mode):
+    client = instructor.from_provider("xai/grok-3-mini", mode=mode)
+    model = client.chat.create_iterable(
+        max_retries=2,
+        messages=[
+            {"role": "system", "content": "You must always use tools"},
+            {
+                "role": "user",
+                "content": "What is the weather in toronto and dallas and who won the super bowl?",
+            },
+        ],
+        response_model=Union[Weather, GoogleSearch],
+    )
+    count = 0
+    for m in model:
+        assert isinstance(m, (Weather, GoogleSearch))
+        count += 1
+    assert count >= 1
+
+
+@pytest.mark.parametrize("mode", modes)
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("XAI_API_KEY") or os.environ.get("XAI_API_KEY") == "test",
+    reason="XAI_API_KEY not set or invalid",
+)
+async def test_iterable_create_union_model_async(mode):
+    client = instructor.from_provider("xai/grok-3-mini", mode=mode, async_client=True)
+    model = client.chat.create_iterable(
+        max_retries=2,
+        messages=[
+            {"role": "system", "content": "You must always use tools"},
+            {
+                "role": "user",
+                "content": "What is the weather in toronto and dallas and who won the super bowl?",
+            },
+        ],
+        response_model=Union[Weather, GoogleSearch],
+    )
+    count = 0
+    async for m in model:
+        assert isinstance(m, (Weather, GoogleSearch))
+        count += 1
+    assert count >= 1

--- a/tests/llm/test_xai/test_stream.py
+++ b/tests/llm/test_xai/test_stream.py
@@ -107,7 +107,7 @@ class GoogleSearch(BaseModel):
     query: str
 
 
-@pytest.mark.parametrize("mode", modes)
+@pytest.mark.parametrize("mode", [instructor.Mode.XAI_JSON])
 @pytest.mark.skipif(
     not os.environ.get("XAI_API_KEY") or os.environ.get("XAI_API_KEY") == "test",
     reason="XAI_API_KEY not set or invalid",
@@ -132,7 +132,7 @@ def test_iterable_create_union_model(mode):
     assert count >= 1
 
 
-@pytest.mark.parametrize("mode", modes)
+@pytest.mark.parametrize("mode", [instructor.Mode.XAI_JSON])
 @pytest.mark.asyncio
 @pytest.mark.skipif(
     not os.environ.get("XAI_API_KEY") or os.environ.get("XAI_API_KEY") == "test",


### PR DESCRIPTION
## Summary

This PR resolves issue #1663. It adds streaming support for the xAI provider.

## Description
* Implemented iterable and partial streaming features for sync and async xAI clients. 
* Works for both XAI_JSON and XAI_TOOLS mode. 
* Added test cases that do simple and union extraction for every case.

**Note**: XAI_TOOLS does not support streaming. The current implementation works, but effectively it is not streaming.
See https://docs.x.ai/docs/guides/function-calling .

PTAL @jxnl @ivanleomk 