### PR TITLE
feat(providers): add Manifest provider support

### DIFF
--- a/docs/integrations/manifest.md
+++ b/docs/integrations/manifest.md
@@ -1,0 +1,184 @@
+---
+title: "Structured outputs with Manifest, a complete guide with instructor"
+description: "Learn how to use Instructor with Manifest, a smart LLM router that scores each request and routes it to the cheapest capable model. Get type-safe, structured outputs with automatic cost optimization."
+---
+
+# Structured outputs with Manifest, a complete guide with instructor
+
+[Manifest](https://manifest.build/) is a smart model router for AI agents. It sits between your agent and your LLM providers, scores each request across 23 dimensions, and routes it to the cheapest model that can handle it. This guide shows you how to use Instructor with Manifest for type-safe, validated responses with automatic cost optimization.
+
+## Quick Start
+
+Install Instructor with the OpenAI extra (Manifest uses an OpenAI-compatible API):
+
+```bash
+pip install "instructor[openai]"
+```
+
+Set your Manifest API key:
+
+```bash
+export MANIFEST_API_KEY=<your-api-key>
+```
+
+You can get an API key at [app.manifest.build](https://app.manifest.build).
+
+## Simple User Example (Sync)
+
+The `"auto"` model lets Manifest automatically select the best model for each request.
+
+```python
+import instructor
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+client = instructor.from_provider(
+    "manifest/auto",
+    async_client=False,
+)
+
+resp = client.create(
+    messages=[
+        {
+            "role": "user",
+            "content": "Ivan is 28 years old",
+        },
+    ],
+    response_model=User,
+)
+
+print(resp)
+#> name='Ivan' age=28
+```
+
+## Simple User Example (Async)
+
+```python
+import instructor
+from pydantic import BaseModel
+import asyncio
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+client = instructor.from_provider(
+    "manifest/auto",
+    async_client=True,
+)
+
+
+async def extract_user():
+    user = await client.create(
+        messages=[
+            {"role": "user", "content": "Extract: Jason is 25 years old"},
+        ],
+        response_model=User,
+    )
+    return user
+
+
+user = asyncio.run(extract_user())
+print(user)
+#> name='Jason' age=25
+```
+
+## Nested Object Example
+
+```python
+import instructor
+from pydantic import BaseModel
+
+
+class Address(BaseModel):
+    street: str
+    city: str
+    country: str
+
+
+class User(BaseModel):
+    name: str
+    age: int
+    addresses: list[Address]
+
+
+client = instructor.from_provider(
+    "manifest/auto",
+    async_client=False,
+)
+
+user = client.create(
+    messages=[
+        {
+            "role": "user",
+            "content": """
+            Extract: Jason is 25 years old.
+            He lives at 123 Main St, New York, USA
+            and has a summer house at 456 Beach Rd, Miami, USA
+        """,
+        },
+    ],
+    response_model=User,
+)
+
+print(user)
+#> name='Jason' age=25 addresses=[Address(street='123 Main St', city='New York', country='USA'), Address(street='456 Beach Rd', city='Miami', country='USA')]
+```
+
+## Streaming
+
+```python
+import instructor
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+client = instructor.from_provider(
+    "manifest/auto",
+    async_client=False,
+)
+
+user = client.create_partial(
+    messages=[
+        {
+            "role": "user",
+            "content": "Extract: Jason is 25 years old",
+        },
+    ],
+    response_model=User,
+)
+
+for chunk in user:
+    print(chunk)
+    #> name=None age=None
+    #> name='Jason' age=None
+    #> name='Jason' age=25
+```
+
+## Self-Hosted
+
+If you're running Manifest locally via Docker, point to your instance:
+
+```python
+client = instructor.from_provider(
+    "manifest/auto",
+    base_url="http://localhost:3001/v1",
+    async_client=False,
+)
+```
+
+## Related Resources
+
+- [Manifest documentation](https://manifest.build/docs)
+- [Instructor concepts](../concepts/index.md)

--- a/instructor/auto_client.py
+++ b/instructor/auto_client.py
@@ -35,6 +35,7 @@ supported_providers = [
     "ollama",
     "openrouter",
     "xai",
+    "manifest",
     "litellm",
 ]
 
@@ -1184,6 +1185,60 @@ def from_provider(
 
             raise ConfigurationError(
                 "The openai package is required to use the OpenRouter provider. "
+                "Install it with `pip install openai`."
+            ) from None
+        except Exception as e:
+            logger.error(
+                "Error initializing %s client: %s",
+                provider,
+                e,
+                exc_info=True,
+                extra={**provider_info, "status": "error"},
+            )
+            raise
+
+    elif provider == "manifest":
+        try:
+            import openai
+            from instructor import from_openai  # type: ignore[attr-defined]
+            import os
+
+            # Get API key from kwargs or environment
+            api_key = api_key or os.environ.get("MANIFEST_API_KEY")
+
+            if not api_key:
+                from .core.exceptions import ConfigurationError
+
+                raise ConfigurationError(
+                    "MANIFEST_API_KEY is not set. "
+                    "Set it with `export MANIFEST_API_KEY=<your-api-key>` or pass it as kwarg api_key=<your-api-key>"
+                )
+
+            # Manifest uses OpenAI-compatible API
+            base_url = kwargs.pop("base_url", "https://app.manifest.build/v1")
+
+            client = (
+                openai.AsyncOpenAI(api_key=api_key, base_url=base_url)
+                if async_client
+                else openai.OpenAI(api_key=api_key, base_url=base_url)
+            )
+
+            result = from_openai(
+                client,
+                model=model_name,
+                mode=mode if mode else instructor.Mode.TOOLS,
+                **kwargs,
+            )
+            logger.info(
+                "Client initialized",
+                extra={**provider_info, "status": "success"},
+            )
+            return result
+        except ImportError:
+            from .core.exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "The openai package is required to use the Manifest provider. "
                 "Install it with `pip install openai`."
             ) from None
         except Exception as e:

--- a/instructor/utils/providers.py
+++ b/instructor/utils/providers.py
@@ -27,6 +27,7 @@ class Provider(Enum):
     BEDROCK = "bedrock"
     PERPLEXITY = "perplexity"
     OPENROUTER = "openrouter"
+    MANIFEST = "manifest"
 
 
 def get_provider(base_url: str) -> Provider:
@@ -73,4 +74,6 @@ def get_provider(base_url: str) -> Provider:
         return Provider.XAI
     elif "openrouter" in str(base_url):
         return Provider.OPENROUTER
+    elif "manifest" in str(base_url):
+        return Provider.MANIFEST
     return Provider.UNKNOWN

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -193,6 +193,7 @@ nav:
     - Ollama: 'integrations/ollama.md'
     - Perplexity: 'integrations/perplexity.md'
     - Writer: 'integrations/writer.md'
+    - Manifest: 'integrations/manifest.md'
     - OpenRouter: 'integrations/openrouter.md'
     - SambaNova: 'integrations/sambanova.md'
     - TrueFoundry: 'integrations/truefoundry.md'


### PR DESCRIPTION
## Summary

Add [Manifest](https://manifest.build/) as a supported provider. Manifest is a smart LLM router that scores each request across 23 dimensions and routes it to the cheapest capable model. It exposes an OpenAI-compatible API, so integration follows the same pattern as OpenRouter and DeepSeek.

**Usage:**

```python
import instructor
from pydantic import BaseModel

class User(BaseModel):
    name: str
    age: int

client = instructor.from_provider("manifest/auto", async_client=False)

resp = client.create(
    messages=[{"role": "user", "content": "Ivan is 28 years old"}],
    response_model=User,
)
print(resp)
#> name='Ivan' age=28
```

## Changes

- **`instructor/auto_client.py`**: Add `manifest` to `supported_providers` list and `elif provider == "manifest":` handler (follows OpenRouter pattern)
- **`instructor/utils/providers.py`**: Add `MANIFEST` to `Provider` enum and base_url detection in `get_provider()`
- **`docs/integrations/manifest.md`**: Integration guide with sync, async, nested objects, and streaming examples
- **`mkdocs.yml`**: Register docs in navigation

## Testing

Tested manually against the live Manifest API:

- [x] `from_provider("manifest/auto")` creates a valid client
- [x] Simple extraction (sync): `name='Ivan' age=28`
- [x] Nested objects: addresses extracted correctly
- [x] Streaming (`create_partial`): chunks received
- [x] Ruff linting passes (`ruff check` + `ruff format`)
- [x] Existing `test_auto_client.py` tests unaffected (15 passed, 3 pre-existing failures from missing google module)