### PR TITLE
fix(security): redact api_key from debug log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Security
+- **Logging**: Redact `api_key`, `api_secret`, `api_token`, and `authorization` from `logger.debug` output in `handle_response_model` — previously these values were logged verbatim when a downstream project enabled DEBUG-level logging ([#2265](https://github.com/567-labs/instructor/issues/2265))
+
 ### Fixed
 - **Templating (GenAI/VertexAI)**: `process_message` no longer crashes with `TypeError: Can't compile non template nodes` when multimodal messages contain image/URI/bytes Parts alongside `validation_context`. Non-text Parts (where `part.text` is `None`) now pass through unchanged. ([#2253](https://github.com/567-labs/instructor/issues/2253))
 

--- a/instructor/processing/response.py
+++ b/instructor/processing/response.py
@@ -164,6 +164,14 @@ from ..providers.xai.utils import (
 
 logger = logging.getLogger("instructor")
 
+_SENSITIVE_KEYS = frozenset({"api_key", "api_secret", "api_token", "authorization"})
+
+
+def _redact_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Return a shallow copy of *kwargs* with sensitive values replaced by ``'[REDACTED]'``."""
+    return {k: "[REDACTED]" if k in _SENSITIVE_KEYS else v for k, v in kwargs.items()}
+
+
 T_Model = TypeVar("T_Model", bound=BaseModel)
 T_Retval = TypeVar("T_Retval")
 T_ParamSpec = ParamSpec("T_ParamSpec")
@@ -439,8 +447,9 @@ def handle_response_model(
 
     if mode in PARALLEL_MODES:
         response_model, new_kwargs = PARALLEL_MODES[mode](response_model, new_kwargs)  # type: ignore
+        safe_kwargs = _redact_kwargs(new_kwargs)
         logger.debug(
-            f"Instructor Request: {mode.value=}, {response_model=}, {new_kwargs=}",
+            f"Instructor Request: {mode.value=}, {response_model=}, new_kwargs={safe_kwargs}",
             extra={
                 "mode": mode.value,
                 "response_model": (
@@ -449,7 +458,7 @@ def handle_response_model(
                     and hasattr(response_model, "__name__")
                     else str(response_model)
                 ),
-                "new_kwargs": new_kwargs,
+                "new_kwargs": safe_kwargs,
             },
         )
         return response_model, new_kwargs
@@ -514,8 +523,9 @@ def handle_response_model(
             autodetect_images=autodetect_images,
         )
 
+    safe_kwargs = _redact_kwargs(new_kwargs)
     logger.debug(
-        f"Instructor Request: {mode.value=}, {response_model=}, {new_kwargs=}",
+        f"Instructor Request: {mode.value=}, {response_model=}, new_kwargs={safe_kwargs}",
         extra={
             "mode": mode.value,
             "response_model": (
@@ -523,7 +533,7 @@ def handle_response_model(
                 if response_model is not None and hasattr(response_model, "__name__")
                 else str(response_model)
             ),
-            "new_kwargs": new_kwargs,
+            "new_kwargs": safe_kwargs,
         },
     )
     return response_model, new_kwargs

--- a/tests/test_redact_kwargs.py
+++ b/tests/test_redact_kwargs.py
@@ -1,0 +1,84 @@
+"""Tests for sensitive-key redaction in debug logging.
+
+Regression tests for https://github.com/jxnl/instructor/issues/2265
+"""
+
+from __future__ import annotations
+
+import logging
+
+from pydantic import BaseModel
+
+from instructor.mode import Mode
+from instructor.processing.response import _redact_kwargs, handle_response_model
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+# -- unit tests for _redact_kwargs ------------------------------------------
+
+
+def test_redact_kwargs_scrubs_sensitive_keys():
+    kwargs = {
+        "model": "gpt-4",
+        "api_key": "sk-secret-123",
+        "api_secret": "secret-456",
+        "api_token": "tok-789",
+        "authorization": "Bearer xxx",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    result = _redact_kwargs(kwargs)
+    assert result["api_key"] == "[REDACTED]"
+    assert result["api_secret"] == "[REDACTED]"
+    assert result["api_token"] == "[REDACTED]"
+    assert result["authorization"] == "[REDACTED]"
+
+
+def test_redact_kwargs_preserves_safe_keys():
+    kwargs = {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+    result = _redact_kwargs(kwargs)
+    assert result == kwargs
+
+
+def test_redact_kwargs_does_not_mutate_original():
+    kwargs = {"api_key": "sk-real-key", "model": "gpt-4"}
+    _redact_kwargs(kwargs)
+    assert kwargs["api_key"] == "sk-real-key"
+
+
+def test_redact_kwargs_empty_dict():
+    assert _redact_kwargs({}) == {}
+
+
+# -- integration test: handle_response_model does not leak api_key -----------
+
+
+def test_handle_response_model_redacts_api_key_in_debug_log(caplog):
+    """Ensure api_key is never written to log output (issue #2265)."""
+    secret = "sk-SUPER-SECRET-KEY-12345"
+
+    with caplog.at_level(logging.DEBUG, logger="instructor"):
+        _, new_kwargs = handle_response_model(
+            response_model=User,
+            mode=Mode.TOOLS,
+            model="gpt-4",
+            messages=[{"role": "user", "content": "test"}],
+            api_key=secret,
+        )
+
+    # The returned kwargs must still carry the real key for the API call.
+    assert new_kwargs["api_key"] == secret
+
+    # But the log output must never contain the real key.
+    for record in caplog.records:
+        assert secret not in record.getMessage(), (
+            f"api_key leaked in log record: {record.getMessage()}"
+        )
+        # Also check the extra dict attached to the record
+        if hasattr(record, "new_kwargs"):
+            assert secret not in str(record.new_kwargs), (
+                "api_key leaked in log record extra"
+            )


### PR DESCRIPTION
## Summary

- Fixes #2265 — `logger.debug` calls in `handle_response_model()` logged the full `new_kwargs` dict verbatim, leaking `api_key` (and similar secrets) to any downstream project running at `DEBUG` level.
- Adds a `_redact_kwargs()` helper that replaces `api_key`, `api_secret`, `api_token`, and `authorization` values with `'[REDACTED]'` before they reach the f-string or the `extra` dict. The original dict is untouched, so the actual API call still receives the real key.
- Adds 5 regression tests (unit + integration via `caplog`) to verify redaction works and the original kwargs are never mutated.
- Adds a `### Security` entry to `CHANGELOG.md` under `[Unreleased]`.

## Reproduction

```python
import logging, sys
logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)

from instructor.processing.response import handle_response_model
from instructor.mode import Mode
from pydantic import BaseModel

class User(BaseModel):
    name: str
    age: int

# Before fix: api_key appears in plaintext in log output
# After fix: api_key shows as '[REDACTED]'
_, kw = handle_response_model(
    response_model=User, mode=Mode.TOOLS,
    model="gpt-4", messages=[{"role": "user", "content": "test"}],
    api_key="sk-SECRET",
)
assert kw["api_key"] == "sk-SECRET"  # returned kwargs still carry real key
```

## Test plan

- [x] `pytest tests/test_redact_kwargs.py` — 5/5 pass
- [x] `ruff check` and `ruff format` clean
- [x] Existing tests unaffected (298 pass; 9 pre-existing failures in gemini/genai unrelated)
- [x] Manual reproduction confirms `[REDACTED]` in log output