### PR TITLE
update cohere text models.

### DIFF
--- a/docs/examples/document_segmentation.md
+++ b/docs/examples/document_segmentation.md
@@ -1,18 +1,18 @@
 ---
-title: 'Document Segmentation with LLMs: A Comprehensive Guide'
+title: "Document Segmentation with LLMs: A Comprehensive Guide"
 description: Learn effective document segmentation techniques using Cohere's LLM, enhancing comprehension of complex texts.
 ---
 
 # Document Segmentation
 
-In this guide, we demonstrate how to do document segmentation using structured output from an LLM. We'll be using [command-r-plus](https://docs.cohere.com/docs/command-r-plus) - one of Cohere's latest LLMs with 128k context length and testing the approach on an article explaining the Transformer architecture. Same approach to document segmentation can be applied to any other domain where we need to break down a complex long document into smaller chunks.
+In this guide, we demonstrate how to do document segmentation using structured output from an LLM. We'll be using [command-a-reasoning-08-2025](https://docs.cohere.com/docs/command-a-reasoning) - one of Cohere's latest LLMs with 256k context length and testing the approach on an article explaining the Transformer architecture. Same approach to document segmentation can be applied to any other domain where we need to break down a complex long document into smaller chunks.
 
 !!! tips "Motivation"
-    Sometimes we need a way to split the document into meaningful parts that center around a single key concept/idea. Simple length-based / rule-based text-splitters are not reliable enough. Consider the cases where documents contain code snippets or math equations - we don't want to split those on `'\n\n'` or have to write extensive rules for different types of documents. It turns out that LLMs with sufficiently long context length are well suited for this task.
+Sometimes we need a way to split the document into meaningful parts that center around a single key concept/idea. Simple length-based / rule-based text-splitters are not reliable enough. Consider the cases where documents contain code snippets or math equations - we don't want to split those on `'\n\n'` or have to write extensive rules for different types of documents. It turns out that LLMs with sufficiently long context length are well suited for this task.
 
 ## Defining the Data Structures
 
-First, we need to define a **`Section`** class for each of the document's segments.  **`StructuredDocument`** class will then encapsulate a list of these sections.
+First, we need to define a **`Section`** class for each of the document's segments. **`StructuredDocument`** class will then encapsulate a list of these sections.
 
 Note that in order to avoid LLM regenerating the content of each section, we can simply enumerate each line of the input document and then ask LLM to segment it by providing start-end line numbers for each section.
 
