### PR TITLE
feat(minimax): add MiniMax provider support (closes #2260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+- **MiniMax**: New provider support via `from_minimax()` and `from_provider("minimax/...")`, with `MINIMAX_TOOLS` and `MINIMAX_JSON` modes targeting MiniMax's OpenAI-compatible chat completions API ([#2260](https://github.com/567-labs/instructor/issues/2260))
+
 ### Fixed
 - **Templating (GenAI/VertexAI)**: `process_message` no longer crashes with `TypeError: Can't compile non template nodes` when multimodal messages contain image/URI/bytes Parts alongside `validation_context`. Non-text Parts (where `part.text` is `None`) now pass through unchanged. ([#2253](https://github.com/567-labs/instructor/issues/2253))
 

--- a/docs/integrations/minimax.md
+++ b/docs/integrations/minimax.md
@@ -1,0 +1,185 @@
+---
+title: Structured Outputs with MiniMax and Pydantic
+description: Learn how to use MiniMax with Instructor for structured JSON outputs using Pydantic models. Create type-safe, validated responses from MiniMax's chat models with Python.
+---
+
+# Structured Outputs with MiniMax
+
+This guide shows how to use [MiniMax](https://www.minimaxi.com/) with Instructor to produce validated, structured outputs. MiniMax exposes an OpenAI-compatible chat completions endpoint, so Instructor wraps it with the same ergonomics as any other OpenAI-style provider.
+
+## Prerequisites
+
+Sign up for a MiniMax account and create an API key in the console, then install the dependencies:
+
+```bash
+export MINIMAX_API_KEY=<your-api-key-here>
+pip install "instructor"
+```
+
+### See Also
+
+- [Getting Started](../getting-started.md) - Quick start guide
+- [from_provider Guide](../concepts/from_provider.md) - Detailed client configuration
+- [Provider Examples](../index.md#provider-examples) - Quick examples for all providers
+
+# MiniMax
+
+Instructor supports both tool-calling and JSON modes against MiniMax:
+
+- `MINIMAX_TOOLS` — function/tool calling (default)
+- `MINIMAX_JSON` — direct JSON responses
+
+### Sync Example
+
+```python
+import instructor
+from pydantic import BaseModel
+
+
+client = instructor.from_provider("minimax/MiniMax-Text-01")
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+user = client.chat.completions.create(
+    messages=[
+        {"role": "user", "content": "Extract: Jason is 25 years old"},
+    ],
+    response_model=User,
+)
+
+print(user)
+# > User(name='Jason', age=25)
+```
+
+### Async Example
+
+```python
+import asyncio
+import instructor
+from pydantic import BaseModel
+
+
+async_client = instructor.from_provider(
+    "minimax/MiniMax-Text-01",
+    async_client=True,
+)
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+async def extract_user() -> User:
+    return await async_client.chat.completions.create(
+        messages=[
+            {"role": "user", "content": "Extract: Jason is 25 years old"},
+        ],
+        response_model=User,
+    )
+
+
+user = asyncio.run(extract_user())
+print(user)
+# > User(name='Jason', age=25)
+```
+
+### Nested Objects
+
+```python
+import instructor
+from pydantic import BaseModel
+
+
+client = instructor.from_provider("minimax/MiniMax-Text-01")
+
+
+class Address(BaseModel):
+    street: str
+    city: str
+    country: str
+
+
+class User(BaseModel):
+    name: str
+    age: int
+    addresses: list[Address]
+
+
+user = client.chat.completions.create(
+    messages=[
+        {
+            "role": "user",
+            "content": (
+                "Extract: Jason is 25 years old. "
+                "He lives at 123 Main St, New York, USA "
+                "and has a summer house at 456 Beach Rd, Miami, USA"
+            ),
+        },
+    ],
+    response_model=User,
+)
+
+print(user)
+```
+
+## Supported Modes
+
+```python
+import instructor
+from instructor import Mode
+from pydantic import BaseModel
+
+
+# Tool calling (default)
+client = instructor.from_provider(
+    "minimax/MiniMax-Text-01",
+    mode=Mode.MINIMAX_TOOLS,
+)
+
+
+# JSON mode
+client = instructor.from_provider(
+    "minimax/MiniMax-Text-01",
+    mode=Mode.MINIMAX_JSON,
+)
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+user = client.chat.completions.create(
+    messages=[
+        {"role": "user", "content": "Extract: Jason is 25 years old"},
+    ],
+    response_model=User,
+)
+print(user)
+```
+
+## Using a pre-configured client
+
+You can also pass your own ``openai`` client pointed at MiniMax's base URL:
+
+```python
+import openai
+import instructor
+
+
+client = instructor.from_minimax(
+    openai.OpenAI(
+        api_key="<your-api-key>",
+        base_url="https://api.minimax.chat/v1",
+    )
+)
+```
+
+## Additional Resources
+
+- [MiniMax API Documentation](https://www.minimaxi.com/en/document)

--- a/examples/minimax_example.py
+++ b/examples/minimax_example.py
@@ -1,0 +1,31 @@
+"""Minimal MiniMax + Instructor example.
+
+Set ``MINIMAX_API_KEY`` before running. MiniMax uses an OpenAI-compatible
+chat completions endpoint, so Instructor wires it up with ``from_minimax``.
+"""
+
+from __future__ import annotations
+
+import instructor
+from pydantic import BaseModel
+
+
+class UserInfo(BaseModel):
+    name: str
+    age: int
+
+
+def main() -> None:
+    client = instructor.from_minimax()
+
+    user = client.chat.completions.create(
+        model="MiniMax-Text-01",
+        messages=[{"role": "user", "content": "Extract: John is 25 years old."}],
+        response_model=UserInfo,
+    )
+
+    print(user)
+
+
+if __name__ == "__main__":
+    main()

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -145,6 +145,11 @@ if importlib.util.find_spec("openai") is not None:
 
     __all__ += ["from_perplexity"]
 
+if importlib.util.find_spec("openai") is not None:
+    from .providers.minimax.client import from_minimax
+
+    __all__ += ["from_minimax"]
+
 if (
     importlib.util.find_spec("google")
     and importlib.util.find_spec("google.genai") is not None

--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -36,6 +36,7 @@ supported_providers = [
     "openrouter",
     "xai",
     "litellm",
+    "minimax",
 ]
 
 
@@ -1184,6 +1185,55 @@ def from_provider(
 
             raise ConfigurationError(
                 "The openai package is required to use the OpenRouter provider. "
+                "Install it with `pip install openai`."
+            ) from None
+        except Exception as e:
+            logger.error(
+                "Error initializing %s client: %s",
+                provider,
+                e,
+                exc_info=True,
+                extra={**provider_info, "status": "error"},
+            )
+            raise
+
+    elif provider == "minimax":
+        try:
+            import openai
+            from instructor import from_minimax  # type: ignore[attr-defined]
+            import os
+
+            api_key = api_key or os.environ.get("MINIMAX_API_KEY")
+            if not api_key:
+                from .core.exceptions import ConfigurationError
+
+                raise ConfigurationError(
+                    "MINIMAX_API_KEY is not set. "
+                    "Set it with `export MINIMAX_API_KEY=<your-api-key>` or pass it as kwarg api_key=<your-api-key>"
+                )
+
+            base_url = kwargs.pop("base_url", "https://api.minimax.chat/v1")
+
+            client = (
+                openai.AsyncOpenAI(api_key=api_key, base_url=base_url)
+                if async_client
+                else openai.OpenAI(api_key=api_key, base_url=base_url)
+            )
+            result = from_minimax(
+                client,
+                mode=mode if mode else instructor.Mode.MINIMAX_TOOLS,
+                **kwargs,
+            )
+            logger.info(
+                "Client initialized",
+                extra={**provider_info, "status": "success"},
+            )
+            return result
+        except ImportError:
+            from .core.exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "The openai package is required to use the MiniMax provider. "
                 "Install it with `pip install openai`."
             ) from None
         except Exception as e:

--- a/instructor/dsl/iterable.py
+++ b/instructor/dsl/iterable.py
@@ -340,6 +340,7 @@ class IterableBase:
                         Mode.CEREBRAS_JSON,
                         Mode.FIREWORKS_JSON,
                         Mode.PERPLEXITY_JSON,
+                        Mode.MINIMAX_JSON,
                         Mode.WRITER_JSON,
                     }:
                         if json_chunk := chunk.choices[0].delta.content:
@@ -349,6 +350,7 @@ class IterableBase:
                         Mode.TOOLS_STRICT,
                         Mode.FIREWORKS_TOOLS,
                         Mode.WRITER_TOOLS,
+                        Mode.MINIMAX_TOOLS,
                     }:
                         if json_chunk := chunk.choices[0].delta.tool_calls:
                             if json_chunk[0].function.arguments is not None:
@@ -545,6 +547,7 @@ class IterableBase:
                         Mode.CEREBRAS_JSON,
                         Mode.FIREWORKS_JSON,
                         Mode.PERPLEXITY_JSON,
+                        Mode.MINIMAX_JSON,
                         Mode.WRITER_JSON,
                     }:
                         if json_chunk := chunk.choices[0].delta.content:
@@ -554,6 +557,7 @@ class IterableBase:
                         Mode.TOOLS_STRICT,
                         Mode.FIREWORKS_TOOLS,
                         Mode.WRITER_TOOLS,
+                        Mode.MINIMAX_TOOLS,
                     }:
                         if json_chunk := chunk.choices[0].delta.tool_calls:
                             if json_chunk[0].function.arguments is not None:

--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -731,6 +731,7 @@ class PartialBase(Generic[T_Model]):
                         Mode.CEREBRAS_JSON,
                         Mode.FIREWORKS_JSON,
                         Mode.PERPLEXITY_JSON,
+                        Mode.MINIMAX_JSON,
                         Mode.WRITER_JSON,
                     }:
                         if json_chunk := chunk.choices[0].delta.content:
@@ -740,6 +741,7 @@ class PartialBase(Generic[T_Model]):
                         Mode.TOOLS_STRICT,
                         Mode.FIREWORKS_TOOLS,
                         Mode.WRITER_TOOLS,
+                        Mode.MINIMAX_TOOLS,
                     }:
                         if json_chunk := chunk.choices[0].delta.tool_calls:
                             if json_chunk[0].function.arguments:
@@ -955,6 +957,7 @@ class PartialBase(Generic[T_Model]):
                         Mode.CEREBRAS_JSON,
                         Mode.FIREWORKS_JSON,
                         Mode.PERPLEXITY_JSON,
+                        Mode.MINIMAX_JSON,
                         Mode.WRITER_JSON,
                     }:
                         if json_chunk := chunk.choices[0].delta.content:
