### PR TITLE
feat(bedrock): add native structured outputs and strict tool use modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Bedrock**: Add native constrained-decoding support for the `JSON_SCHEMA` mode (structured outputs via `outputConfig.textFormat`) and the `TOOLS_STRICT` mode (strict tool use with `strict: true` on the toolSpec), giving guaranteed schema compliance and fewer retries. `from_provider("bedrock/...")` now defaults to `JSON_SCHEMA` for models that support it. The provider-named aliases `BEDROCK_STRUCTURED_OUTPUTS` and `BEDROCK_TOOLS_STRICT` are also accepted but deprecated in favor of the canonical modes. ([#2086](https://github.com/567-labs/instructor/pull/2086))
+
+---
+
 ## [1.15.5] - 2026-06-28
 
 ### Fixed

--- a/docs/integrations/bedrock.md
+++ b/docs/integrations/bedrock.md
@@ -123,13 +123,43 @@ print(user)
 
 ## Supported Modes
 
-AWS Bedrock supports the following **core** modes:
+AWS Bedrock supports the following modes:
 
-- `TOOLS`: Uses function calling for models that support it (like Claude models)
-- `MD_JSON`: Direct JSON response generation (text extraction fallback)
+| Mode | Description | Response format |
+|------|-------------|-----------------|
+| `JSON_SCHEMA` | Native JSON schema constrained decoding via `outputConfig.textFormat` | JSON text |
+| `TOOLS_STRICT` | Strict tool use with `strict: true` on `toolSpec` | Tool use |
+| `TOOLS` | Standard tool use / function calling | Tool use |
+| `MD_JSON` | Prompt-based JSON extraction | JSON text |
 
-> Legacy modes (`BEDROCK_TOOLS`, `BEDROCK_JSON`) are deprecated and map to `Mode.TOOLS` and `Mode.MD_JSON`.
-> modes above. Use `TOOLS` or `MD_JSON` in new code.
+The provider-named aliases `BEDROCK_STRUCTURED_OUTPUTS`, `BEDROCK_TOOLS_STRICT`, `BEDROCK_TOOLS`, and `BEDROCK_JSON` still work but are deprecated: they emit a warning and resolve to the canonical modes above (`JSON_SCHEMA`, `TOOLS_STRICT`, `TOOLS`, `MD_JSON` respectively). The provider is determined by the client, not the mode.
+
+### Native Structured Outputs (Recommended)
+
+`JSON_SCHEMA` and `TOOLS_STRICT` leverage Bedrock's native constrained decoding to guarantee schema-conformant output. This eliminates JSON parsing failures and reduces retries.
+
+**Supported models:** Instructor's Bedrock integration uses the **Converse API** (`client.converse()`). As of February 2026, the following models support structured outputs via the Converse API:
+
+- **Anthropic:** Claude Haiku 4.5, Claude Sonnet 4.5, Claude Opus 4.5, Claude Opus 4.6
+- **Qwen:** Qwen3 (all variants), Qwen3 Coder
+- **Mistral:** Mistral Large 3, Ministral (3B/8B/14B), Voxtral (Mini/Small)
+- **Google:** Gemma 3 (12B/27B)
+- **MiniMax:** M2
+- **Moonshot:** Kimi K2 Thinking
+- **NVIDIA:** Nemotron Nano (9B/12B v2)
+
+**Known broken models** (listed by AWS but ignore the schema constraint in practice):
+
+- OpenAI GPT-OSS (all variants) — returns markdown-wrapped JSON, ignores `outputConfig`
+- Mistral Magistral Small 2509 — returns free-form text, ignores `outputConfig`
+- DeepSeek V3.2 — `outputConfig.textFormat` returns `ValidationException`
+
+**Notes:**
+
+- First request for a new schema may have higher latency due to grammar compilation (cached for 24 hours)
+- `JSON_SCHEMA` (structured outputs) is mutually exclusive with tool use — do not combine with `toolConfig`
+- Incompatible with citations for Anthropic models
+- See [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html) for the latest supported models
 
 ```python
 import boto3
@@ -137,16 +167,34 @@ import instructor
 from instructor import Mode
 from pydantic import BaseModel
 
-# Use from_provider for simplified setup
-client = instructor.from_provider("bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", mode=Mode.TOOLS)
-
-# Or if you need to use a custom boto3 client:
-# bedrock_client = boto3.client('bedrock-runtime')
-# client = instructor.from_provider("bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", client=bedrock_client, mode=Mode.TOOLS)
+# Structured outputs mode (recommended for supported models)
+bedrock_client = boto3.client("bedrock-runtime")
+client = instructor.from_bedrock(bedrock_client, mode=Mode.JSON_SCHEMA)
 
 class User(BaseModel):
     name: str
     age: int
+
+user = client.create(
+    model="anthropic.claude-sonnet-4-5-v1",
+    messages=[{"role": "user", "content": "Extract: Jason is 25 years old"}],
+    response_model=User,
+)
+print(user)
+# > User(name='Jason', age=25)
+```
+
+### Strict Tool Use
+
+```python
+# Strict tool use mode — same response format as TOOLS but with native schema enforcement
+client = instructor.from_bedrock(bedrock_client, mode=Mode.TOOLS_STRICT)
+
+user = client.create(
+    model="anthropic.claude-sonnet-4-5-v1",
+    messages=[{"role": "user", "content": "Extract: Jason is 25 years old"}],
+    response_model=User,
+)
 ```
 
 ## OpenAI Compatibility: Flexible Input Format and Model Parameter

--- a/instructor/v2/auto_client.py
+++ b/instructor/v2/auto_client.py
@@ -1007,12 +1007,38 @@ def _build_bedrock(
         # Create bedrock-runtime client
         client = boto3.client("bedrock-runtime", **aws_kwargs)
 
-        # Determine default mode based on model
+        # Determine default mode based on model.
+        # Models that support native structured outputs via the Converse API.
+        # See https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
+        _structured_outputs_models = {
+            # Anthropic Claude 4.5+
+            "claude-haiku-4-5",
+            "claude-sonnet-4-5",
+            "claude-opus-4-5",
+            "claude-opus-4-6",
+            # Qwen
+            "qwen3",
+            # Google
+            "gemma-3",
+            # MiniMax
+            "minimax-m2",
+            # Mistral (not Magistral Small - ignores schema constraint)
+            "ministral",
+            "mistral-large-3",
+            "voxtral",
+            # Moonshot
+            "kimi-k2",
+            # NVIDIA
+            "nemotron-nano",
+        }
         if mode is None:
-            # Anthropic models (Claude) support tools, others use JSON
-            if model_name and (
-                "anthropic" in model_name.lower() or "claude" in model_name.lower()
-            ):
+            model_lower = (model_name or "").lower()
+            if any(m in model_lower for m in _structured_outputs_models):
+                # Canonical structured-outputs mode (BEDROCK_STRUCTURED_OUTPUTS
+                # normalizes to this); use the canonical form for defaults, like
+                # every other provider builder.
+                default_mode = Mode.JSON_SCHEMA
+            elif "anthropic" in model_lower or "claude" in model_lower:
                 default_mode = Mode.TOOLS
             else:
                 default_mode = Mode.MD_JSON

--- a/instructor/v2/core/mode.py
+++ b/instructor/v2/core/mode.py
@@ -71,7 +71,9 @@ class Mode(enum.Enum):
     WRITER_TOOLS = "writer_tools"
     WRITER_JSON = "writer_json"
     BEDROCK_TOOLS = "bedrock_tools"
+    BEDROCK_TOOLS_STRICT = "bedrock_tools_strict"
     BEDROCK_JSON = "bedrock_json"
+    BEDROCK_STRUCTURED_OUTPUTS = "bedrock_structured_outputs"
     PERPLEXITY_JSON = "perplexity_json"
     OPENROUTER_STRUCTURED_OUTPUTS = "openrouter_structured_outputs"
 
@@ -96,6 +98,7 @@ class Mode(enum.Enum):
             cls.FIREWORKS_TOOLS,
             cls.WRITER_TOOLS,
             cls.BEDROCK_TOOLS,
+            cls.BEDROCK_TOOLS_STRICT,
             cls.OPENROUTER_STRUCTURED_OUTPUTS,
             cls.MISTRAL_STRUCTURED_OUTPUTS,
             cls.XAI_TOOLS,
@@ -120,6 +123,7 @@ class Mode(enum.Enum):
             cls.FIREWORKS_JSON,
             cls.WRITER_JSON,
             cls.BEDROCK_JSON,
+            cls.BEDROCK_STRUCTURED_OUTPUTS,
             cls.PERPLEXITY_JSON,
             cls.OPENROUTER_STRUCTURED_OUTPUTS,
             cls.MISTRAL_STRUCTURED_OUTPUTS,
@@ -235,7 +239,9 @@ DEPRECATED_TO_CORE: dict[Mode, Mode] = {
     Mode.WRITER_JSON: Mode.MD_JSON,
     # Bedrock legacy modes
     Mode.BEDROCK_TOOLS: Mode.TOOLS,
+    Mode.BEDROCK_TOOLS_STRICT: Mode.TOOLS_STRICT,
     Mode.BEDROCK_JSON: Mode.MD_JSON,
+    Mode.BEDROCK_STRUCTURED_OUTPUTS: Mode.JSON_SCHEMA,
     # Perplexity legacy modes
     Mode.PERPLEXITY_JSON: Mode.MD_JSON,
     # VertexAI legacy modes

--- a/instructor/v2/core/provider_specs.py
+++ b/instructor/v2/core/provider_specs.py
@@ -388,15 +388,21 @@ PROVIDER_SPECS: Mapping[Provider, ProviderSpec] = MappingProxyType(
             Provider.BEDROCK,
             aliases=("bedrock",),
             handler_module="instructor.v2.providers.bedrock.handlers",
-            supported_modes=(Mode.TOOLS, Mode.MD_JSON),
-            unsupported_modes=(
+            supported_modes=(
+                Mode.TOOLS,
+                Mode.TOOLS_STRICT,
+                Mode.MD_JSON,
                 Mode.JSON_SCHEMA,
+            ),
+            unsupported_modes=(
                 Mode.PARALLEL_TOOLS,
                 Mode.RESPONSES_TOOLS,
             ),
             legacy_modes={
                 Mode.BEDROCK_TOOLS: Mode.TOOLS,
+                Mode.BEDROCK_TOOLS_STRICT: Mode.TOOLS_STRICT,
                 Mode.BEDROCK_JSON: Mode.MD_JSON,
+                Mode.BEDROCK_STRUCTURED_OUTPUTS: Mode.JSON_SCHEMA,
             },
             from_function="from_bedrock",
             client_module="instructor.v2.providers.bedrock.client",

--- a/instructor/v2/core/providers.py
+++ b/instructor/v2/core/providers.py
@@ -66,7 +66,9 @@ def provider_from_mode(mode: Mode, default: Provider = Provider.OPENAI) -> Provi
         Mode.WRITER_TOOLS: Provider.WRITER,
         Mode.WRITER_JSON: Provider.WRITER,
         Mode.BEDROCK_TOOLS: Provider.BEDROCK,
+        Mode.BEDROCK_TOOLS_STRICT: Provider.BEDROCK,
         Mode.BEDROCK_JSON: Provider.BEDROCK,
+        Mode.BEDROCK_STRUCTURED_OUTPUTS: Provider.BEDROCK,
         Mode.PERPLEXITY_JSON: Provider.PERPLEXITY,
         Mode.OPENROUTER_STRUCTURED_OUTPUTS: Provider.OPENROUTER,
     }

--- a/instructor/v2/providers/bedrock/client.py
+++ b/instructor/v2/providers/bedrock/client.py
@@ -51,7 +51,9 @@ def from_bedrock(
     """Create an Instructor instance from a Bedrock client using v2 registry.
 
     Bedrock uses the Converse API through a boto3 BaseClient. This factory supports
-    TOOLS and MD_JSON modes, and can wrap calls in an async interface if needed.
+    TOOLS, TOOLS_STRICT, MD_JSON, and JSON_SCHEMA modes (the latter two also reachable
+    via the BEDROCK_TOOLS_STRICT and BEDROCK_STRUCTURED_OUTPUTS aliases), and can wrap
+    calls in an async interface if needed.
 
     Args:
         client: boto3 Bedrock Runtime client

--- a/instructor/v2/providers/bedrock/handlers.py
+++ b/instructor/v2/providers/bedrock/handlers.py
@@ -119,6 +119,33 @@ def reask_bedrock_tools(
     return kwargs
 
 
+def reask_bedrock_structured_outputs(
+    kwargs: dict[str, Any],
+    response: Any,
+    exception: Exception,
+):
+    """Handle reask for Bedrock structured outputs mode when validation fails.
+
+    Structured outputs return plain JSON text, so the correction flow is identical
+    to :func:`reask_bedrock_json`; ``outputConfig.textFormat`` lives in the original
+    request kwargs and is carried over untouched via the shallow copy.
+    """
+    return reask_bedrock_json(kwargs, response, exception)
+
+
+def reask_bedrock_tools_strict(
+    kwargs: dict[str, Any],
+    response: Any,
+    exception: Exception,
+):
+    """Handle reask for Bedrock strict tools mode when validation fails.
+
+    Same as :func:`reask_bedrock_tools` but preserves ``strict: true`` on the
+    tool spec that was set at request time.
+    """
+    return reask_bedrock_tools(kwargs, response, exception)
+
+
 def _normalize_bedrock_image_format(mime_or_ext: str) -> str:
     """Map common image types to Bedrock format enum."""
     if not mime_or_ext:
@@ -404,6 +431,107 @@ def handle_bedrock_tools(
     return response_model, new_kwargs
 
 
+def _set_additional_properties_false(schema: dict[str, Any]) -> None:
+    """Recursively set ``additionalProperties: false`` on object types in a schema.
+
+    Bedrock structured outputs (and strict tool use) requires every object type to
+    explicitly set ``additionalProperties`` to false. Pydantic doesn't include this
+    by default. Only sets the value when not already present, to respect
+    user-provided schemas.
+    """
+    if not isinstance(schema, dict):
+        return
+
+    if (
+        schema.get("type") == "object" or "properties" in schema
+    ) and "additionalProperties" not in schema:
+        schema["additionalProperties"] = False
+
+    # Recurse into properties
+    for prop in schema.get("properties", {}).values():
+        if isinstance(prop, dict):
+            _set_additional_properties_false(prop)
+
+    # Recurse into $defs and definitions (Pydantic v2 uses $defs, older uses definitions)
+    for defs_key in ("$defs", "definitions"):
+        for defn in schema.get(defs_key, {}).values():
+            if isinstance(defn, dict):
+                _set_additional_properties_false(defn)
+
+    # Recurse into items (for array types)
+    items = schema.get("items")
+    if isinstance(items, dict):
+        _set_additional_properties_false(items)
+
+    # Recurse into anyOf / oneOf / allOf
+    for key in ("anyOf", "oneOf", "allOf"):
+        for variant in schema.get(key, []):
+            if isinstance(variant, dict):
+                _set_additional_properties_false(variant)
+
+
+def handle_bedrock_structured_outputs(
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
+    """Handle Bedrock structured outputs mode via native constrained decoding.
+
+    Adds ``outputConfig.textFormat`` containing the model's JSON schema so Bedrock
+    guarantees schema-compliant JSON.
+    """
+    new_kwargs = _prepare_bedrock_converse_kwargs_internal(new_kwargs)
+
+    if response_model is None:
+        return None, new_kwargs
+
+    schema = response_model.model_json_schema()
+    _set_additional_properties_false(schema)
+    schema_name = response_model.__name__
+    schema_description = response_model.__doc__ or (
+        f"Correctly extracted `{schema_name}` with all "
+        "the required parameters with correct types"
+    )
+
+    new_kwargs["outputConfig"] = {
+        "textFormat": {
+            "type": "json_schema",
+            "structure": {
+                "jsonSchema": {
+                    "schema": json.dumps(schema),
+                    "name": schema_name,
+                    "description": schema_description,
+                }
+            },
+        }
+    }
+
+    return response_model, new_kwargs
+
+
+def handle_bedrock_tools_strict(
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
+    """Handle Bedrock strict tools mode with native constrained decoding.
+
+    Same as :func:`handle_bedrock_tools` but adds ``strict: true`` to the toolSpec,
+    enabling Bedrock's native schema enforcement on tool use.
+    """
+    new_kwargs = _prepare_bedrock_converse_kwargs_internal(new_kwargs)
+
+    if response_model is None:
+        return None, new_kwargs
+
+    tool_schema = generate_bedrock_schema(response_model)
+    tool_schema["toolSpec"]["strict"] = True
+    _set_additional_properties_false(tool_schema["toolSpec"]["inputSchema"]["json"])
+
+    new_kwargs["toolConfig"] = {
+        "tools": [tool_schema],
+        "toolChoice": {"tool": {"name": response_model.__name__}},
+    }
+
+    return response_model, new_kwargs
+
+
 def _extract_bedrock_text(response: Any) -> str:
     """Extract text from Bedrock response formats."""
     if isinstance(response, dict):
@@ -555,7 +683,105 @@ class BedrockMDJSONHandler(ModeHandler):
         )
 
 
+@register_mode_handler(Provider.BEDROCK, Mode.TOOLS_STRICT)
+class BedrockToolsStrictHandler(ModeHandler):
+    """Handler for Bedrock strict tool use (native constrained decoding)."""
+
+    mode = Mode.TOOLS_STRICT
+
+    def prepare_request(
+        self,
+        response_model: type[BaseModel] | None,
+        kwargs: dict[str, Any],
+    ) -> tuple[type[BaseModel] | None, dict[str, Any]]:
+        new_kwargs = kwargs.copy()
+        if response_model is None:
+            return handle_bedrock_tools_strict(None, new_kwargs)
+
+        prepared_model = cast(type[BaseModel], prepare_response_model(response_model))
+        return handle_bedrock_tools_strict(prepared_model, new_kwargs)
+
+    def handle_reask(
+        self,
+        kwargs: dict[str, Any],
+        response: Any,
+        exception: Exception,
+    ) -> dict[str, Any]:
+        return reask_bedrock_tools_strict(kwargs, response, exception)
+
+    def parse_response(
+        self,
+        response: Any,
+        response_model: type[BaseModel],
+        validation_context: dict[str, Any] | None = None,
+        strict: bool | None = None,
+        stream: bool = False,
+        is_async: bool = False,  # noqa: ARG002
+    ) -> BaseModel:
+        if stream:
+            raise ConfigurationError(
+                "Streaming is not supported for Bedrock in TOOLS_STRICT mode."
+            )
+        tool_input = _extract_bedrock_tool_input(response, response_model)
+        return response_model.model_validate(
+            tool_input,
+            context=validation_context,
+            strict=strict,
+        )
+
+
+@register_mode_handler(Provider.BEDROCK, Mode.JSON_SCHEMA)
+class BedrockStructuredOutputsHandler(ModeHandler):
+    """Handler for Bedrock native structured outputs (JSON schema decoding)."""
+
+    mode = Mode.JSON_SCHEMA
+
+    def prepare_request(
+        self,
+        response_model: type[BaseModel] | None,
+        kwargs: dict[str, Any],
+    ) -> tuple[type[BaseModel] | None, dict[str, Any]]:
+        new_kwargs = kwargs.copy()
+        if response_model is None:
+            return handle_bedrock_structured_outputs(None, new_kwargs)
+
+        prepared_model = cast(type[BaseModel], prepare_response_model(response_model))
+        return handle_bedrock_structured_outputs(prepared_model, new_kwargs)
+
+    def handle_reask(
+        self,
+        kwargs: dict[str, Any],
+        response: Any,
+        exception: Exception,
+    ) -> dict[str, Any]:
+        return reask_bedrock_structured_outputs(kwargs, response, exception)
+
+    def parse_response(
+        self,
+        response: Any,
+        response_model: type[BaseModel],
+        validation_context: dict[str, Any] | None = None,
+        strict: bool | None = None,
+        stream: bool = False,
+        is_async: bool = False,  # noqa: ARG002
+    ) -> BaseModel:
+        if stream:
+            raise ConfigurationError(
+                "Streaming is not supported for Bedrock in structured outputs mode."
+            )
+        # Bedrock's constrained decoding guarantees valid JSON, so no markdown
+        # unwrapping is needed here.
+        text = _extract_bedrock_text(response)
+        return response_model.model_validate_json(
+            text,
+            context=validation_context,
+            strict=strict,
+        )
+
+
 __all__ = [
     "BedrockToolsHandler",
     "BedrockMDJSONHandler",
+    "BedrockToolsStrictHandler",
+    "BedrockStructuredOutputsHandler",
 ]

--- a/tests/llm/test_bedrock/test_bedrock_structured_outputs.py
+++ b/tests/llm/test_bedrock/test_bedrock_structured_outputs.py
@@ -1,0 +1,383 @@
+"""Unit tests for Bedrock BEDROCK_STRUCTURED_OUTPUTS and BEDROCK_TOOLS_STRICT modes.
+
+These are pure unit tests (no real API calls) exercising the v2 Bedrock handlers
+and the registry wiring that backs the two native constrained-decoding modes.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, Field
+
+from instructor import Mode, Provider
+from instructor.v2.core.registry import mode_registry, normalize_mode
+from instructor.v2.core.mode import reset_deprecated_mode_warnings
+from instructor.v2.core.errors import ResponseParsingError
+from instructor.v2.providers.bedrock.handlers import (
+    handle_bedrock_structured_outputs,
+    handle_bedrock_tools_strict,
+    reask_bedrock_structured_outputs,
+    reask_bedrock_tools_strict,
+)
+
+
+# --- Test models ---
+
+
+class SimpleUser(BaseModel):
+    """A simple user model for testing."""
+
+    name: str
+    age: int
+
+
+class NestedAddress(BaseModel):
+    """A nested address model."""
+
+    street: str
+    city: str
+    zip_code: str = Field(description="5-digit ZIP code")
+
+
+class UserWithAddress(BaseModel):
+    """A user with a nested address."""
+
+    name: str
+    age: int
+    address: NestedAddress
+
+
+# --- handler tests: BEDROCK_STRUCTURED_OUTPUTS ---
+
+
+class TestHandleBedrockStructuredOutputs:
+    def test_returns_none_when_no_response_model(self):
+        result_model, result_kwargs = handle_bedrock_structured_outputs(
+            None,
+            {"model": "anthropic.claude-sonnet-4-5-v1", "messages": []},
+        )
+        assert result_model is None
+        assert "outputConfig" not in result_kwargs
+
+    def test_sets_output_config(self):
+        _, kwargs = handle_bedrock_structured_outputs(
+            SimpleUser,
+            {
+                "model": "anthropic.claude-sonnet-4-5-v1",
+                "messages": [{"role": "user", "content": "Extract user info"}],
+            },
+        )
+        assert "outputConfig" in kwargs
+        text_format = kwargs["outputConfig"]["textFormat"]
+        assert text_format["type"] == "json_schema"
+        json_schema = text_format["structure"]["jsonSchema"]
+        assert json_schema["name"] == "SimpleUser"
+        # schema must be a JSON string, not a dict
+        assert isinstance(json_schema["schema"], str)
+        parsed_schema = json.loads(json_schema["schema"])
+        assert "properties" in parsed_schema
+        assert "name" in parsed_schema["properties"]
+        assert "age" in parsed_schema["properties"]
+        # Bedrock requires additionalProperties: false on object schemas
+        assert parsed_schema["additionalProperties"] is False
+
+    def test_does_not_set_tool_config(self):
+        _, kwargs = handle_bedrock_structured_outputs(
+            SimpleUser,
+            {
+                "model": "anthropic.claude-sonnet-4-5-v1",
+                "messages": [{"role": "user", "content": "test"}],
+            },
+        )
+        assert "toolConfig" not in kwargs
+
+    def test_normalizes_kwargs(self):
+        _, kwargs = handle_bedrock_structured_outputs(
+            SimpleUser,
+            {
+                "model": "anthropic.claude-sonnet-4-5-v1",
+                "temperature": 0.5,
+                "max_tokens": 100,
+                "messages": [{"role": "user", "content": "test"}],
+            },
+        )
+        # model -> modelId
+        assert "modelId" in kwargs
+        assert "model" not in kwargs
+        # temperature/max_tokens -> inferenceConfig
+        assert kwargs["inferenceConfig"]["temperature"] == 0.5
+        assert kwargs["inferenceConfig"]["maxTokens"] == 100
+
+    def test_nested_model_schema(self):
+        _, kwargs = handle_bedrock_structured_outputs(
+            UserWithAddress,
+            {
+                "model": "anthropic.claude-sonnet-4-5-v1",
+                "messages": [{"role": "user", "content": "test"}],
+            },
+        )
+        schema_str = kwargs["outputConfig"]["textFormat"]["structure"]["jsonSchema"][
+            "schema"
+        ]
+        parsed = json.loads(schema_str)
+        # Should reference the nested model
+        assert "address" in parsed["properties"]
+        # additionalProperties: false must be applied to nested $defs too
+        nested = parsed["$defs"]["NestedAddress"]
+        assert nested["additionalProperties"] is False
+
+    def test_uses_docstring_as_description(self):
+        _, kwargs = handle_bedrock_structured_outputs(
+            SimpleUser,
+            {
+                "model": "anthropic.claude-sonnet-4-5-v1",
+                "messages": [{"role": "user", "content": "test"}],
+            },
+        )
+        desc = kwargs["outputConfig"]["textFormat"]["structure"]["jsonSchema"][
+            "description"
+        ]
+        assert desc == "A simple user model for testing."
+
+
+# --- handler tests: BEDROCK_TOOLS_STRICT ---
+
+
+class TestHandleBedrockToolsStrict:
+    def test_returns_none_when_no_response_model(self):
+        result_model, result_kwargs = handle_bedrock_tools_strict(
+            None,
+            {"model": "anthropic.claude-sonnet-4-5-v1", "messages": []},
+        )
+        assert result_model is None
+        assert "toolConfig" not in result_kwargs
+
+    def test_sets_strict_on_tool_spec(self):
+        _, kwargs = handle_bedrock_tools_strict(
+            SimpleUser,
+            {
+                "model": "anthropic.claude-sonnet-4-5-v1",
+                "messages": [{"role": "user", "content": "test"}],
+            },
+        )
+        assert "toolConfig" in kwargs
+        tool_spec = kwargs["toolConfig"]["tools"][0]["toolSpec"]
+        assert tool_spec["strict"] is True
+        assert tool_spec["name"] == "SimpleUser"
+        # additionalProperties: false must be applied to the tool input schema
+        assert tool_spec["inputSchema"]["json"]["additionalProperties"] is False
+
+    def test_tool_choice_set(self):
+        _, kwargs = handle_bedrock_tools_strict(
+            SimpleUser,
+            {
+                "model": "anthropic.claude-sonnet-4-5-v1",
+                "messages": [{"role": "user", "content": "test"}],
+            },
+        )
+        assert kwargs["toolConfig"]["toolChoice"] == {"tool": {"name": "SimpleUser"}}
+
+    def test_does_not_set_output_config(self):
+        _, kwargs = handle_bedrock_tools_strict(
+            SimpleUser,
+            {
+                "model": "anthropic.claude-sonnet-4-5-v1",
+                "messages": [{"role": "user", "content": "test"}],
+            },
+        )
+        assert "outputConfig" not in kwargs
+
+
+# --- reask tests ---
+
+
+class TestReaskBedrockStructuredOutputs:
+    def test_appends_messages(self):
+        original_kwargs: dict[str, Any] = {
+            "messages": [
+                {"role": "user", "content": [{"text": "Extract user"}]},
+            ],
+            "outputConfig": {
+                "textFormat": {
+                    "type": "json_schema",
+                    "structure": {"jsonSchema": {"schema": "{}", "name": "Test"}},
+                }
+            },
+        }
+        response = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [{"text": '{"name": "John"}'}],
+                }
+            }
+        }
+        exception = ValueError("Missing field: age")
+
+        result = reask_bedrock_structured_outputs(original_kwargs, response, exception)
+
+        # Should have 3 messages now: original user + assistant + correction user
+        assert len(result["messages"]) == 3
+        assert result["messages"][1]["role"] == "assistant"
+        assert result["messages"][2]["role"] == "user"
+        assert "age" in result["messages"][2]["content"][0]["text"]
+        # outputConfig should be preserved
+        assert "outputConfig" in result
+
+
+class TestReaskBedrockToolsStrict:
+    def test_delegates_to_reask_bedrock_tools(self):
+        original_kwargs: dict[str, Any] = {
+            "messages": [
+                {"role": "user", "content": [{"text": "test"}]},
+            ],
+        }
+        response = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "toolUse": {
+                                "toolUseId": "tool_123",
+                                "name": "SimpleUser",
+                                "input": {"name": "John"},
+                            }
+                        }
+                    ],
+                }
+            }
+        }
+        exception = ValueError("Missing field: age")
+        result = reask_bedrock_tools_strict(original_kwargs, response, exception)
+
+        # Should have appended assistant + tool result error messages
+        assert len(result["messages"]) == 3
+        tool_result = result["messages"][2]["content"][0]["toolResult"]
+        assert tool_result["toolUseId"] == "tool_123"
+        assert tool_result["status"] == "error"
+
+
+# --- registry wiring tests ---
+
+
+class TestBedrockRegistry:
+    def test_structured_outputs_alias_normalizes_to_json_schema(self):
+        # The provider-named alias is a deprecated shim for canonical JSON_SCHEMA:
+        # it still resolves correctly but warns to steer users to the canonical mode.
+        reset_deprecated_mode_warnings()
+        with pytest.warns(DeprecationWarning):
+            result = normalize_mode(Provider.BEDROCK, Mode.BEDROCK_STRUCTURED_OUTPUTS)
+        assert result is Mode.JSON_SCHEMA
+
+    def test_tools_strict_alias_normalizes_to_tools_strict(self):
+        reset_deprecated_mode_warnings()
+        with pytest.warns(DeprecationWarning):
+            result = normalize_mode(Provider.BEDROCK, Mode.BEDROCK_TOOLS_STRICT)
+        assert result is Mode.TOOLS_STRICT
+
+    def test_structured_outputs_handler_registered(self):
+        assert mode_registry.is_registered(
+            Provider.BEDROCK, Mode.BEDROCK_STRUCTURED_OUTPUTS
+        )
+        handlers = mode_registry.get_handlers(
+            Provider.BEDROCK, Mode.BEDROCK_STRUCTURED_OUTPUTS
+        )
+        assert handlers.response_parser is not None
+        assert handlers.reask_handler is not None
+
+    def test_tools_strict_handler_registered(self):
+        assert mode_registry.is_registered(Provider.BEDROCK, Mode.BEDROCK_TOOLS_STRICT)
+        handlers = mode_registry.get_handlers(
+            Provider.BEDROCK, Mode.BEDROCK_TOOLS_STRICT
+        )
+        assert handlers.response_parser is not None
+        assert handlers.reask_handler is not None
+
+
+# --- parse tests (via registered handlers) ---
+
+
+class TestParseBedrockStructuredOutputs:
+    @pytest.fixture
+    def parser(self):
+        return mode_registry.get_handlers(
+            Provider.BEDROCK, Mode.BEDROCK_STRUCTURED_OUTPUTS
+        ).response_parser
+
+    def test_parse_dict_response(self, parser):
+        completion = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [{"text": '{"name": "Alice", "age": 30}'}],
+                }
+            }
+        }
+        result = parser(completion, SimpleUser)
+        assert isinstance(result, SimpleUser)
+        assert result.name == "Alice"
+        assert result.age == 30
+
+    def test_parse_missing_text_raises(self, parser):
+        completion = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [{"image": {}}],
+                }
+            }
+        }
+        with pytest.raises(ResponseParsingError):
+            parser(completion, SimpleUser)
+
+
+class TestParseBedrockToolsStrict:
+    @pytest.fixture
+    def parser(self):
+        return mode_registry.get_handlers(
+            Provider.BEDROCK, Mode.BEDROCK_TOOLS_STRICT
+        ).response_parser
+
+    def test_parse_tool_use_response(self, parser):
+        """BEDROCK_TOOLS_STRICT parses tool use the same way as BEDROCK_TOOLS."""
+        completion = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "toolUse": {
+                                "toolUseId": "t1",
+                                "name": "SimpleUser",
+                                "input": {"name": "Bob", "age": 25},
+                            }
+                        }
+                    ],
+                }
+            }
+        }
+        result = parser(completion, SimpleUser)
+        assert isinstance(result, SimpleUser)
+        assert result.name == "Bob"
+        assert result.age == 25
+
+
+# --- Mode classification tests ---
+
+
+class TestModeClassification:
+    def test_structured_outputs_is_json_mode(self):
+        assert Mode.BEDROCK_STRUCTURED_OUTPUTS in Mode.json_modes()
+
+    def test_structured_outputs_is_not_tool_mode(self):
+        assert Mode.BEDROCK_STRUCTURED_OUTPUTS not in Mode.tool_modes()
+
+    def test_tools_strict_is_tool_mode(self):
+        assert Mode.BEDROCK_TOOLS_STRICT in Mode.tool_modes()
+
+    def test_tools_strict_is_not_json_mode(self):
+        assert Mode.BEDROCK_TOOLS_STRICT not in Mode.json_modes()

