### PR TITLE
fix(retry): let IncompleteOutputException propagate without wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 - **Templating (GenAI/VertexAI)**: `process_message` no longer crashes with `TypeError: Can't compile non template nodes` when multimodal messages contain image/URI/bytes Parts alongside `validation_context`. Non-text Parts (where `part.text` is `None`) now pass through unchanged. ([#2253](https://github.com/567-labs/instructor/issues/2253))
+- **Retry**: `IncompleteOutputException` now propagates directly to the caller without being wrapped in `InstructorRetryException`, making `except IncompleteOutputException` catch blocks work as documented. Applies to both sync and async paths. ([#2273](https://github.com/567-labs/instructor/issues/2273))
 
 ---
 

--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -10,6 +10,7 @@ from .exceptions import (
     InstructorRetryException,
     AsyncValidationError,
     FailedAttempt,
+    IncompleteOutputException,
     ValidationError as InstructorValidationError,
 )
 from .hooks import Hooks
@@ -187,6 +188,9 @@ def retry_sync(
 
     # Track all failed attempts
     failed_attempts: list[FailedAttempt] = []
+    # IncompleteOutputException is stored here to be re-raised outside tenacity
+    # so callers can catch it directly without it being wrapped in InstructorRetryException
+    _incomplete_exc: IncompleteOutputException | None = None
 
     try:
         response = None
@@ -261,6 +265,14 @@ def retry_sync(
                     )
                     raise e
                 except Exception as e:
+                    # IncompleteOutputException must propagate directly so callers
+                    # can catch it without it being wrapped in InstructorRetryException.
+                    # Break out of the tenacity loop without raising so tenacity does
+                    # not see the exception; it is re-raised after the loop below.
+                    if isinstance(e, IncompleteOutputException):
+                        _incomplete_exc = e
+                        break
+
                     # Emit completion:error for non-validation errors (API errors, network errors, etc.)
                     logger.debug(f"Completion error: {e}")
                     attempt_number = attempt.retry_state.attempt_number
@@ -322,6 +334,9 @@ def retry_sync(
             failed_attempts=failed_attempts,
         ) from e
 
+    if _incomplete_exc is not None:
+        raise _incomplete_exc
+
 
 async def retry_async(
     func: Callable[T_ParamSpec, T_Retval],
@@ -365,6 +380,7 @@ async def retry_async(
 
     # Track all failed attempts
     failed_attempts: list[FailedAttempt] = []
+    _incomplete_exc: IncompleteOutputException | None = None
 
     try:
         response = None
@@ -440,6 +456,12 @@ async def retry_async(
                     )
                     raise e
                 except Exception as e:
+                    # IncompleteOutputException must propagate directly so callers
+                    # can catch it without it being wrapped in InstructorRetryException.
+                    if isinstance(e, IncompleteOutputException):
+                        _incomplete_exc = e
+                        break
+
                     # Emit completion:error for non-validation errors (API errors, network errors, etc.)
                     logger.debug(f"Completion error: {e}")
                     attempt_number = attempt.retry_state.attempt_number
@@ -500,3 +522,6 @@ async def retry_async(
             total_usage=total_usage,
             failed_attempts=failed_attempts,
         ) from e
+
+    if _incomplete_exc is not None:
+        raise _incomplete_exc

--- a/tests/test_incomplete_output_exception.py
+++ b/tests/test_incomplete_output_exception.py
@@ -1,0 +1,117 @@
+"""
+Tests that IncompleteOutputException propagates directly from retry_sync/retry_async
+without being wrapped in InstructorRetryException.
+
+Regression tests for issue #2273.
+"""
+
+import pytest
+import asyncio
+from unittest.mock import Mock, AsyncMock
+from pydantic import BaseModel
+
+import instructor
+from instructor.core.exceptions import IncompleteOutputException, InstructorRetryException
+from instructor.mode import Mode
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+def _make_truncated_response() -> Mock:
+    """Return a mock response that simulates a MAX_TOKENS truncation."""
+    mock_response = Mock()
+    mock_response.choices = [Mock()]
+    mock_response.choices[0].message = Mock()
+    mock_response.choices[0].message.content = '{"name": "Alice"'  # truncated JSON
+    mock_response.choices[0].finish_reason = "length"
+    mock_response.usage = None
+    return mock_response
+
+
+def _raise_incomplete(*args, **kwargs):
+    raise IncompleteOutputException(last_completion=None)
+
+
+def test_incomplete_output_exception_is_catchable_sync():
+    """IncompleteOutputException must be catchable directly, not wrapped."""
+    mock_client = Mock()
+    mock_client.chat = Mock()
+    mock_client.chat.completions = Mock()
+    mock_client.chat.completions.create = Mock(side_effect=_raise_incomplete)
+
+    client = instructor.patch(mock_client, mode=Mode.TOOLS)
+
+    with pytest.raises(IncompleteOutputException):
+        client.chat.completions.create(
+            model="gpt-4o-mini",
+            response_model=User,
+            messages=[{"role": "user", "content": "test"}],
+            max_retries=0,
+        )
+
+
+def test_incomplete_output_not_wrapped_in_instructor_retry_exception_sync():
+    """IncompleteOutputException must NOT be wrapped in InstructorRetryException."""
+    mock_client = Mock()
+    mock_client.chat = Mock()
+    mock_client.chat.completions = Mock()
+    mock_client.chat.completions.create = Mock(side_effect=_raise_incomplete)
+
+    client = instructor.patch(mock_client, mode=Mode.TOOLS)
+
+    with pytest.raises(IncompleteOutputException):
+        client.chat.completions.create(
+            model="gpt-4o-mini",
+            response_model=User,
+            messages=[{"role": "user", "content": "test"}],
+            max_retries=3,
+        )
+
+
+def test_incomplete_output_exception_with_max_retries_zero():
+    """IncompleteOutputException is raised immediately when max_retries=0."""
+    call_count = {"n": 0}
+
+    def _raise_incomplete_and_count(*args, **kwargs):
+        call_count["n"] += 1
+        raise IncompleteOutputException(last_completion=None)
+
+    mock_client = Mock()
+    mock_client.chat = Mock()
+    mock_client.chat.completions = Mock()
+    mock_client.chat.completions.create = _raise_incomplete_and_count
+
+    client = instructor.patch(mock_client, mode=Mode.TOOLS)
+
+    with pytest.raises(IncompleteOutputException):
+        client.chat.completions.create(
+            model="gpt-4o-mini",
+            response_model=User,
+            messages=[{"role": "user", "content": "test"}],
+            max_retries=0,
+        )
+
+    # Should only have been called once (no retries for IncompleteOutputException)
+    assert call_count["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_incomplete_output_exception_is_catchable_async():
+    """Async path: IncompleteOutputException must be directly catchable."""
+    mock_client = Mock()
+    mock_client.chat = Mock()
+    mock_client.chat.completions = Mock()
+    mock_client.chat.completions.create = AsyncMock(side_effect=_raise_incomplete)
+
+    client = instructor.patch(mock_client, mode=Mode.TOOLS)
+
+    with pytest.raises(IncompleteOutputException):
+        await client.chat.completions.create(
+            model="gpt-4o-mini",
+            response_model=User,
+            messages=[{"role": "user", "content": "test"}],
+            max_retries=0,
+        )


### PR DESCRIPTION
## Motivation and Context

Closes #2273

When an LLM returns a truncated response (e.g. `finish_reason=length`), instructor raises `IncompleteOutputException`. The documented usage pattern is:

```python
try:
    result = client.chat.completions.create(...)
except IncompleteOutputException:
    # handle truncation
```

However, this catch block **never fires**. `IncompleteOutputException` falls into the generic `except Exception` handler inside the tenacity retry loop, and after retries are exhausted it gets wrapped in `InstructorRetryException`. Users must catch `InstructorRetryException` and inspect its `.last_attempt` to find the original exception — an undocumented workaround that defeats the purpose of a named exception type.

## What changes

In both `retry_sync` and `retry_async`:

1. Detect `IncompleteOutputException` in the `except Exception` handler **before** tenacity's retry logic runs
2. Store it and `break` out of the tenacity loop cleanly (tenacity never sees the exception)
3. Re-raise it after the loop — directly, without wrapping

The change is minimal: 4 new lines in the exception handler of each function, 2 variable initializations, 2 post-loop raises.

## Tests

Added `tests/test_incomplete_output_exception.py` with 4 tests:
- Sync path: exception is catchable directly
- Sync path: exception is **not** wrapped in `InstructorRetryException`
- Sync path: with `max_retries=0`, API called exactly once
- Async path: exception is catchable directly

All existing retry and hooks tests continue to pass.