@@ -964,6 +967,7 @@ class PartialBase(Generic[T_Model]):
                         Mode.TOOLS_STRICT,
                         Mode.FIREWORKS_TOOLS,
                         Mode.WRITER_TOOLS,
+                        Mode.MINIMAX_TOOLS,
                     }:
                         if json_chunk := chunk.choices[0].delta.tool_calls:
                             if json_chunk[0].function.arguments:

--- a/instructor/mode.py
+++ b/instructor/mode.py
@@ -71,6 +71,10 @@ class Mode(enum.Enum):
     PERPLEXITY_JSON = "perplexity_json"
     OPENROUTER_STRUCTURED_OUTPUTS = "openrouter_structured_outputs"
 
+    # MiniMax modes
+    MINIMAX_TOOLS = "minimax_tools"
+    MINIMAX_JSON = "minimax_json"
+
     # Classification helpers
     @classmethod
     def tool_modes(cls) -> set["Mode"]:
@@ -98,6 +102,7 @@ class Mode(enum.Enum):
             cls.GENAI_TOOLS,
             cls.RESPONSES_TOOLS,
             cls.RESPONSES_TOOLS_WITH_INBUILT_TOOLS,
+            cls.MINIMAX_TOOLS,
         }
 
     @classmethod
@@ -120,6 +125,7 @@ class Mode(enum.Enum):
             cls.OPENROUTER_STRUCTURED_OUTPUTS,
             cls.MISTRAL_STRUCTURED_OUTPUTS,
             cls.XAI_JSON,
