### PR TITLE
Investigate instructor client import errors

### DIFF
--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -63,10 +63,15 @@ __all__ = [
     "llm_validator",
     "openai_moderation",
     "hooks",
+    "client",  # Backward compatibility
     # Backward compatibility exports
     "handle_response_model",
     "handle_parallel_model",
 ]
+
+# Backward compatibility: Make instructor.client available as an attribute
+# This allows code like `instructor.client.Instructor` to work
+from . import client
 
 
 if importlib.util.find_spec("anthropic") is not None:

--- a/instructor/providers/writer/client.py
+++ b/instructor/providers/writer/client.py
@@ -27,7 +27,7 @@ def from_writer(
     client: Writer | AsyncWriter,
     mode: instructor.Mode = instructor.Mode.WRITER_TOOLS,
     **kwargs: Any,
-) -> instructor.client.Instructor | instructor.client.AsyncInstructor:
+) -> instructor.Instructor | instructor.AsyncInstructor:
     valid_modes = {instructor.Mode.WRITER_TOOLS, instructor.Mode.WRITER_JSON}
 
     if mode not in valid_modes:


### PR DESCRIPTION
fix: re-expose instructor.client for backward compatibility

## Describe your changes

This PR addresses the critical breaking change where `instructor.client` was no longer directly accessible, causing `AttributeError` for users.

The changes re-expose `client` in `instructor/__init__.py` to restore backward compatibility, allowing `instructor.client.Instructor` and `instructor.client.AsyncInstructor` to function again. Deprecation warnings are in place to guide users towards the new direct import paths. Additionally, an internal reference in `instructor/providers/writer/client.py` was updated for consistency.

## Issue ticket number and link

#1816

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.

---
[Slack Thread](https://567-studio.slack.com/archives/C08U5CAP8KV/p1758785426626979?thread_ts=1758785426.626979&cid=C08U5CAP8KV)

<a href="https://cursor.com/background-agent?bcId=bc-4c062dcf-ca79-46b8-b16e-dcc5bbf1b509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4c062dcf-ca79-46b8-b16e-dcc5bbf1b509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-expose `instructor.client` for backward compatibility and update internal references in `from_writer()`.
> 
>   - **Behavior**:
>     - Re-expose `client` in `instructor/__init__.py` for backward compatibility, allowing `instructor.client.Instructor` and `instructor.client.AsyncInstructor` to work.
>     - Add deprecation warnings to guide users to new import paths.
>   - **Internal References**:
>     - Update return type in `from_writer()` in `instructor/providers/writer/client.py` to use `instructor.Instructor` and `instructor.AsyncInstructor` directly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 91245da55ff4863c425bc7bc39a3d3ff21a2f0e8. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->