### PR TITLE
fix(openai): remove duplicate schema from messages in JSON_SCHEMA mode

### DIFF
--- a/instructor/providers/openai/utils.py
+++ b/instructor/providers/openai/utils.py
@@ -433,22 +433,23 @@ def handle_json_modes(
         )
         new_kwargs["messages"] = merge_consecutive_messages(new_kwargs["messages"])
 
-    if new_kwargs["messages"][0]["role"] != "system":
-        new_kwargs["messages"].insert(
-            0,
-            {
-                "role": "system",
-                "content": message,
-            },
-        )
-    elif isinstance(new_kwargs["messages"][0]["content"], str):
-        new_kwargs["messages"][0]["content"] += f"\n\n{message}"
-    elif isinstance(new_kwargs["messages"][0]["content"], list):
-        new_kwargs["messages"][0]["content"][0]["text"] += f"\n\n{message}"
-    else:
-        raise ValueError(
-            "Invalid message format, must be a string or a list of messages"
-        )
+    if mode != Mode.JSON_SCHEMA:
+        if new_kwargs["messages"][0]["role"] != "system":
+            new_kwargs["messages"].insert(
+                0,
+                {
+                    "role": "system",
+                    "content": message,
+                },
+            )
+        elif isinstance(new_kwargs["messages"][0]["content"], str):
+            new_kwargs["messages"][0]["content"] += f"\n\n{message}"
+        elif isinstance(new_kwargs["messages"][0]["content"], list):
+            new_kwargs["messages"][0]["content"][0]["text"] += f"\n\n{message}"
+        else:
+            raise ValueError(
+                "Invalid message format, must be a string or a list of messages"
+            )
 
     return response_model, new_kwargs
 


### PR DESCRIPTION
Removes redundant schema information from messages when using `JSON_SCHEMA` mode.

### Why This Change?

**JSON mode** (`response_format: {"type": "json_object"}`) - OpenAI docs require explicit JSON instruction in messages since no schema is provided in response_format. 
https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#json-mode

> When using JSON mode, you must always instruct the model to produce JSON via some message in the conversation, for example via your system message. If you don't include an explicit instruction to generate JSON, the model may generate an unending stream of whitespace and the request may run continually until it reaches the token limit. To help ensure you don't forget, the API will throw an error if the string "JSON" does not appear somewhere in the context.

**JSON_SCHEMA mode** (`response_format: {"type": "json_schema", ...}`) - Schema is already provided in response_format. Adding the same schema to messages creates redundancy, increases token consumption unnecessarily, and provides no additional value to the model.

### Changes

- `JSON_SCHEMA` mode: No schema added to messages (schema already in response_format)
- `JSON` and `MD_JSON` modes: Unchanged behavior (still add schema to messages as required)