### PR TITLE
Fix enum validation error in Google GenAI provider

### DIFF
--- a/instructor/processing/function_calls.py
+++ b/instructor/processing/function_calls.py
@@ -284,8 +284,9 @@ class OpenAISchema(BaseModel):
         )
 
         assert function_call.name == cls.openai_schema["name"]
-        return cls.model_validate(
-            obj=function_call.args, context=validation_context, strict=strict
+        # Convert to JSON and back to handle string-to-enum conversion properly
+        return cls.model_validate_json(
+            json.dumps(function_call.args), context=validation_context, strict=strict
         )
 
     @classmethod


### PR DESCRIPTION
## Changes
  - **Fix response parsing**: Change `model_validate()` to `model_validate_json()` in `parse_genai_tools()` to properly
  handle string-to-enum conversion
  - **Fixes:** #1756 