### PR TITLE
fix: preserve true partial streaming behavior

### DIFF
--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -157,22 +157,9 @@ def _build_streaming_reask_kwargs(
 ) -> dict[str, Any]:
     """Build a generic retry prompt when the provider-specific reask path cannot inspect a stream."""
     kwargs_copy = kwargs.copy()
-
     retry_prompt = _build_streaming_retry_prompt(exception)
 
-    if "contents" in kwargs_copy:
-        contents = kwargs_copy.get("contents")
-        if isinstance(contents, list):
-            contents_copy = contents.copy()
-        elif contents is None:
-            contents_copy = []
-        else:
-            contents_copy = list(contents)
-
-        contents_copy.append({"role": "user", "parts": [retry_prompt]})
-        kwargs_copy["contents"] = contents_copy
-        return kwargs_copy
-
+    # Cohere V1 uses chat_history + message (not messages/contents).
     if "chat_history" in kwargs_copy or "message" in kwargs_copy:
         chat_history = kwargs_copy.get("chat_history")
         if isinstance(chat_history, list):
@@ -183,27 +170,77 @@ def _build_streaming_reask_kwargs(
             chat_history_copy = list(chat_history)
 
         message = kwargs_copy.get("message")
-        if message is not None:
+        if message is not None and message != "":
             chat_history_copy.append({"role": "user", "message": message})
 
         kwargs_copy["chat_history"] = chat_history_copy
         kwargs_copy["message"] = retry_prompt
         return kwargs_copy
 
-    messages = list(extract_messages(kwargs_copy))
+    # Gemini/GenAI/VertexAI commonly use "contents".
+    if "contents" in kwargs_copy:
+        contents = kwargs_copy.get("contents")
+        if isinstance(contents, list):
+            contents_copy = contents.copy()
+        elif contents is None:
+            contents_copy = []
+        else:
+            contents_copy = list(contents)
+
+        # Preserve the contents item type when possible (optional deps).
+        sample = next((c for c in contents_copy if c is not None), None)
+        module = getattr(type(sample), "__module__", "") if sample is not None else ""
+
+        if module.startswith("google.genai."):
+            try:
+                from google.genai import types  # type: ignore[import-not-found]
+
+                contents_copy.append(
+                    types.Content(
+                        role="user",
+                        parts=[types.Part.from_text(text=retry_prompt)],
+                    )
+                )
+            except Exception:
+                contents_copy.append({"role": "user", "parts": [retry_prompt]})
+        elif module.startswith("vertexai."):
+            try:
+                import vertexai.generative_models as gm  # type: ignore[import-not-found]
+
+                contents_copy.append(
+                    gm.Content(role="user", parts=[gm.Part.from_text(retry_prompt)])
+                )
+            except Exception:
+                contents_copy.append({"role": "user", "parts": [retry_prompt]})
+        else:
+            # Gemini (dict) and safe fallback for unknown content types.
+            contents_copy.append({"role": "user", "parts": [retry_prompt]})
+
+        kwargs_copy["contents"] = contents_copy
+        return kwargs_copy
+
+    # Default: OpenAI-style messages.
+    messages = list(kwargs_copy.get("messages") or [])
     messages.append({"role": "user", "content": retry_prompt})
     kwargs_copy["messages"] = messages
     return kwargs_copy
 
 
-def _should_fallback_to_streaming_reask(exception: Exception, response: Any) -> bool:
+def _should_fallback_to_streaming_reask(
+    exception: Exception,
+    response: Any,  # noqa: ARG001
+) -> bool:
     """Return True when a provider reask handler failed because it inspected a stream."""
     if not isinstance(exception, AttributeError):
         return False
 
-    if getattr(exception, "name", None) not in {"choices", "output"}:
+    expected_attrs = {"choices", "output", "candidates", "parts", "message", "text"}
+    attr_name = getattr(exception, "name", None)
+    if attr_name not in expected_attrs:
         message = str(exception)
-        if "choices" not in message and "output" not in message:
+        if "has no attribute" not in message or not any(
+            f"has no attribute '{a}'" in message for a in expected_attrs
+        ):
             return False
 
     response_type = type(response).__name__.lower() if response is not None else ""
@@ -229,7 +266,8 @@ def _handle_reask_kwargs_with_streaming_fallback(
         if _should_fallback_to_streaming_reask(e, response):
             logger.debug(
                 "Provider reask handler could not inspect streaming response; "
-                "falling back to a generic retry prompt."
+                "falling back to a generic retry prompt.",
+                exc_info=e,
             )
             return _build_streaming_reask_kwargs(kwargs, exception)
         raise
@@ -341,7 +379,6 @@ def retry_sync(
                                 max_attempts=max_attempt_number,
                                 is_last_attempt=True,
                             )
-
                     kwargs = _handle_reask_kwargs_with_streaming_fallback(
                         kwargs=kwargs,
                         mode=mode,
@@ -520,7 +557,6 @@ async def retry_async(
                                 max_attempts=max_attempt_number,
                                 is_last_attempt=True,
                             )
-
                     kwargs = _handle_reask_kwargs_with_streaming_fallback(
                         kwargs=kwargs,
                         mode=mode,

--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -145,23 +145,94 @@ def extract_messages(kwargs: dict[str, Any]) -> Any:
     return []
 
 
+def _build_streaming_retry_prompt(exception: Exception) -> str:
+    return (
+        f"Validation Error found:\n{exception}\n"
+        "Recall the function correctly, fix the errors"
+    )
+
+
 def _build_streaming_reask_kwargs(
     kwargs: dict[str, Any], exception: Exception
 ) -> dict[str, Any]:
     """Build a generic retry prompt when the provider-specific reask path cannot inspect a stream."""
     kwargs_copy = kwargs.copy()
+
+    retry_prompt = _build_streaming_retry_prompt(exception)
+
+    if "contents" in kwargs_copy:
+        contents = kwargs_copy.get("contents")
+        if isinstance(contents, list):
+            contents_copy = contents.copy()
+        elif contents is None:
+            contents_copy = []
+        else:
+            contents_copy = list(contents)
+
+        contents_copy.append({"role": "user", "parts": [retry_prompt]})
+        kwargs_copy["contents"] = contents_copy
+        return kwargs_copy
+
+    if "chat_history" in kwargs_copy or "message" in kwargs_copy:
+        chat_history = kwargs_copy.get("chat_history")
+        if isinstance(chat_history, list):
+            chat_history_copy = chat_history.copy()
+        elif chat_history is None:
+            chat_history_copy = []
+        else:
+            chat_history_copy = list(chat_history)
+
+        message = kwargs_copy.get("message")
+        if message is not None:
+            chat_history_copy.append({"role": "user", "message": message})
+
+        kwargs_copy["chat_history"] = chat_history_copy
+        kwargs_copy["message"] = retry_prompt
+        return kwargs_copy
+
     messages = list(extract_messages(kwargs_copy))
-    messages.append(
-        {
-            "role": "user",
-            "content": (
-                f"Validation Error found:\n{exception}\n"
-                "Recall the function correctly, fix the errors"
-            ),
-        }
-    )
+    messages.append({"role": "user", "content": retry_prompt})
     kwargs_copy["messages"] = messages
     return kwargs_copy
+
+
+def _should_fallback_to_streaming_reask(exception: Exception, response: Any) -> bool:
+    """Return True when a provider reask handler failed because it inspected a stream."""
+    if not isinstance(exception, AttributeError):
+        return False
+
+    if getattr(exception, "name", None) not in {"choices", "output"}:
+        message = str(exception)
+        if "choices" not in message and "output" not in message:
+            return False
+
+    response_type = type(response).__name__.lower() if response is not None else ""
+    return "stream" in response_type
+
+
+def _handle_reask_kwargs_with_streaming_fallback(
+    kwargs: dict[str, Any],
+    mode: Mode,
+    response: Any,
+    exception: Exception,
+    failed_attempts: list[Any] | None = None,
+) -> dict[str, Any]:
+    try:
+        return handle_reask_kwargs(
+            kwargs=kwargs,
+            mode=mode,
+            response=response,
+            exception=exception,
+            failed_attempts=failed_attempts,
+        )
+    except AttributeError as e:
+        if _should_fallback_to_streaming_reask(e, response):
+            logger.debug(
+                "Provider reask handler could not inspect streaming response; "
+                "falling back to a generic retry prompt."
+            )
+            return _build_streaming_reask_kwargs(kwargs, exception)
+        raise
 
 
 def retry_sync(
@@ -271,20 +342,13 @@ def retry_sync(
                                 is_last_attempt=True,
                             )
 
-                    try:
-                        kwargs = handle_reask_kwargs(
-                            kwargs=kwargs,
-                            mode=mode,
-                            response=response,
-                            exception=e,
-                            failed_attempts=failed_attempts,
-                        )
-                    except AttributeError:
-                        logger.debug(
-                            "Provider reask handler could not inspect streaming response; "
-                            "falling back to a generic retry prompt."
-                        )
-                        kwargs = _build_streaming_reask_kwargs(kwargs, e)
+                    kwargs = _handle_reask_kwargs_with_streaming_fallback(
+                        kwargs=kwargs,
+                        mode=mode,
+                        response=response,
+                        exception=e,
+                        failed_attempts=failed_attempts,
+                    )
                     raise e
                 except Exception as e:
                     # Emit completion:error for non-validation errors (API errors, network errors, etc.)
@@ -457,20 +521,13 @@ async def retry_async(
                                 is_last_attempt=True,
                             )
 
-                    try:
-                        kwargs = handle_reask_kwargs(
-                            kwargs=kwargs,
-                            mode=mode,
-                            response=response,
-                            exception=e,
-                            failed_attempts=failed_attempts,
-                        )
-                    except AttributeError:
-                        logger.debug(
-                            "Provider reask handler could not inspect streaming response; "
-                            "falling back to a generic retry prompt."
-                        )
-                        kwargs = _build_streaming_reask_kwargs(kwargs, e)
+                    kwargs = _handle_reask_kwargs_with_streaming_fallback(
+                        kwargs=kwargs,
+                        mode=mode,
+                        response=response,
+                        exception=e,
+                        failed_attempts=failed_attempts,
+                    )
                     raise e
                 except Exception as e:
                     # Emit completion:error for non-validation errors (API errors, network errors, etc.)

--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -145,6 +145,25 @@ def extract_messages(kwargs: dict[str, Any]) -> Any:
     return []
 
 
+def _build_streaming_reask_kwargs(
+    kwargs: dict[str, Any], exception: Exception
+) -> dict[str, Any]:
+    """Build a generic retry prompt when the provider-specific reask path cannot inspect a stream."""
+    kwargs_copy = kwargs.copy()
+    messages = list(extract_messages(kwargs_copy))
+    messages.append(
+        {
+            "role": "user",
+            "content": (
+                f"Validation Error found:\n{exception}\n"
+                "Recall the function correctly, fix the errors"
+            ),
+        }
+    )
+    kwargs_copy["messages"] = messages
+    return kwargs_copy
+
+
 def retry_sync(
     func: Callable[T_ParamSpec, T_Retval],
     response_model: type[T_Model] | None,
@@ -252,13 +271,20 @@ def retry_sync(
                                 is_last_attempt=True,
                             )
 
-                    kwargs = handle_reask_kwargs(
-                        kwargs=kwargs,
-                        mode=mode,
-                        response=response,
-                        exception=e,
-                        failed_attempts=failed_attempts,
-                    )
+                    try:
+                        kwargs = handle_reask_kwargs(
+                            kwargs=kwargs,
+                            mode=mode,
+                            response=response,
+                            exception=e,
+                            failed_attempts=failed_attempts,
+                        )
+                    except AttributeError:
+                        logger.debug(
+                            "Provider reask handler could not inspect streaming response; "
+                            "falling back to a generic retry prompt."
+                        )
+                        kwargs = _build_streaming_reask_kwargs(kwargs, e)
                     raise e
                 except Exception as e:
                     # Emit completion:error for non-validation errors (API errors, network errors, etc.)
@@ -431,13 +457,20 @@ async def retry_async(
                                 is_last_attempt=True,
                             )
 
-                    kwargs = handle_reask_kwargs(
-                        kwargs=kwargs,
-                        mode=mode,
-                        response=response,
-                        exception=e,
-                        failed_attempts=failed_attempts,
-                    )
+                    try:
+                        kwargs = handle_reask_kwargs(
+                            kwargs=kwargs,
+                            mode=mode,
+                            response=response,
+                            exception=e,
+                            failed_attempts=failed_attempts,
+                        )
+                    except AttributeError:
+                        logger.debug(
+                            "Provider reask handler could not inspect streaming response; "
+                            "falling back to a generic retry prompt."
+                        )
+                        kwargs = _build_streaming_reask_kwargs(kwargs, e)
                     raise e
                 except Exception as e:
                     # Emit completion:error for non-validation errors (API errors, network errors, etc.)

--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 from json import JSONDecodeError
 from typing import Any, Callable, TypeVar
@@ -152,6 +153,39 @@ def _build_streaming_retry_prompt(exception: Exception) -> str:
     )
 
 
+def _append_streaming_retry_content(contents: list[Any], retry_prompt: str) -> None:
+    sample = next((item for item in contents if item is not None), None)
+    module_name = getattr(type(sample), "__module__", "") if sample is not None else ""
+
+    if module_name.startswith("google.genai"):
+        try:
+            genai_types = importlib.import_module("google.genai.types")
+            contents.append(
+                genai_types.Content(
+                    role="user",
+                    parts=[genai_types.Part.from_text(text=retry_prompt)],
+                )
+            )
+            return
+        except Exception:
+            pass
+
+    if module_name.startswith("vertexai."):
+        try:
+            gm = importlib.import_module("vertexai.generative_models")
+            contents.append(
+                gm.Content(
+                    role="user",
+                    parts=[gm.Part.from_text(retry_prompt)],
+                )
+            )
+            return
+        except Exception:
+            pass
+
+    contents.append({"role": "user", "parts": [retry_prompt]})
+
+
 def _build_streaming_reask_kwargs(
     kwargs: dict[str, Any], exception: Exception
 ) -> dict[str, Any]:
@@ -187,35 +221,7 @@ def _build_streaming_reask_kwargs(
         else:
             contents_copy = list(contents)
 
-        # Preserve the contents item type when possible (optional deps).
-        sample = next((c for c in contents_copy if c is not None), None)
-        module = getattr(type(sample), "__module__", "") if sample is not None else ""
-
-        if module.startswith("google.genai."):
-            try:
-                from google.genai import types  # type: ignore[import-not-found]
-
-                contents_copy.append(
-                    types.Content(
-                        role="user",
-                        parts=[types.Part.from_text(text=retry_prompt)],
-                    )
-                )
-            except Exception:
-                contents_copy.append({"role": "user", "parts": [retry_prompt]})
-        elif module.startswith("vertexai."):
-            try:
-                import vertexai.generative_models as gm  # type: ignore[import-not-found]
-
-                contents_copy.append(
-                    gm.Content(role="user", parts=[gm.Part.from_text(retry_prompt)])
-                )
-            except Exception:
-                contents_copy.append({"role": "user", "parts": [retry_prompt]})
-        else:
-            # Gemini (dict) and safe fallback for unknown content types.
-            contents_copy.append({"role": "user", "parts": [retry_prompt]})
-
+        _append_streaming_retry_content(contents_copy, retry_prompt)
         kwargs_copy["contents"] = contents_copy
         return kwargs_copy
 

--- a/instructor/processing/response.py
+++ b/instructor/processing/response.py
@@ -241,7 +241,7 @@ async def process_response_async(
         and issubclass(response_model, PartialBase)
         and stream
     ):
-        # Return the AsyncGenerator directly for streaming Partial responses.
+        # Preserve streaming behavior for `create_partial()`.
         return response_model.from_streaming_response_async(  # type: ignore[return-value,arg-type]
             cast(AsyncGenerator[Any, None], response),
             mode=mode,
@@ -359,12 +359,10 @@ def process_response(
         and issubclass(response_model, PartialBase)
         and stream
     ):
-        # Collect partial stream to surface validation errors inside retry logic.
-        return list(
-            response_model.from_streaming_response(  # type: ignore
-                response,
-                mode=mode,
-            )
+        # Preserve streaming behavior for `create_partial()`.
+        return response_model.from_streaming_response(  # type: ignore[return-value]
+            response,
+            mode=mode,
         )
 
     model = response_model.from_response(  # type: ignore

--- a/tests/test_process_response_streaming.py
+++ b/tests/test_process_response_streaming.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Generator
+
+import pytest
+from pydantic import BaseModel
+
+from instructor.dsl.iterable import IterableBase
+from instructor.dsl.partial import PartialBase
+from instructor.mode import Mode
+from instructor.processing.response import process_response, process_response_async
+
+
+class DummyCompletion(BaseModel):
+    """Minimal stand-in for a provider completion object."""
+
+
+class DummyIterableModel(BaseModel, IterableBase):
+    tasks: list[int]
+
+    @classmethod
+    def from_response(cls, completion, **kwargs):  # noqa: ANN001,ARG003
+        return cls(tasks=[1, 2])
+
+    @classmethod
+    def from_streaming_response(  # noqa: ANN001
+        cls, _completion, mode: Mode, **_kwargs
+    ) -> Generator[int, None, None]:
+        del mode
+        yield 1
+        yield 2
+
+    @classmethod
+    async def from_streaming_response_async(  # noqa: ANN001
+        cls, _completion, mode: Mode, **_kwargs
+    ) -> AsyncGenerator[int, None]:
+        del mode
+        yield 1
+        yield 2
+
+
+class DummyPartialModel(BaseModel, PartialBase):
+    value: str | None = None
+
+    @classmethod
+    def from_response(cls, completion, **kwargs):  # noqa: ANN001,ARG003
+        return cls(value="final")
+
+    @classmethod
+    def from_streaming_response(  # noqa: ANN001
+        cls, _completion, mode: Mode, **_kwargs
+    ) -> Generator[BaseModel, None, None]:
+        del mode
+        yield cls(value=None)
+        yield cls(value="streamed")
+
+    @classmethod
+    async def from_streaming_response_async(  # noqa: ANN001
+        cls, _completion, mode: Mode, **_kwargs
+    ) -> AsyncGenerator[BaseModel, None]:
+        del mode
+        yield cls(value=None)
+        yield cls(value="streamed")
+
+
+def test_process_response_streaming_returns_generator_for_partial_model():
+    raw = DummyCompletion()
+
+    result = process_response(
+        raw,
+        response_model=DummyPartialModel,
+        stream=True,
+        mode=Mode.TOOLS,
+    )
+
+    assert not isinstance(result, list)
+    assert list(result) == [
+        DummyPartialModel(value=None),
+        DummyPartialModel(value="streamed"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_response_async_streaming_returns_async_generator_for_partial_model():
+    async def completion_stream() -> AsyncGenerator[object, None]:
+        yield object()
+
+    result = await process_response_async(
+        completion_stream(),  # type: ignore[arg-type]
+        response_model=DummyPartialModel,
+        stream=True,
+        mode=Mode.TOOLS,
+    )
+
+    collected: list[DummyPartialModel] = []
+    async for item in result:
+        collected.append(item)
+
+    assert collected == [
+        DummyPartialModel(value=None),
+        DummyPartialModel(value="streamed"),
+    ]
+
+
+def test_process_response_streaming_preserves_iterable_generator_behavior():
+    raw = DummyCompletion()
+
+    result = process_response(
+        raw,
+        response_model=DummyIterableModel,
+        stream=True,
+        mode=Mode.TOOLS,
+    )
+
+    assert list(result) == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_process_response_async_streaming_preserves_iterable_generator_behavior():
+    async def completion_stream() -> AsyncGenerator[object, None]:
+        yield object()
+
+    result = await process_response_async(
+        completion_stream(),  # type: ignore[arg-type]
+        response_model=DummyIterableModel,
+        stream=True,
+        mode=Mode.TOOLS,
+    )
+
+    collected: list[int] = []
+    async for item in result:
+        collected.append(item)
+
+    assert collected == [1, 2]

--- a/tests/test_streaming_reask_bug.py
+++ b/tests/test_streaming_reask_bug.py
@@ -13,7 +13,12 @@ import pytest
 from pydantic import ValidationError, BaseModel, field_validator
 
 from instructor.core.exceptions import InstructorRetryException
-from instructor.core.retry import retry_sync
+from instructor.core.retry import (
+    _build_streaming_reask_kwargs,
+    _handle_reask_kwargs_with_streaming_fallback,
+    _should_fallback_to_streaming_reask,
+    retry_sync,
+)
 from instructor.mode import Mode
 from instructor.processing.response import handle_reask_kwargs
 
@@ -183,6 +188,76 @@ class TestStreamingReaskBug:
         )
 
         assert "messages" in result
+
+    def test_build_streaming_reask_kwargs_preserves_provider_shape(self):
+        """Test that the fallback keeps provider-specific containers when present."""
+        exception = create_mock_validation_error()
+
+        gemini_kwargs = {
+            "contents": [{"role": "user", "parts": ["test"]}],
+            "tools": [{"type": "function", "function": {"name": "test"}}],
+        }
+        gemini_result = _build_streaming_reask_kwargs(gemini_kwargs, exception)
+
+        assert "contents" in gemini_result
+        assert "messages" not in gemini_result
+        assert gemini_result["contents"][-1]["role"] == "user"
+        assert gemini_result["contents"][-1]["parts"][0].startswith(
+            "Validation Error found:\n"
+        )
+        assert (
+            "Recall the function correctly, fix the errors"
+            in gemini_result["contents"][-1]["parts"][0]
+        )
+
+        cohere_kwargs = {
+            "chat_history": [{"role": "user", "message": "prior"}],
+            "message": "current",
+        }
+        cohere_result = _build_streaming_reask_kwargs(cohere_kwargs, exception)
+
+        assert "chat_history" in cohere_result
+        assert "messages" not in cohere_result
+        assert cohere_result["chat_history"][-1] == {
+            "role": "user",
+            "message": "current",
+        }
+        assert cohere_result["message"].startswith("Validation Error found:\n")
+
+    def test_streaming_fallback_helper_rejects_unrelated_attribute_error(
+        self, monkeypatch
+    ):
+        """Test that only the known stream-inspection AttributeError uses the fallback."""
+        from instructor.core import retry as retry_module
+
+        validation_error = create_mock_validation_error()
+
+        def fake_handle_reask_kwargs(
+            kwargs: dict[str, Any],
+            mode: Mode,
+            response: Any,
+            exception: Exception,
+            failed_attempts: list[Any] | None = None,
+        ) -> dict[str, Any]:
+            del kwargs, mode, response, exception, failed_attempts
+            raise AttributeError("'Stream' object has no attribute 'something_else'")
+
+        monkeypatch.setattr(
+            retry_module, "handle_reask_kwargs", fake_handle_reask_kwargs
+        )
+
+        with pytest.raises(AttributeError, match="something_else"):
+            _handle_reask_kwargs_with_streaming_fallback(
+                kwargs={"messages": [{"role": "user", "content": "test"}]},
+                mode=Mode.TOOLS,
+                response=MockStream(),
+                exception=validation_error,
+            )
+
+        assert not _should_fallback_to_streaming_reask(
+            AttributeError("'Stream' object has no attribute 'something_else'"),
+            MockStream(),
+        )
 
     def test_retry_sync_falls_back_when_reask_handler_cannot_inspect_stream(
         self, monkeypatch

--- a/tests/test_streaming_reask_bug.py
+++ b/tests/test_streaming_reask_bug.py
@@ -7,6 +7,8 @@ because they expect a ChatCompletion but receive a Stream object.
 GitHub Issue: https://github.com/jxnl/instructor/issues/1991
 """
 
+import sys
+import types
 from typing import Any, Optional
 
 import pytest
@@ -223,6 +225,103 @@ class TestStreamingReaskBug:
             "message": "current",
         }
         assert cohere_result["message"].startswith("Validation Error found:\n")
+
+    def test_build_streaming_reask_kwargs_preserves_google_genai_content_type(
+        self, monkeypatch
+    ):
+        exception = create_mock_validation_error()
+
+        class FakeGenAIContent:
+            __module__ = "google.genai.types"
+
+            def __init__(self, role: str, parts: list[Any]) -> None:
+                self.role = role
+                self.parts = parts
+
+        class FakeGenAIPart:
+            __module__ = "google.genai.types"
+
+            @classmethod
+            def from_text(cls, *, text: str) -> dict[str, str]:
+                return {"text": text}
+
+        google_module = types.ModuleType("google")
+        genai_module = types.ModuleType("google.genai")
+        genai_types_module = types.ModuleType("google.genai.types")
+        genai_types_module.Content = FakeGenAIContent
+        genai_types_module.Part = FakeGenAIPart
+        genai_module.types = genai_types_module
+        google_module.genai = genai_module
+
+        monkeypatch.setitem(sys.modules, "google", google_module)
+        monkeypatch.setitem(sys.modules, "google.genai", genai_module)
+        monkeypatch.setitem(sys.modules, "google.genai.types", genai_types_module)
+
+        result = _build_streaming_reask_kwargs(
+            {"contents": [FakeGenAIContent(role="user", parts=[{"text": "prior"}])]},
+            exception,
+        )
+
+        appended = result["contents"][-1]
+        assert isinstance(appended, FakeGenAIContent)
+        assert appended.role == "user"
+        assert appended.parts == [
+            {
+                "text": (
+                    "Validation Error found:\n"
+                    f"{exception}\n"
+                    "Recall the function correctly, fix the errors"
+                )
+            }
+        ]
+
+    def test_build_streaming_reask_kwargs_preserves_vertexai_content_type(
+        self, monkeypatch
+    ):
+        exception = create_mock_validation_error()
+
+        class FakeVertexPart:
+            __module__ = "vertexai.generative_models"
+
+            @classmethod
+            def from_text(cls, text: str) -> dict[str, str]:
+                return {"text": text}
+
+        class FakeVertexContent:
+            __module__ = "vertexai.generative_models"
+
+            def __init__(self, role: str, parts: list[Any]) -> None:
+                self.role = role
+                self.parts = parts
+
+        vertexai_module = types.ModuleType("vertexai")
+        generative_models_module = types.ModuleType("vertexai.generative_models")
+        generative_models_module.Part = FakeVertexPart
+        generative_models_module.Content = FakeVertexContent
+        vertexai_module.generative_models = generative_models_module
+
+        monkeypatch.setitem(sys.modules, "vertexai", vertexai_module)
+        monkeypatch.setitem(
+            sys.modules, "vertexai.generative_models", generative_models_module
+        )
+
+        result = _build_streaming_reask_kwargs(
+            {"contents": [FakeVertexContent(role="user", parts=[{"text": "prior"}])]},
+            exception,
+        )
+
+        appended = result["contents"][-1]
+        assert isinstance(appended, FakeVertexContent)
+        assert appended.role == "user"
+        assert appended.parts == [
+            {
+                "text": (
+                    "Validation Error found:\n"
+                    f"{exception}\n"
+                    "Recall the function correctly, fix the errors"
+                )
+            }
+        ]
 
     def test_streaming_fallback_helper_rejects_unrelated_attribute_error(
         self, monkeypatch

--- a/tests/test_streaming_reask_bug.py
+++ b/tests/test_streaming_reask_bug.py
@@ -12,6 +12,8 @@ from typing import Any, Optional
 import pytest
 from pydantic import ValidationError, BaseModel, field_validator
 
+from instructor.core.exceptions import InstructorRetryException
+from instructor.core.retry import retry_sync
 from instructor.mode import Mode
 from instructor.processing.response import handle_reask_kwargs
 
@@ -182,6 +184,72 @@ class TestStreamingReaskBug:
 
         assert "messages" in result
 
+    def test_retry_sync_falls_back_when_reask_handler_cannot_inspect_stream(
+        self, monkeypatch
+    ):
+        """Test that retry handling falls back to a generic prompt for raw streams."""
+
+        from instructor.core import retry as retry_module
+
+        validation_error = create_mock_validation_error()
+        fallback_calls: list[dict[str, Any]] = []
+
+        def fake_process_response(*args, **kwargs):  # noqa: ANN001,ARG001
+            raise validation_error
+
+        def fake_handle_reask_kwargs(
+            kwargs: dict[str, Any],
+            mode: Mode,
+            response: Any,
+            exception: Exception,
+            failed_attempts: list[Any] | None = None,  # noqa: ARG001
+        ) -> dict[str, Any]:
+            del kwargs, mode, exception, failed_attempts
+            if response is not None:
+                raise AttributeError("'Stream' object has no attribute 'choices'")
+            return {"messages": [{"role": "user", "content": "fallback"}]}
+
+        def fake_build_streaming_reask_kwargs(
+            kwargs: dict[str, Any], exception: Exception
+        ) -> dict[str, Any]:
+            fallback_calls.append({"kwargs": kwargs.copy(), "exception": exception})
+            return {
+                **kwargs,
+                "messages": [
+                    *kwargs.get("messages", []),
+                    {"role": "user", "content": "fallback"},
+                ],
+            }
+
+        monkeypatch.setattr(retry_module, "process_response", fake_process_response)
+        monkeypatch.setattr(
+            retry_module, "handle_reask_kwargs", fake_handle_reask_kwargs
+        )
+        monkeypatch.setattr(
+            retry_module,
+            "_build_streaming_reask_kwargs",
+            fake_build_streaming_reask_kwargs,
+        )
+
+        def fake_func(*args, **kwargs):  # noqa: ANN001,ARG001
+            return MockStream()
+
+        with pytest.raises(InstructorRetryException):
+            retry_sync(
+                func=fake_func,
+                response_model=None,
+                args=(),
+                kwargs={
+                    "messages": [{"role": "user", "content": "test"}],
+                    "stream": True,
+                },
+                mode=Mode.TOOLS,
+                max_retries=1,
+            )
+
+        assert fallback_calls
+        assert fallback_calls[0]["kwargs"]["messages"][0]["content"] == "test"
+
 
 @pytest.mark.skipif(
     not pytest.importorskip("openai", reason="openai not installed"),
@@ -204,7 +272,7 @@ class TestStreamingReaskIntegration:
         return instructor.from_openai(OpenAI())
 
     def test_streaming_with_retries_and_failing_validator(self, client):
-        """Test that streaming with retries doesn't crash on validation failure.
+        """Test that streaming validation failures surface without stream crashes.
 
         This test verifies that the reask handler doesn't crash with
         "'Stream' object has no attribute 'choices'" when validation fails
@@ -221,11 +289,8 @@ class TestStreamingReaskIntegration:
             def always_fail(cls, v: str) -> str:  # noqa: ARG003
                 raise ValueError("This validator always fails for testing")
 
-        # This should not crash with AttributeError about Stream.choices
-        # It should raise InstructorRetryException after retries are exhausted
-        from instructor.core.exceptions import InstructorRetryException
-
-        with pytest.raises(InstructorRetryException):
+        # This should not crash with AttributeError about Stream.choices.
+        with pytest.raises(ValidationError):
             list(
                 client.chat.completions.create_partial(
                     model="gpt-4o-mini",


### PR DESCRIPTION
## Summary
Make sync `create_partial()` preserve true streaming behavior instead of buffering the full partial stream, and add a safer retry fallback when a streaming response cannot be inspected by provider-specific reask helpers.

## Tests
- `uv run pytest tests/test_process_response_streaming.py tests/test_list_response_wrapper.py tests/test_streaming_reask_bug.py -q`
- `uv run pytest tests/test_process_response_streaming.py tests/test_streaming_reask_bug.py -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes streaming return types for `PartialBase` models and alters retry re-ask handling on validation failures, which can impact downstream consumers and retry behavior in streaming flows.
> 
> **Overview**
> **Preserves true streaming for `create_partial()`** by stopping `process_response` from buffering `PartialBase` streaming results into a list, returning the generator/async-generator instead.
> 
> **Hardens retry logic for streaming validation failures** by catching `AttributeError` when provider-specific `handle_reask_kwargs` can’t inspect a raw stream and falling back to a generic “retry with validation error” message builder.
> 
> Adds focused tests to assert generator behavior for `PartialBase`/`IterableBase` in sync+async processing and to verify the new retry fallback path for uninspectable streaming responses (and adjusts the integration test expectation accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ec86cc7f7c190ef6ba2986690ff87d3e247f929. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->