### PR TITLE
fix: include tool description in RESPONSES_TOOLS mode payload

### DIFF
--- a/instructor/providers/openai/utils.py
+++ b/instructor/providers/openai/utils.py
@@ -383,13 +383,7 @@ def handle_responses_tools(
             f"the required parameters with correct types"
         )
 
-    new_kwargs["tools"] = [
-        {
-            "type": "function",
-            "name": schema["function"]["name"],
-            "parameters": schema["function"]["parameters"],
-        }
-    ]
+    new_kwargs["tools"] = [tool_definition]
 
     new_kwargs["tool_choice"] = {
         "type": "function",

--- a/tests/test_process_response.py
+++ b/tests/test_process_response.py
@@ -1,7 +1,11 @@
 from typing_extensions import TypedDict
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from instructor.processing.response import handle_response_model
 from instructor.providers.bedrock.utils import _prepare_bedrock_converse_kwargs_internal
+from instructor.providers.openai.utils import (
+    handle_responses_tools,
+    handle_responses_tools_with_inbuilt_tools,
+)
 
 
 def test_typed_dict_conversion() -> None:
@@ -130,3 +134,49 @@ def test_bedrock_invalid_content_format() -> None:
         raise AssertionError("Should have raised ValueError")
     except ValueError as e:
         assert "Unsupported message content type for Bedrock" in str(e)
+
+
+def test_handle_responses_tools_includes_description() -> None:
+    """Tool description must be included in the RESPONSES_TOOLS payload."""
+
+    class User(BaseModel):
+        """Extract a user from text."""
+
+        name: str = Field(description="The user's full name")
+        age: int
+
+    _, new_kwargs = handle_responses_tools(User, {})
+    tool = new_kwargs["tools"][0]
+    assert "description" in tool, "tool description missing from RESPONSES_TOOLS payload"
+    assert tool["description"] == "Extract a user from text."
+
+
+def test_handle_responses_tools_fallback_description() -> None:
+    """Models without a docstring get a generated description."""
+
+    class Item(BaseModel):
+        title: str
+
+    _, new_kwargs = handle_responses_tools(Item, {})
+    tool = new_kwargs["tools"][0]
+    assert "description" in tool
+    assert "Item" in tool["description"]
+
+
+def test_handle_responses_tools_matches_inbuilt_tools_format() -> None:
+    """RESPONSES_TOOLS and RESPONSES_TOOLS_WITH_INBUILT_TOOLS must produce
+    the same tool definition for an identical response model."""
+
+    class Order(BaseModel):
+        """Process an order."""
+
+        product: str
+        quantity: int
+
+    _, kwargs_plain = handle_responses_tools(Order, {})
+    _, kwargs_inbuilt = handle_responses_tools_with_inbuilt_tools(Order, {})
+
+    plain_tool = kwargs_plain["tools"][0]
+    inbuilt_tool = kwargs_inbuilt["tools"][0]
+
+    assert plain_tool == inbuilt_tool


### PR DESCRIPTION
## Describe your changes

`handle_responses_tools()` builds a `tool_definition` dict with proper description handling (from the model docstring or a fallback), but then discards it and creates a new inline dict without the `description` field. The sibling function `handle_responses_tools_with_inbuilt_tools()` already uses `tool_definition` correctly — this brings the two functions into consistency.

**Before:** RESPONSES_TOOLS mode silently drops the tool description from the API payload.
**After:** The description is included, matching the behavior of RESPONSES_TOOLS_WITH_INBUILT_TOOLS mode.

```python
# Before (line 386–392) — tool_definition built above but ignored:
new_kwargs["tools"] = [
    {
        "type": "function",
        "name": schema["function"]["name"],
        "parameters": schema["function"]["parameters"],
    }
]

# After — uses the already-correct variable:
new_kwargs["tools"] = [tool_definition]
```

## Issue ticket number and link

No existing issue — found while reading `handle_responses_tools` alongside `handle_responses_tools_with_inbuilt_tools` in `instructor/providers/openai/utils.py`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.