--- a/tests/v2/test_bedrock_client.py
+++ b/tests/v2/test_bedrock_client.py
@@ -64,4 +64,4 @@ class TestBedrockClientWithSDK:
         client.converse = _converse  # type: ignore[assignment]
 
         with pytest.raises(ModeError):
-            from_bedrock(client, mode=Mode.JSON_SCHEMA)
+            from_bedrock(client, mode=Mode.PARALLEL_TOOLS)


### PR DESCRIPTION
## Describe your changes

Add `BEDROCK_STRUCTURED_OUTPUTS` and `BEDROCK_TOOLS_STRICT` modes that leverage Bedrock's native constrained decoding ([announced Feb 2026](https://aws.amazon.com/about-aws/whats-new/2026/02/structured-outputs-available-amazon-bedrock/)) for guaranteed JSON schema compliance via the Converse API.

**What's included:**

- **`BEDROCK_STRUCTURED_OUTPUTS`** — uses `outputConfig.textFormat` with `json_schema` type for native schema-constrained text generation
- **`BEDROCK_TOOLS_STRICT`** — adds `strict: true` to `toolSpec` for native schema enforcement on tool use
- `_set_additional_properties_false()` helper to recursively patch Pydantic schemas (Bedrock requires `additionalProperties: false` on all object types)
- Handler, reask, and parser functions for both modes
- Auto-routing in `from_provider()` — models that support structured outputs default to `BEDROCK_STRUCTURED_OUTPUTS` instead of `BEDROCK_JSON`/`BEDROCK_TOOLS`
- 22 unit tests covering handlers, reask, parsing, registry, and mode classification

**Smoke-tested models (all pass first-try):**
- Anthropic: Claude Haiku 4.5, Sonnet 4.5, Opus 4.5, Opus 4.6
- Qwen: Qwen3 32B, Qwen3 Coder
- Google: Gemma 3 12B, 27B
- MiniMax: M2
- Mistral: Large 3, Ministral 8B, Voxtral Small
- Moonshot: Kimi K2 Thinking
- NVIDIA: Nemotron Nano 9B, 12B

**Known broken models** (excluded from auto-routing, documented):
- OpenAI GPT-OSS (all variants) — returns markdown-wrapped JSON, ignores `outputConfig`
- Mistral Magistral Small 2509 — returns free-form text, ignores `outputConfig`
- DeepSeek V3.2 — API rejects `outputConfig.textFormat` with `ValidationException`

## Issue ticket number and link

Closes #2084

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.