+            cls.MINIMAX_JSON,
         }
 
     @classmethod

--- a/instructor/models.py
+++ b/instructor/models.py
@@ -159,5 +159,11 @@ KnownModelName = TypeAliasType(
         # DeepSeek Models
         "deepseek/deepseek-chat",
         "deepseek/deepseek-reasoner",
+        # MiniMax Models
+        "minimax/MiniMax-Text-01",
+        "minimax/abab6.5s-chat",
+        "minimax/abab6.5-chat",
+        "minimax/abab5.5s-chat",
+        "minimax/abab5.5-chat",
     ],
 )

--- a/instructor/processing/function_calls.py
+++ b/instructor/processing/function_calls.py
@@ -240,6 +240,7 @@ class OpenAISchema(BaseModel):
             Mode.TOOLS_STRICT,
             Mode.CEREBRAS_TOOLS,
             Mode.FIREWORKS_TOOLS,
+            Mode.MINIMAX_TOOLS,
         }:
             return cls.parse_tools(completion, validation_context, strict)
 
@@ -252,6 +253,7 @@ class OpenAISchema(BaseModel):
             Mode.FIREWORKS_JSON,
             Mode.PERPLEXITY_JSON,
             Mode.OPENROUTER_STRUCTURED_OUTPUTS,
+            Mode.MINIMAX_JSON,
         }:
             return cls.parse_json(completion, validation_context, strict)
 

