### PR TITLE
fix(exceptions): restore backwards compatibility for instructor.exceptions imports

### DIFF
--- a/instructor/exceptions.py
+++ b/instructor/exceptions.py
@@ -1,0 +1,42 @@
+"""Backward compatibility module for instructor.exceptions imports.
+
+.. deprecated:: 1.11.0
+    This module is deprecated. Import exceptions from `instructor.core` instead.
+    For example: `from instructor.core import InstructorRetryException`
+"""
+
+import warnings
+
+# Show deprecation warning when this module is imported
+warnings.warn(
+    "Importing from 'instructor.exceptions' is deprecated and will be removed in a future version. "
+    "Please import from 'instructor.core' instead. "
+    "For example: 'from instructor.core import InstructorRetryException'",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+# Explicit re-exports for better IDE support and clarity
+from .core.exceptions import (
+    AsyncValidationError,
+    ClientError,
+    ConfigurationError,
+    IncompleteOutputException,
+    InstructorError,
+    InstructorRetryException,
+    ModeError,
+    ProviderError,
+    ValidationError,
+)
+
+__all__ = [
+    "AsyncValidationError",
+    "ClientError",
+    "ConfigurationError",
+    "IncompleteOutputException",
+    "InstructorError",
+    "InstructorRetryException",
+    "ModeError",
+    "ProviderError",
+    "ValidationError",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "diskcache>=5.6.3",
 ]
 name = "instructor"
-version = "1.11.1"
+version = "1.11.2"
 description = "structured outputs for llm"
 readme = "README.md"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1753,7 +1753,7 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.11.1"
+version = "1.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Restore backwards compatibility for `instructor.exceptions` imports that broke in v1.11.0
- Add deprecation warnings to guide users to new import path `instructor.core`
- Bump version to 1.11.2 (patch version for backwards compatibility fix)

## Problem
Version 1.11.0 introduced a breaking change by removing the backwards compatibility module `instructor/exceptions.py`. This caused imports like `from instructor.exceptions import InstructorRetryException` to fail, breaking downstream applications without warning.

## Solution
- Recreated `instructor/exceptions.py` with proper re-exports from `instructor.core.exceptions`
- Added deprecation warnings to guide users to the recommended import path
- Used proper semantic versioning (patch bump) for a backwards compatibility fix

## Test plan
- [x] Test that old import path works: `from instructor.exceptions import InstructorRetryException`
- [x] Test that new import path still works: `from instructor.core import InstructorRetryException`
- [x] Verify deprecation warning is shown when using old import path
- [x] Run linting and type checking
- [x] Version bump to 1.11.2

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores backwards compatibility for `instructor.exceptions` imports with deprecation warnings and bumps version to 1.11.2.
> 
>   - **Behavior**:
>     - Reintroduces `instructor/exceptions.py` to restore backwards compatibility for imports like `from instructor.exceptions import InstructorRetryException`.
>     - Adds deprecation warning in `instructor/exceptions.py` to guide users to `instructor.core`.
>   - **Versioning**:
>     - Bumps version to 1.11.2 in `pyproject.toml` and `uv.lock` for backwards compatibility fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for ff9d88f03dd2241e47ab6f90c50fc364e24e7eba. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->