### PR TITLE
fix(openai): reask functionality broken in JSON mode since v1.9.0

### DIFF
--- a/instructor/processing/function_calls.py
+++ b/instructor/processing/function_calls.py
@@ -95,12 +95,7 @@ def _validate_model_from_json(
         raise ValueError(f"Failed to parse JSON: {e}") from e
     except Exception as e:
         logger.debug(f"Model validation error: {e}")
-        # Re-raise with more context
-        from ..core.exceptions import ValidationError as InstructorValidationError
-
-        raise InstructorValidationError(
-            f"Failed to validate model {cls.__name__}: {str(e)}"
-        ) from e
+        raise
 
 
 class OpenAISchema(BaseModel):


### PR DESCRIPTION
Since v1.9.0, from this PR: https://github.com/567-labs/instructor/pull/1549, the reask functionality with JSON mode is broken.

Irrespective of whether the underlying error is a `JSONDecodeError` or `ValidationError`, both are being wrapped under `instructor.core.exceptions.ValidationError`

Hence in `retry_sync`/`retry_async` of `instructor/core/retry.py`, these wrapped errors are always caught by the generic `Exception` block instead of the specific `(ValidationError, JSONDecodeError)` block, even when those specific exception types should trigger retries with error messages included
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes reask functionality in JSON mode by removing exception wrapping in `_validate_model_from_json()` to allow specific exception handling.
> 
>   - **Behavior**:
>     - Fixes reask functionality in JSON mode by removing exception wrapping in `_validate_model_from_json()` in `function_calls.py`.
>     - Allows `JSONDecodeError` and `ValidationError` to be caught specifically in `retry_sync`/`retry_async` in `retry.py`.
>   - **Exceptions**:
>     - Removes wrapping of exceptions in `instructor.core.exceptions.ValidationError` in `_validate_model_from_json()`.
>   - **Logging**:
>     - Retains debug logging for JSON decode and model validation errors in `_validate_model_from_json()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for b6a47d928534416709e896830c34d53840e3fc5d. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->