--- a/instructor/processing/response.py
+++ b/instructor/processing/response.py
@@ -146,6 +146,14 @@ from ..providers.perplexity.utils import (
     reask_perplexity_json,
 )
 
+# MiniMax utils
+from ..providers.minimax.utils import (
+    handle_minimax_json,
+    handle_minimax_tools,
+    reask_minimax_json,
+    reask_minimax_tools,
+)
+
 # Writer utils
 from ..providers.writer.utils import (
     handle_writer_json,
@@ -490,6 +498,8 @@ def handle_response_model(
         Mode.BEDROCK_JSON: handle_bedrock_json,
         Mode.BEDROCK_TOOLS: handle_bedrock_tools,
         Mode.PERPLEXITY_JSON: handle_perplexity_json,
+        Mode.MINIMAX_TOOLS: handle_minimax_tools,
+        Mode.MINIMAX_JSON: handle_minimax_json,
         Mode.OPENROUTER_STRUCTURED_OUTPUTS: handle_openrouter_structured_outputs,
         Mode.RESPONSES_TOOLS: handle_responses_tools,
         Mode.RESPONSES_TOOLS_WITH_INBUILT_TOOLS: handle_responses_tools_with_inbuilt_tools,
@@ -688,6 +698,9 @@ def handle_reask_kwargs(
         Mode.BEDROCK_JSON: reask_bedrock_json,
         # Perplexity modes
         Mode.PERPLEXITY_JSON: reask_perplexity_json,
+        # MiniMax modes
+        Mode.MINIMAX_TOOLS: reask_minimax_tools,
+        Mode.MINIMAX_JSON: reask_minimax_json,
         # OpenRouter modes
         Mode.OPENROUTER_STRUCTURED_OUTPUTS: reask_md_json,
         # XAI modes

--- a/instructor/providers/minimax/__init__.py
+++ b/instructor/providers/minimax/__init__.py
@@ -1,0 +1,1 @@
+"""Provider implementation."""

--- a/instructor/providers/minimax/client.py
+++ b/instructor/providers/minimax/client.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import os
+from typing import Any, overload
+
+import openai
+
+import instructor
+
+
+DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.chat/v1"
+
+
+def _build_openai_client(
+    async_client: bool,
+    api_key: str | None,
+    base_url: str | None,
+) -> openai.OpenAI | openai.AsyncOpenAI:
+    """Construct an OpenAI-compatible client pointed at MiniMax."""
+    resolved_api_key = api_key or os.environ.get("MINIMAX_API_KEY")
+    if not resolved_api_key:
+        from ...core.exceptions import ConfigurationError
+
+        raise ConfigurationError(
+            "MINIMAX_API_KEY is not set. "
+            "Set it with `export MINIMAX_API_KEY=<your-api-key>` or "
+            "pass it as a kwarg `api_key=<your-api-key>`."
+        )
+
+    resolved_base_url = base_url or DEFAULT_MINIMAX_BASE_URL
+    if async_client:
+        return openai.AsyncOpenAI(api_key=resolved_api_key, base_url=resolved_base_url)
+    return openai.OpenAI(api_key=resolved_api_key, base_url=resolved_base_url)
+
+
+@overload
+def from_minimax(
+    client: openai.OpenAI,
+    mode: instructor.Mode = instructor.Mode.MINIMAX_TOOLS,
+    **kwargs: Any,
+) -> instructor.Instructor: ...
+
+
+@overload
+def from_minimax(
+    client: openai.AsyncOpenAI,
+    mode: instructor.Mode = instructor.Mode.MINIMAX_TOOLS,
+    **kwargs: Any,
+) -> instructor.AsyncInstructor: ...
+
+
+@overload
+def from_minimax(
+    client: None = None,
+    mode: instructor.Mode = instructor.Mode.MINIMAX_TOOLS,
+    *,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    async_client: bool = False,
+    **kwargs: Any,
+) -> instructor.Instructor | instructor.AsyncInstructor: ...
+
+
+def from_minimax(
+    client: openai.OpenAI | openai.AsyncOpenAI | None = None,
+    mode: instructor.Mode = instructor.Mode.MINIMAX_TOOLS,
+    *,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    async_client: bool = False,
+    **kwargs: Any,
+) -> instructor.Instructor | instructor.AsyncInstructor:
+    """Create an Instructor client for the MiniMax API.
+
+    MiniMax exposes an OpenAI-compatible chat completions endpoint, so this
+    factory wraps an ``openai`` client configured to talk to MiniMax. If no
+    client is provided, one is constructed automatically using the
+    ``MINIMAX_API_KEY`` environment variable and the default MiniMax base
+    URL (``https://api.minimax.chat/v1``).
+
+    Args:
+        client: An optional pre-configured ``openai.OpenAI`` or
+            ``openai.AsyncOpenAI`` client pointing at MiniMax.
+        mode: The mode to use for the client. Must be one of
+            ``MINIMAX_TOOLS`` or ``MINIMAX_JSON``.
+        api_key: API key to use when constructing a client automatically.
+            Falls back to the ``MINIMAX_API_KEY`` environment variable.
+        base_url: Override the default MiniMax base URL.
+        async_client: When ``client`` is ``None``, controls whether an async
+            or sync client is constructed.
+        **kwargs: Additional arguments forwarded to the Instructor client.
+
+    Returns:
+        An ``Instructor`` or ``AsyncInstructor`` instance.
+    """
+    valid_modes = {instructor.Mode.MINIMAX_TOOLS, instructor.Mode.MINIMAX_JSON}
+
+    if mode not in valid_modes:
+        from ...core.exceptions import ModeError
+
+        raise ModeError(
+            mode=str(mode),
+            provider="MiniMax",
+            valid_modes=[str(m) for m in valid_modes],
+        )
+
+    if client is None:
+        client = _build_openai_client(
+            async_client=async_client,
+            api_key=api_key,
+            base_url=base_url,
+        )
+
+    if not isinstance(client, (openai.OpenAI, openai.AsyncOpenAI)):
+        from ...core.exceptions import ClientError
+
+        raise ClientError(
+            "Client must be an instance of openai.OpenAI or openai.AsyncOpenAI. "
+            f"Got: {type(client).__name__}"
+        )
+
+    if isinstance(client, openai.AsyncOpenAI):
+        create = client.chat.completions.create
+        return instructor.AsyncInstructor(
+            client=client,
+            create=instructor.patch(create=create, mode=mode),
+            provider=instructor.Provider.MINIMAX,
+            mode=mode,
+            **kwargs,
+        )
+
+    create = client.chat.completions.create
+    return instructor.Instructor(
+        client=client,
+        create=instructor.patch(create=create, mode=mode),
+        provider=instructor.Provider.MINIMAX,
+        mode=mode,
+        **kwargs,
+    )

--- a/instructor/providers/minimax/utils.py
+++ b/instructor/providers/minimax/utils.py
@@ -1,0 +1,148 @@
+"""MiniMax-specific utilities.
+
+This module contains utilities specific to the MiniMax provider,
+including reask functions and response handlers. MiniMax exposes an
+OpenAI-compatible chat completions API, so the handlers delegate to the
+shared OpenAI helpers.
+"""
+
+from __future__ import annotations
+
+import json
+from textwrap import dedent
+from typing import Any
+
+from ...mode import Mode
+from ...processing.schema import generate_openai_schema
+from ...utils.core import dump_message
+
+
+def reask_minimax_tools(
+    kwargs: dict[str, Any],
+    response: Any,
+    exception: Exception,
+):
+    """
+    Handle reask for MiniMax tools mode when validation fails.
+
+    Kwargs modifications:
+    - Adds: "messages" (tool response messages indicating validation errors)
+    """
+    kwargs = kwargs.copy()
+    reask_msgs = [dump_message(response.choices[0].message)]
+    for tool_call in response.choices[0].message.tool_calls:
+        reask_msgs.append(
+            {
+                "role": "tool",
+                "tool_call_id": tool_call.id,
+                "name": tool_call.function.name,
+                "content": (
+                    f"Validation Error found:\n{exception}\n"
+                    "Recall the function correctly, fix the errors"
+                ),
+            }
+        )
+    kwargs["messages"].extend(reask_msgs)
+    return kwargs
+
+
+def reask_minimax_json(
+    kwargs: dict[str, Any],
+    response: Any,
+    exception: Exception,
+):
+    """
+    Handle reask for MiniMax JSON mode when validation fails.
+
+    Kwargs modifications:
+    - Adds: "messages" (user message requesting JSON correction)
+    """
+    kwargs = kwargs.copy()
+    reask_msgs = [dump_message(response.choices[0].message)]
+    reask_msgs.append(
+        {
+            "role": "user",
+            "content": (
+                "Correct your JSON ONLY RESPONSE, based on the following errors:\n"
+                f"{exception}"
+            ),
+        }
+    )
+    kwargs["messages"].extend(reask_msgs)
+    return kwargs
+
+
+def handle_minimax_tools(
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
+    """
+    Handle MiniMax tools mode.
+
+    Kwargs modifications:
+    - When response_model is None: No modifications
+    - When response_model is provided:
+      - Adds: "tools" (list with function schema)
+      - Adds: "tool_choice" (forced function call)
+    """
+    if response_model is None:
+        return None, new_kwargs
+
+    schema = generate_openai_schema(response_model)
+    new_kwargs["tools"] = [
+        {
+            "type": "function",
+            "function": schema,
+        }
+    ]
+    new_kwargs["tool_choice"] = {
+        "type": "function",
+        "function": {"name": schema["name"]},
+    }
+    return response_model, new_kwargs
+
+
+def handle_minimax_json(
+    response_model: type[Any] | None, new_kwargs: dict[str, Any]
+) -> tuple[type[Any] | None, dict[str, Any]]:
+    """
+    Handle MiniMax JSON mode.
+
+    Kwargs modifications:
+    - When response_model is None: No modifications
+    - When response_model is provided:
+      - Adds: "response_format" with type="json_object"
+      - Appends a user message describing the expected JSON schema
+    """
+    if response_model is None:
+        return None, new_kwargs
+
+    message = dedent(
+        f"""
+        Parse the content and return a JSON object matching this schema:
+
+        {json.dumps(response_model.model_json_schema(), indent=2, ensure_ascii=False)}
+
+        Return a valid JSON instance, not the schema definition."""
+    )
+
+    new_kwargs["response_format"] = {"type": "json_object"}
+    new_kwargs["messages"].append(
+        {
+            "role": "user",
+            "content": message,
+        }
+    )
+    return response_model, new_kwargs
+
+
+# Handler registry for MiniMax
+MINIMAX_HANDLERS = {
+    Mode.MINIMAX_TOOLS: {
+        "reask": reask_minimax_tools,
+        "response": handle_minimax_tools,
+    },
+    Mode.MINIMAX_JSON: {
+        "reask": reask_minimax_json,
+        "response": handle_minimax_json,
+    },
+}

--- a/instructor/utils/providers.py
+++ b/instructor/utils/providers.py
@@ -27,6 +27,7 @@ class Provider(Enum):
     BEDROCK = "bedrock"
     PERPLEXITY = "perplexity"
     OPENROUTER = "openrouter"
+    MINIMAX = "minimax"
 
 
 def get_provider(base_url: str) -> Provider:
@@ -73,4 +74,6 @@ def get_provider(base_url: str) -> Provider:
         return Provider.XAI
     elif "openrouter" in str(base_url):
         return Provider.OPENROUTER
+    elif "minimax" in str(base_url):
+        return Provider.MINIMAX
     return Provider.UNKNOWN

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,6 +189,7 @@ nav:
     - Databricks: 'integrations/databricks.md'
     - Cortex: 'integrations/cortex.md'
     - LiteLLM: 'integrations/litellm.md'
+    - MiniMax: 'integrations/minimax.md'
     - Mistral: 'integrations/mistral.md'
     - Ollama: 'integrations/ollama.md'
     - Perplexity: 'integrations/perplexity.md'

--- a/tests/llm/test_minimax.py
+++ b/tests/llm/test_minimax.py
@@ -1,0 +1,253 @@
+"""Unit tests for the MiniMax provider.
+
+These tests exercise the ``from_minimax`` factory and the mode dispatch paths
+without making real API calls. MiniMax exposes an OpenAI-compatible API, so
+the tests use mocked ``openai`` clients to assert that Instructor configures
+requests correctly for each supported mode.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import openai
+import pytest
+from pydantic import BaseModel
+
+import instructor
+from instructor.providers.minimax.client import (
+    DEFAULT_MINIMAX_BASE_URL,
+    from_minimax,
+)
+from instructor.providers.minimax.utils import (
+    MINIMAX_HANDLERS,
+    handle_minimax_json,
+    handle_minimax_tools,
+    reask_minimax_json,
+    reask_minimax_tools,
+)
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+def _make_sync_client() -> openai.OpenAI:
+    return openai.OpenAI(api_key="test-key", base_url=DEFAULT_MINIMAX_BASE_URL)
+
+
+def _make_async_client() -> openai.AsyncOpenAI:
+    return openai.AsyncOpenAI(api_key="test-key", base_url=DEFAULT_MINIMAX_BASE_URL)
+
+
+def test_from_minimax_returns_sync_instructor():
+    client = _make_sync_client()
+    result = from_minimax(client)
+
+    assert isinstance(result, instructor.Instructor)
+    assert result.provider == instructor.Provider.MINIMAX
+    assert result.mode == instructor.Mode.MINIMAX_TOOLS
+
+
+def test_from_minimax_returns_async_instructor():
+    client = _make_async_client()
+    result = from_minimax(client, mode=instructor.Mode.MINIMAX_JSON)
+
+    assert isinstance(result, instructor.AsyncInstructor)
+    assert result.provider == instructor.Provider.MINIMAX
+    assert result.mode == instructor.Mode.MINIMAX_JSON
+
+
+def test_from_minimax_builds_default_client(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "env-key")
+
+    result = from_minimax()
+
+    assert isinstance(result, instructor.Instructor)
+    assert isinstance(result.client, openai.OpenAI)
+    assert str(result.client.base_url).rstrip("/") == DEFAULT_MINIMAX_BASE_URL
+
+
+def test_from_minimax_builds_async_default_client(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "env-key")
+
+    result = from_minimax(async_client=True, mode=instructor.Mode.MINIMAX_JSON)
+
+    assert isinstance(result, instructor.AsyncInstructor)
+    assert isinstance(result.client, openai.AsyncOpenAI)
+
+
+def test_from_minimax_missing_api_key_raises(monkeypatch: pytest.MonkeyPatch):
+    from instructor.core.exceptions import ConfigurationError
+
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+
+    with pytest.raises(ConfigurationError, match="MINIMAX_API_KEY"):
+        from_minimax()
+
+
+def test_from_minimax_invalid_mode_raises():
+    from instructor.core.exceptions import ModeError
+
+    client = _make_sync_client()
+
+    with pytest.raises(ModeError):
+        from_minimax(client, mode=instructor.Mode.TOOLS)
+
+
+def test_from_minimax_invalid_client_raises():
+    from instructor.core.exceptions import ClientError
+
+    with pytest.raises(ClientError):
+        from_minimax(object())  # type: ignore[arg-type]
+
+
+def test_handle_minimax_tools_adds_tool_definition():
+    response_model, kwargs = handle_minimax_tools(
+        User, {"messages": [{"role": "user", "content": "Extract"}]}
+    )
+
+    assert response_model is User
+    assert kwargs["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "User"},
+    }
+    assert len(kwargs["tools"]) == 1
+    tool = kwargs["tools"][0]
+    assert tool["type"] == "function"
+    assert tool["function"]["name"] == "User"
+    assert "parameters" in tool["function"]
+
+
+def test_handle_minimax_tools_noop_without_response_model():
+    response_model, kwargs = handle_minimax_tools(None, {"messages": []})
+
+    assert response_model is None
+    assert "tools" not in kwargs
+    assert "tool_choice" not in kwargs
+
+
+def test_handle_minimax_json_adds_response_format_and_schema_message():
+    response_model, kwargs = handle_minimax_json(
+        User, {"messages": [{"role": "user", "content": "Extract"}]}
+    )
+
+    assert response_model is User
+    assert kwargs["response_format"] == {"type": "json_object"}
+    assert kwargs["messages"][-1]["role"] == "user"
+    # The appended message must include the JSON schema for the model.
+    schema_fragment = json.dumps(
+        User.model_json_schema(), indent=2, ensure_ascii=False
+    )
+    assert schema_fragment in kwargs["messages"][-1]["content"]
+
+
+def test_handle_minimax_json_noop_without_response_model():
+    response_model, kwargs = handle_minimax_json(None, {"messages": []})
+
+    assert response_model is None
+    assert "response_format" not in kwargs
+
+
+def _make_tool_response() -> MagicMock:
+    from openai.types.chat import ChatCompletionMessage
+    from openai.types.chat.chat_completion_message_tool_call import (
+        ChatCompletionMessageToolCall,
+        Function,
+    )
+
+    tool_call = ChatCompletionMessageToolCall(
+        id="call-1",
+        type="function",
+        function=Function(name="User", arguments="{}"),
+    )
+    message = ChatCompletionMessage(
+        role="assistant",
+        content=None,
+        tool_calls=[tool_call],
+    )
+    response = MagicMock()
+    response.choices = [MagicMock(message=message)]
+    return response
+
+
+def _make_json_response() -> MagicMock:
+    from openai.types.chat import ChatCompletionMessage
+
+    message = ChatCompletionMessage(role="assistant", content="{}")
+    response = MagicMock()
+    response.choices = [MagicMock(message=message)]
+    return response
+
+
+def test_reask_minimax_tools_appends_tool_messages():
+    response = _make_tool_response()
+
+    new_kwargs = reask_minimax_tools(
+        {"messages": [{"role": "user", "content": "Extract"}]},
+        response,
+        ValueError("bad"),
+    )
+
+    roles = [m["role"] for m in new_kwargs["messages"]]
+    assert "tool" in roles
+    tool_msg = next(m for m in new_kwargs["messages"] if m["role"] == "tool")
+    assert tool_msg["tool_call_id"] == "call-1"
+    assert tool_msg["name"] == "User"
+    assert "Validation Error" in tool_msg["content"]
+
+
+def test_reask_minimax_json_appends_user_correction():
+    response = _make_json_response()
+
+    new_kwargs = reask_minimax_json(
+        {"messages": [{"role": "user", "content": "Extract"}]},
+        response,
+        ValueError("bad"),
+    )
+
+    last = new_kwargs["messages"][-1]
+    assert last["role"] == "user"
+    assert "JSON ONLY RESPONSE" in last["content"]
+
+
+def test_minimax_handlers_registry():
+    assert set(MINIMAX_HANDLERS.keys()) == {
+        instructor.Mode.MINIMAX_TOOLS,
+        instructor.Mode.MINIMAX_JSON,
+    }
+    for entry in MINIMAX_HANDLERS.values():
+        assert callable(entry["response"])
+        assert callable(entry["reask"])
+
+
+def test_from_provider_minimax_uses_env_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "env-key")
+
+    client = instructor.from_provider("minimax/MiniMax-Text-01")
+
+    assert isinstance(client, instructor.Instructor)
+    assert client.provider == instructor.Provider.MINIMAX
+    assert client.mode == instructor.Mode.MINIMAX_TOOLS
+
+
+def test_from_provider_minimax_missing_key(monkeypatch: pytest.MonkeyPatch):
+    from instructor.core.exceptions import ConfigurationError
+
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+
+    with pytest.raises(ConfigurationError, match="MINIMAX_API_KEY"):
+        instructor.from_provider("minimax/MiniMax-Text-01")
+
+
+def test_get_provider_detects_minimax_base_url():
+    from instructor.utils.providers import get_provider
+
+    assert get_provider("https://api.minimax.chat/v1") == instructor.Provider.MINIMAX
+
+
+def test_mode_classifications_include_minimax():
+    assert instructor.Mode.MINIMAX_TOOLS in instructor.Mode.tool_modes()
+    assert instructor.Mode.MINIMAX_JSON in instructor.Mode.json_modes()

--- a/tests/llm/test_minimax.py
+++ b/tests/llm/test_minimax.py
@@ -138,9 +138,7 @@ def test_handle_minimax_json_adds_response_format_and_schema_message():
     assert kwargs["response_format"] == {"type": "json_object"}
     assert kwargs["messages"][-1]["role"] == "user"
     # The appended message must include the JSON schema for the model.
-    schema_fragment = json.dumps(
-        User.model_json_schema(), indent=2, ensure_ascii=False
-    )
+    schema_fragment = json.dumps(User.model_json_schema(), indent=2, ensure_ascii=False)
     assert schema_fragment in kwargs["messages"][-1]["content"]
 
 


### PR DESCRIPTION
## Summary
- Add `from_minimax()` factory and `from_provider("minimax/...")` support targeting MiniMax's OpenAI-compatible chat completions API (`https://api.minimax.chat/v1`), with `MINIMAX_API_KEY` environment-variable fallback.
- Introduce `Mode.MINIMAX_TOOLS` (default) and `Mode.MINIMAX_JSON`, with matching response/reask handlers wired into the central dispatchers (`processing/response.py`, `processing/function_calls.py`) and streaming mode sets (`dsl/iterable.py`, `dsl/partial.py`).
- Register `Provider.MINIMAX`, base-URL detection in `get_provider`, known MiniMax model names in `models.py`, and an `auto_client` handler so `from_provider("minimax/MiniMax-Text-01")` works end-to-end.
- Add an integration doc, a cookbook example, a `CHANGELOG.md` entry, and 18 unit tests that mock the OpenAI client so no live API calls are made.

Closes #2260.

## Test plan
- [x] `ruff check instructor tests/llm/test_minimax.py examples/minimax_example.py` — all checks passed
- [x] `ruff format --check` clean on new files
- [x] `pytest tests/llm/test_minimax.py -v` — 18/18 passed
- [x] `pytest tests/dsl/ tests/test_xai_optional_dependency.py -k "not llm and not openai"` — still green
- [x] `from_provider("minimax/MiniMax-Text-01", api_key="...")` returns an `Instructor` with `Provider.MINIMAX` and `Mode.MINIMAX_TOOLS`
- [x] `get_provider("https://api.minimax.chat/v1")` resolves to `Provider.MINIMAX`