### PR TITLE
perf(import): lazy module loading to reduce import time and memory

### DIFF
--- a/benchmarks/import_benchmark.py
+++ b/benchmarks/import_benchmark.py
@@ -1,0 +1,60 @@
+"""Benchmark import time and memory usage for instructor.
+
+Usage:
+    python benchmarks/import_benchmark.py
+"""
+
+import subprocess
+import sys
+
+
+def measure(label: str, stmt: str) -> None:
+    code = f"""
+import sys, time, tracemalloc
+from collections import Counter
+
+tracemalloc.start()
+before = set(sys.modules.keys())
+start = time.time()
+{stmt}
+elapsed = time.time() - start
+_, peak = tracemalloc.get_traced_memory()
+tracemalloc.stop()
+
+new = set(sys.modules.keys()) - before
+print(f"{{elapsed:.3f}}s  {{peak / 1024 / 1024:6.1f}}MB  {{len(new):>5}} modules")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    out = result.stdout.strip()
+    print(f"  {label:<35} {out}")
+    if result.returncode != 0:
+        err = result.stderr.strip().split("\n")[-1]
+        print(f"    ERROR: {err}")
+
+
+def main() -> None:
+    print("Import benchmark")
+    print("=" * 70)
+    print(f"  {'target':<35} {'time':>7}  {'peak':>7}  {'modules':>7}")
+    print("-" * 70)
+
+    measure("import instructor", "import instructor")
+    measure("instructor + from_openai()", (
+        "import instructor; "
+        "instructor.from_openai(None)"
+    ))
+    measure("instructor + from_anthropic()", (
+        "import instructor; "
+        "import anthropic; "
+        "instructor.from_anthropic(anthropic.Anthropic(api_key='test'))"
+    ))
+    measure("import openai (baseline)", "import openai")
+    measure("import anthropic (baseline)", "import anthropic")
+
+
+if __name__ == "__main__":
+    main()

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -1,40 +1,10 @@
+from __future__ import annotations
+
 import importlib.util
+from importlib import import_module
+from typing import Any
 
 __version__ = "1.15.1"
-
-from .mode import Mode
-from .processing.multimodal import Image, Audio
-
-from .dsl import (
-    CitationMixin,
-    Maybe,
-    Partial,
-    IterableModel,
-)
-
-from .validation import llm_validator, openai_moderation
-from .processing.function_calls import OpenAISchema, openai_schema
-from .processing.schema import (
-    generate_openai_schema,
-    generate_anthropic_schema,
-    generate_gemini_schema,
-)
-from .core.patch import apatch, patch
-from .core.client import (
-    Instructor,
-    AsyncInstructor,
-    from_openai,
-    from_litellm,
-)
-from .core import hooks
-from .utils.providers import Provider
-from .auto_client import from_provider
-from .batch import BatchProcessor, BatchRequest, BatchJob
-from .distil import FinetuneFormat, Instructions
-
-# Backward compatibility: Re-export removed functions
-from .processing.response import handle_response_model
-from .dsl.parallel import handle_parallel_model
 
 __all__ = [
     "Instructor",
@@ -71,84 +41,120 @@ __all__ = [
     "handle_parallel_model",
 ]
 
-# Backward compatibility: Make instructor.client available as an attribute
-# This allows code like `instructor.client.Instructor` to work
-from . import client
-
-
+# Provider availability checks (lightweight, no SDK imports)
 if importlib.util.find_spec("anthropic") is not None:
-    from .providers.anthropic.client import from_anthropic
-
     __all__ += ["from_anthropic"]
 
-# Keep from_gemini for backward compatibility but it's deprecated
 if (
     importlib.util.find_spec("google")
     and importlib.util.find_spec("google.generativeai") is not None
 ):
-    from .providers.gemini.client import from_gemini
-
     __all__ += ["from_gemini"]
 
 if importlib.util.find_spec("fireworks") is not None:
-    from .providers.fireworks.client import from_fireworks
-
     __all__ += ["from_fireworks"]
 
 if importlib.util.find_spec("cerebras") is not None:
-    from .providers.cerebras.client import from_cerebras
-
     __all__ += ["from_cerebras"]
 
 if importlib.util.find_spec("groq") is not None:
-    from .providers.groq.client import from_groq
-
     __all__ += ["from_groq"]
 
 if importlib.util.find_spec("mistralai") is not None:
-    from .providers.mistral.client import from_mistral
-
     __all__ += ["from_mistral"]
 
 if importlib.util.find_spec("cohere") is not None:
-    from .providers.cohere.client import from_cohere
-
     __all__ += ["from_cohere"]
 
 if all(importlib.util.find_spec(pkg) for pkg in ("vertexai", "jsonref")):
-    try:
-        from .providers.vertexai.client import from_vertexai
-    except Exception:
-        # Optional dependency may be present but broken/misconfigured at import time.
-        # Avoid failing `import instructor` in that case.
-        pass
-    else:
-        __all__ += ["from_vertexai"]
+    __all__ += ["from_vertexai"]
 
 if importlib.util.find_spec("boto3") is not None:
-    from .providers.bedrock.client import from_bedrock
-
     __all__ += ["from_bedrock"]
 
 if importlib.util.find_spec("writerai") is not None:
-    from .providers.writer.client import from_writer
-
     __all__ += ["from_writer"]
 
 if importlib.util.find_spec("xai_sdk") is not None:
-    from .providers.xai.client import from_xai
-
     __all__ += ["from_xai"]
 
 if importlib.util.find_spec("openai") is not None:
-    from .providers.perplexity.client import from_perplexity
-
     __all__ += ["from_perplexity"]
 
 if (
     importlib.util.find_spec("google")
     and importlib.util.find_spec("google.genai") is not None
 ):
-    from .providers.genai.client import from_genai
-
     __all__ += ["from_genai"]
+
+
+_LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
+    # Core
+    "Instructor": (".core.client", "Instructor"),
+    "AsyncInstructor": (".core.client", "AsyncInstructor"),
+    "from_openai": (".core.client", "from_openai"),
+    "from_litellm": (".core.client", "from_litellm"),
+    "Mode": (".mode", "Mode"),
+    "patch": (".core.patch", "patch"),
+    "apatch": (".core.patch", "apatch"),
+    "hooks": (".core.hooks", None),
+    # Multimodal
+    "Image": (".processing.multimodal", "Image"),
+    "Audio": (".processing.multimodal", "Audio"),
+    # DSL
+    "CitationMixin": (".dsl", "CitationMixin"),
+    "IterableModel": (".dsl", "IterableModel"),
+    "Maybe": (".dsl", "Maybe"),
+    "Partial": (".dsl", "Partial"),
+    # Processing
+    "OpenAISchema": (".processing.function_calls", "OpenAISchema"),
+    "openai_schema": (".processing.function_calls", "openai_schema"),
+    "generate_openai_schema": (".processing.schema", "generate_openai_schema"),
+    "generate_anthropic_schema": (".processing.schema", "generate_anthropic_schema"),
+    "generate_gemini_schema": (".processing.schema", "generate_gemini_schema"),
+    # Validation
+    "llm_validator": (".validation", "llm_validator"),
+    "openai_moderation": (".validation", "openai_moderation"),
+    # Utilities
+    "Provider": (".utils.providers", "Provider"),
+    "from_provider": (".auto_client", "from_provider"),
+    # Batch
+    "BatchProcessor": (".batch", "BatchProcessor"),
+    "BatchRequest": (".batch", "BatchRequest"),
+    "BatchJob": (".batch", "BatchJob"),
+    # Distil
+    "FinetuneFormat": (".distil", "FinetuneFormat"),
+    "Instructions": (".distil", "Instructions"),
+    # Backward compatibility
+    "client": (".client", None),
+    "handle_response_model": (".processing.response", "handle_response_model"),
+    "handle_parallel_model": (".dsl.parallel", "handle_parallel_model"),
+    # Provider factories
+    "from_anthropic": (".providers.anthropic.client", "from_anthropic"),
+    "from_gemini": (".providers.gemini.client", "from_gemini"),
+    "from_fireworks": (".providers.fireworks.client", "from_fireworks"),
+    "from_cerebras": (".providers.cerebras.client", "from_cerebras"),
+    "from_groq": (".providers.groq.client", "from_groq"),
+    "from_mistral": (".providers.mistral.client", "from_mistral"),
+    "from_cohere": (".providers.cohere.client", "from_cohere"),
+    "from_vertexai": (".providers.vertexai.client", "from_vertexai"),
+    "from_bedrock": (".providers.bedrock.client", "from_bedrock"),
+    "from_writer": (".providers.writer.client", "from_writer"),
+    "from_xai": (".providers.xai.client", "from_xai"),
+    "from_perplexity": (".providers.perplexity.client", "from_perplexity"),
+    "from_genai": (".providers.genai.client", "from_genai"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    if name in _LAZY_IMPORTS:
+        module_path, attr_name = _LAZY_IMPORTS[name]
+        module = import_module(module_path, package=__name__)
+        value = module if attr_name is None else getattr(module, attr_name)
+        globals()[name] = value
+        return value
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/instructor/core/__init__.py
+++ b/instructor/core/__init__.py
@@ -1,23 +1,9 @@
 """Core components of the instructor package."""
 
-from .client import Instructor, AsyncInstructor, Response, from_openai, from_litellm
-from .exceptions import (
-    InstructorRetryException,
-    InstructorError,
-    ConfigurationError,
-    IncompleteOutputException,
-    ValidationError,
-    ProviderError,
-    ModeError,
-    ClientError,
-    AsyncValidationError,
-    FailedAttempt,
-    ResponseParsingError,
-    MultimodalError,
-)
-from .hooks import Hooks, HookName
-from .patch import patch, apatch
-from .retry import retry_sync, retry_async
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     "Instructor",
@@ -44,3 +30,39 @@ __all__ = [
     "retry_sync",
     "retry_async",
 ]
+
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "Instructor": (".client", "Instructor"),
+    "AsyncInstructor": (".client", "AsyncInstructor"),
+    "Response": (".client", "Response"),
+    "from_openai": (".client", "from_openai"),
+    "from_litellm": (".client", "from_litellm"),
+    "InstructorRetryException": (".exceptions", "InstructorRetryException"),
+    "InstructorError": (".exceptions", "InstructorError"),
+    "ConfigurationError": (".exceptions", "ConfigurationError"),
+    "IncompleteOutputException": (".exceptions", "IncompleteOutputException"),
+    "ValidationError": (".exceptions", "ValidationError"),
+    "ProviderError": (".exceptions", "ProviderError"),
+    "ModeError": (".exceptions", "ModeError"),
+    "ClientError": (".exceptions", "ClientError"),
+    "AsyncValidationError": (".exceptions", "AsyncValidationError"),
+    "FailedAttempt": (".exceptions", "FailedAttempt"),
+    "ResponseParsingError": (".exceptions", "ResponseParsingError"),
+    "MultimodalError": (".exceptions", "MultimodalError"),
+    "Hooks": (".hooks", "Hooks"),
+    "HookName": (".hooks", "HookName"),
+    "patch": (".patch", "patch"),
+    "apatch": (".patch", "apatch"),
+    "retry_sync": (".retry", "retry_sync"),
+    "retry_async": (".retry", "retry_async"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LAZY_IMPORTS:
+        module_path, attr_name = _LAZY_IMPORTS[name]
+        module = import_module(module_path, package=__name__)
+        value = getattr(module, attr_name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/instructor/processing/__init__.py
+++ b/instructor/processing/__init__.py
@@ -1,19 +1,9 @@
 """Processing components for request/response handling."""
 
-from .function_calls import OpenAISchema, openai_schema
-from .multimodal import convert_messages
-from .response import (
-    handle_response_model,
-    process_response,
-    process_response_async,
-    handle_reask_kwargs,
-)
-from .schema import (
-    generate_openai_schema,
-    generate_anthropic_schema,
-    generate_gemini_schema,
-)
-from .validators import Validator
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     "OpenAISchema",
@@ -28,3 +18,27 @@ __all__ = [
     "generate_gemini_schema",
     "Validator",
 ]
+
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "OpenAISchema": (".function_calls", "OpenAISchema"),
+    "openai_schema": (".function_calls", "openai_schema"),
+    "convert_messages": (".multimodal", "convert_messages"),
+    "handle_response_model": (".response", "handle_response_model"),
+    "process_response": (".response", "process_response"),
+    "process_response_async": (".response", "process_response_async"),
+    "handle_reask_kwargs": (".response", "handle_reask_kwargs"),
+    "generate_openai_schema": (".schema", "generate_openai_schema"),
+    "generate_anthropic_schema": (".schema", "generate_anthropic_schema"),
+    "generate_gemini_schema": (".schema", "generate_gemini_schema"),
+    "Validator": (".validators", "Validator"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LAZY_IMPORTS:
+        module_path, attr_name = _LAZY_IMPORTS[name]
+        module = import_module(module_path, package=__name__)
+        value = getattr(module, attr_name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/instructor/providers/__init__.py
+++ b/instructor/providers/__init__.py
@@ -1,82 +1,86 @@
 """Provider implementations for instructor."""
 
+from __future__ import annotations
+
 import importlib.util
+from importlib import import_module
+from typing import Any
 
-__all__ = []
+__all__: list[str] = []
 
-# Conditional imports based on installed packages
+_LAZY_PROVIDER_EXPORTS: dict[str, tuple[str, str]] = {
+    "from_anthropic": (".anthropic.client", "from_anthropic"),
+    "from_bedrock": (".bedrock.client", "from_bedrock"),
+    "from_cerebras": (".cerebras.client", "from_cerebras"),
+    "from_cohere": (".cohere.client", "from_cohere"),
+    "from_fireworks": (".fireworks.client", "from_fireworks"),
+    "from_gemini": (".gemini.client", "from_gemini"),
+    "from_genai": (".genai.client", "from_genai"),
+    "from_groq": (".groq.client", "from_groq"),
+    "from_mistral": (".mistral.client", "from_mistral"),
+    "from_perplexity": (".perplexity.client", "from_perplexity"),
+    "from_vertexai": (".vertexai.client", "from_vertexai"),
+    "from_writer": (".writer.client", "from_writer"),
+    "from_xai": (".xai.client", "from_xai"),
+}
+
+# Conditional exports based on installed packages
 if importlib.util.find_spec("anthropic") is not None:
-    from .anthropic.client import from_anthropic  # noqa: F401
-
     __all__.append("from_anthropic")
 
 if importlib.util.find_spec("boto3") is not None:
-    from .bedrock.client import from_bedrock  # noqa: F401
-
     __all__.append("from_bedrock")
 
 if importlib.util.find_spec("cerebras") is not None:
-    from .cerebras.client import from_cerebras  # noqa: F401
-
     __all__.append("from_cerebras")
 
 if importlib.util.find_spec("cohere") is not None:
-    from .cohere.client import from_cohere  # noqa: F401
-
     __all__.append("from_cohere")
 
 if importlib.util.find_spec("fireworks") is not None:
-    from .fireworks.client import from_fireworks  # noqa: F401
-
     __all__.append("from_fireworks")
 
 if (
     importlib.util.find_spec("google")
     and importlib.util.find_spec("google.generativeai") is not None
 ):
-    from .gemini.client import from_gemini  # noqa: F401
-
     __all__.append("from_gemini")
 
 if (
     importlib.util.find_spec("google")
     and importlib.util.find_spec("google.genai") is not None
 ):
-    from .genai.client import from_genai  # noqa: F401
-
     __all__.append("from_genai")
 
 if importlib.util.find_spec("groq") is not None:
-    from .groq.client import from_groq  # noqa: F401
-
     __all__.append("from_groq")
 
 if importlib.util.find_spec("mistralai") is not None:
-    from .mistral.client import from_mistral  # noqa: F401
-
     __all__.append("from_mistral")
 
 if importlib.util.find_spec("openai") is not None:
-    from .perplexity.client import from_perplexity  # noqa: F401
-
     __all__.append("from_perplexity")
 
 if all(importlib.util.find_spec(pkg) for pkg in ("vertexai", "jsonref")):
-    try:
-        from .vertexai.client import from_vertexai  # noqa: F401
-    except Exception:
-        # Optional dependency may be present but broken/misconfigured at import time.
-        # Avoid failing `import instructor` in that case.
-        pass
-    else:
-        __all__.append("from_vertexai")
+    __all__.append("from_vertexai")
 
 if importlib.util.find_spec("writerai") is not None:
-    from .writer.client import from_writer  # noqa: F401
-
     __all__.append("from_writer")
 
 if importlib.util.find_spec("xai_sdk") is not None:
-    from .xai.client import from_xai  # noqa: F401
-
     __all__.append("from_xai")
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LAZY_PROVIDER_EXPORTS and name in __all__:
+        module_path, attr_name = _LAZY_PROVIDER_EXPORTS[name]
+        try:
+            module = import_module(module_path, package=__name__)
+        except Exception as exc:
+            raise AttributeError(
+                f"module {__name__!r} has no attribute {name!r}"
+            ) from exc
+        value = getattr(module, attr_name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

Fixes #2205

`import instructor` was loading every installed provider SDK eagerly, pulling in ~1600 modules and ~43MB just on import. This replaces the eager top-level imports in four `__init__.py` files with `__getattr__`-based lazy loading so provider SDKs only load when actually used.

### Changes

- `instructor/__init__.py`: defer all symbol imports to first access
- `instructor/core/__init__.py`: defer client, patch, retry, hooks imports
- `instructor/processing/__init__.py`: defer function_calls, multimodal, response, schema imports
- `instructor/providers/__init__.py`: defer provider client imports

### Benchmark

Included `benchmarks/import_benchmark.py` for easy reproduction.

| scenario | before | after |
|---|---|---|
| `import instructor` | 1.8s / 43MB / 1647 modules | 0.01s / 0.7MB / 13 modules |
| `import instructor` + `from_openai()` | same | 1.0s / 30MB / 894 modules |
| `import instructor` + `from_anthropic()` | same | 1.5s / 43MB / 1662 modules |

Provider SDKs (anthropic, etc.) are no longer loaded unless actually needed. The public API is unchanged — all existing imports and attribute access work the same way.

### Testing

Ran the full test suite excluding LLM/API tests. No new failures introduced (pre-existing failures are API key / missing SDK related).