### PR TITLE
Fix Pydantic v2 deprecation warnings by migrating from class Config to   ConfigDict

### DIFF
--- a/instructor/batch/models.py
+++ b/instructor/batch/models.py
@@ -7,7 +7,7 @@ used throughout the batch processing system.
 
 from __future__ import annotations
 from typing import Any, Union, TypeVar, Generic
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from datetime import datetime, timezone
 from enum import Enum
 
@@ -21,8 +21,7 @@ class BatchSuccess(BaseModel, Generic[T]):
     result: T
     success: bool = True
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class BatchError(BaseModel):

--- a/instructor/batch/request.py
+++ b/instructor/batch/request.py
@@ -7,7 +7,7 @@ provider-specific batch requests with JSON schema generation.
 
 from __future__ import annotations
 from typing import Any, Generic
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 import json
 import io
 from .models import T
@@ -50,8 +50,7 @@ class BatchRequest(BaseModel, Generic[T]):
     max_tokens: int | None = Field(default=1000)
     temperature: float | None = Field(default=0.1)
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def get_json_schema(self) -> dict[str, Any]:
         """Generate JSON schema from response_model"""


### PR DESCRIPTION
This PR fixes PydanticDeprecatedSince20 warnings that appear when using instructor v1.10.0 with Pydantic v2. The warnings occur because two classes still use the deprecated class Config: pattern instead of the modern `model_config = ConfigDict(...)` approach.

### Changes:
  - Updated BatchSuccess and BatchRequest classes to use ConfigDict
  - Added ConfigDict to imports in both files
  - Maintains backward compatibility while eliminating deprecation warnings

### Testing:
  - All existing functionality remains unchanged
  - Deprecation warnings eliminated when importing instructor