@@ -89,7 +89,7 @@ Each line of the document is marked with its line number in square brackets (e.g
 
 def get_structured_document(document_with_line_numbers) -> StructuredDocument:
     return client.chat.completions.create(
-        model="command-r-plus",
+        model="command-a-reasoning-08-2025",
         response_model=StructuredDocument,
         messages=[
             {
@@ -103,7 +103,6 @@ def get_structured_document(document_with_line_numbers) -> StructuredDocument:
         ],
     )  # type: ignore
 ```
-
 
 Next, we need to get back the section text based on the start/end indices and our `line2text` dict from the preprocessing step.
 
@@ -124,7 +123,6 @@ def get_sections_text(structured_doc, line2text):
         )
     return segments
 ```
-
 
 ## Example
 
@@ -174,7 +172,7 @@ class StructuredDocument(BaseModel):
 
 def get_structured_document(document_with_line_numbers) -> StructuredDocument:
     return client.chat.completions.create(
-        model="command-r-plus",
+        model="command-a-reasoning-08-2025",
         response_model=StructuredDocument,
         messages=[
             {

--- a/docs/integrations/cohere.md
+++ b/docs/integrations/cohere.md
@@ -35,7 +35,7 @@ import instructor
 
 # Patching the Cohere client with the instructor for enhanced capabilities
 client = instructor.from_provider(
-    "cohere/command-r-plus",
+    "cohere/command-a-reasoning-08-2025",
     max_tokens=1000,
 )
 
@@ -94,7 +94,7 @@ print(group.model_dump_json(indent=2))
 import instructor
 
 async_client = instructor.from_provider(
-    "cohere/command-r-plus",
+    "cohere/command-a-reasoning-08-2025",
     async_client=True,
     max_tokens=1000,
 )

--- a/examples/cohere/cohere.py
+++ b/examples/cohere/cohere.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 client = instructor.from_cohere(
     cohere.Client(),
     max_tokens=1000,
-    model="command-r-plus",
+    model="command-a-reasoning-08-2025",
 )
 
 

--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -809,7 +809,7 @@ def from_provider(
                 "llama4",
                 "mistral-nemo",
                 "firefunction-v2",
-                "command-r-plus",
+                "command-a-reasoning-08-2025",
                 "qwen2.5",
                 "qwen2.5-coder",
                 "qwen3",

--- a/instructor/models.py
+++ b/instructor/models.py
@@ -16,13 +16,17 @@ KnownModelName = TypeAliasType(
         "anthropic/claude-3-opus-latest",
         "anthropic/claude-3-opus-20240229",
         "anthropic/claude-3-haiku-20240307",
-        # Cohere Models
+        # Cohere Models - https://docs.cohere.com/docs/models
         "cohere/c4ai-aya-expanse-32b",
         "cohere/c4ai-aya-expanse-8b",
         "cohere/command",
         "cohere/command-light",
         "cohere/command-light-nightly",
         "cohere/command-nightly",
+        "cohere/command-a-03-2025",
+        "cohere/command-r7b-12-2024",
+        "cohere/command-a-translate-08-2025",
+        "cohere/command-a-reasoning-08-2025",
         "cohere/command-r",
         "cohere/command-r-03-2024",
         "cohere/command-r-08-2024",

--- a/tests/llm/test_cohere/test_json_schema.py
+++ b/tests/llm/test_cohere/test_json_schema.py
@@ -88,7 +88,7 @@ async def test_parse_user_async(aclient, mode):
 
     resp = await client.chat.completions.create(
         response_model=ValidatedUser,
-        model="command-r-plus",
+        model="command-a-reasoning-08-2025",
         messages=[
             {
                 "role": "user",
@@ -109,7 +109,7 @@ async def test_parse_user_async_jinja(aclient, mode):
 
     resp = await client.chat.completions.create(
         response_model=ValidatedUser,
-        model="command-r-plus",
+        model="command-a-reasoning-08-2025",
         messages=[
             {
                 "role": "user",

--- a/tests/llm/test_new_client.py
+++ b/tests/llm/test_new_client.py
@@ -267,7 +267,7 @@ def test_client_cohere_response():
     instructor_client = instructor.from_cohere(
         client,
         max_tokens=1000,
-        model="command-r-plus",
+        model="command-a-reasoning-08-2025",
     )
 
     user = instructor_client.messages.create(
@@ -285,7 +285,7 @@ def test_client_cohere_response_with_nested_classes():
     instructor_client = instructor.from_cohere(
         client,
         max_tokens=1000,
-        model="command-r-plus",
+        model="command-a-reasoning-08-2025",
     )
 
     class Person(BaseModel):
@@ -322,7 +322,7 @@ async def test_client_cohere_async():
     instructor_client = instructor.from_cohere(
         client,
         max_tokens=1000,
-        model="command-r-plus",
+        model="command-a-reasoning-08-2025",
     )
 
     class Person(BaseModel):

--- a/tests/test_auto_client.py
+++ b/tests/test_auto_client.py
@@ -23,7 +23,7 @@ PROVIDERS = [
     "openai/gpt-4o-mini",
     "azure_openai/gpt-4o-mini",
     "mistral/ministral-8b-latest",
-    "cohere/command-a-03-2025",
+    "cohere/command-a-reasoning-08-2025",
     "perplexity/sonar-pro",
     "groq/llama-3.1-8b-instant",
     "writer/palmyra-x5",

--- a/tests/test_auto_client.py
+++ b/tests/test_auto_client.py
@@ -23,7 +23,7 @@ PROVIDERS = [
     "openai/gpt-4o-mini",
     "azure_openai/gpt-4o-mini",
     "mistral/ministral-8b-latest",
-    "cohere/command-r-plus",
+    "cohere/command-a-03-2025",
     "perplexity/sonar-pro",
     "groq/llama-3.1-8b-instant",
     "writer/palmyra-x5",
@@ -39,7 +39,7 @@ def should_skip_provider(provider_string: str) -> bool:
 
     if os.getenv("INSTRUCTOR_ENV") == "CI":
         return provider_string not in [
-            "cohere/command-r-plus",
+            "cohere/command-a-reasoning-08-2025",
             "google/gemini-2.0-flash",
             "openai/gpt-4o-mini",
         ]


### PR DESCRIPTION
fix: cohere `command-r-plus` model is deprecated - causing tests to break

- update the models to include the latest models from cohere. Keep deprecated models for the moment.
- update tests and example code appropriately to use the latest `command-a-reasoning-08-2025`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Cohere model to `command-a-reasoning-08-2025` across documentation, examples, and tests, while retaining deprecated models for compatibility.
> 
>   - **Model Update**:
>     - Update Cohere model from `command-r-plus` to `command-a-reasoning-08-2025` in `document_segmentation.md`, `cohere.md`, and `cohere.py`.
>     - Update `from_provider()` in `auto_client.py` to include `command-a-reasoning-08-2025`.
>     - Add `command-a-reasoning-08-2025` to `KnownModelName` in `models.py`.
>   - **Tests**:
>     - Update tests in `test_json_schema.py` and `test_new_client.py` to use `command-a-reasoning-08-2025`.
>     - Modify `test_auto_client.py` to include `command-a-reasoning-08-2025` in the list of providers to test.
>   - **Misc**:
>     - Keep deprecated `command-r-plus` model in `models.py` for backward compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 7eb2b69810fed46e27a0b1b1da8ef7090726ef84. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->