### PR TITLE
fix(hooks): expose attempt_number, max_attempts, is_last_attempt on completion:error and completion:last_attempt hooks

### DIFF
--- a/instructor/core/hooks.py
+++ b/instructor/core/hooks.py
@@ -32,9 +32,38 @@ class CompletionResponseHandler(Protocol):
 
 
 class CompletionErrorHandler(Protocol):
-    """Protocol for completion error and last attempt handlers."""
+    """Protocol for completion error and last attempt handlers.
 
-    def __call__(self, error: Exception) -> None: ...
+    Handlers may optionally accept retry metadata as keyword arguments:
+
+    - ``attempt_number`` (int): 1-based index of the current attempt.
+    - ``max_attempts`` (int | None): Maximum number of attempts configured, or
+      ``None`` when unbounded.
+    - ``is_last_attempt`` (bool): ``True`` when no further retries will be made.
+
+    Example::
+
+        def on_error(
+            error: Exception,
+            *,
+            attempt_number: int = 1,
+            max_attempts: int | None = None,
+            is_last_attempt: bool = False,
+        ) -> None:
+            severity = "ERROR" if is_last_attempt else "WARNING"
+            print(f"[{severity}] attempt {attempt_number}/{max_attempts}: {error}")
+
+        client.on("completion:error", on_error)
+    """
+
+    def __call__(
+        self,
+        error: Exception,
+        *,
+        attempt_number: int = ...,
+        max_attempts: int | None = ...,
+        is_last_attempt: bool = ...,
+    ) -> None: ...
 
 
 class ParseErrorHandler(Protocol):

--- a/tests/test_hooks_retry_metadata.py
+++ b/tests/test_hooks_retry_metadata.py
@@ -1,0 +1,123 @@
+"""Tests for retry metadata exposed via completion:error and completion:last_attempt hooks.
+
+Verifies that handlers registered on these hooks receive attempt_number,
+max_attempts, and is_last_attempt as keyword arguments (issue #2222).
+"""
+
+from instructor.core.hooks import Hooks, HookName
+
+
+class TestCompletionErrorMetadata:
+    def test_attempt_number_forwarded(self):
+        hooks = Hooks()
+        received: dict = {}
+
+        def handler(error: Exception, *, attempt_number: int = 0, **kw):
+            received["attempt_number"] = attempt_number
+
+        hooks.on(HookName.COMPLETION_ERROR, handler)
+        hooks.emit_completion_error(ValueError("boom"), attempt_number=3, max_attempts=5, is_last_attempt=False)
+
+        assert received["attempt_number"] == 3
+
+    def test_max_attempts_forwarded(self):
+        hooks = Hooks()
+        received: dict = {}
+
+        def handler(error: Exception, *, max_attempts=None, **kw):
+            received["max_attempts"] = max_attempts
+
+        hooks.on(HookName.COMPLETION_ERROR, handler)
+        hooks.emit_completion_error(ValueError("boom"), attempt_number=1, max_attempts=5, is_last_attempt=False)
+
+        assert received["max_attempts"] == 5
+
+    def test_is_last_attempt_false(self):
+        hooks = Hooks()
+        received: dict = {}
+
+        def handler(error: Exception, *, is_last_attempt: bool = True, **kw):
+            received["is_last_attempt"] = is_last_attempt
+
+        hooks.on(HookName.COMPLETION_ERROR, handler)
+        hooks.emit_completion_error(ValueError("boom"), attempt_number=1, max_attempts=3, is_last_attempt=False)
+
+        assert received["is_last_attempt"] is False
+
+    def test_is_last_attempt_true(self):
+        hooks = Hooks()
+        received: dict = {}
+
+        def handler(error: Exception, *, is_last_attempt: bool = False, **kw):
+            received["is_last_attempt"] = is_last_attempt
+
+        hooks.on(HookName.COMPLETION_ERROR, handler)
+        hooks.emit_completion_error(ValueError("boom"), attempt_number=3, max_attempts=3, is_last_attempt=True)
+
+        assert received["is_last_attempt"] is True
+
+    def test_handler_without_metadata_params_still_called(self):
+        """Handlers that only accept error (old-style) must still work."""
+        hooks = Hooks()
+        received: list = []
+
+        def handler(error: Exception):
+            received.append(error)
+
+        hooks.on(HookName.COMPLETION_ERROR, handler)
+        err = ValueError("boom")
+        hooks.emit_completion_error(err, attempt_number=1, max_attempts=3, is_last_attempt=False)
+
+        assert received == [err]
+
+    def test_max_attempts_none_when_unbounded(self):
+        hooks = Hooks()
+        received: dict = {}
+
+        def handler(error: Exception, *, max_attempts=..., **kw):
+            received["max_attempts"] = max_attempts
+
+        hooks.on(HookName.COMPLETION_ERROR, handler)
+        hooks.emit_completion_error(ValueError("boom"), attempt_number=1, max_attempts=None, is_last_attempt=False)
+
+        assert received["max_attempts"] is None
+
+
+class TestCompletionLastAttemptMetadata:
+    def test_attempt_number_forwarded(self):
+        hooks = Hooks()
+        received: dict = {}
+
+        def handler(error: Exception, *, attempt_number: int = 0, **kw):
+            received["attempt_number"] = attempt_number
+
+        hooks.on(HookName.COMPLETION_LAST_ATTEMPT, handler)
+        hooks.emit_completion_last_attempt(ValueError("final"), attempt_number=5, max_attempts=5, is_last_attempt=True)
+
+        assert received["attempt_number"] == 5
+
+    def test_is_last_attempt_always_true(self):
+        hooks = Hooks()
+        received: dict = {}
+
+        def handler(error: Exception, *, is_last_attempt: bool = False, **kw):
+            received["is_last_attempt"] = is_last_attempt
+
+        hooks.on(HookName.COMPLETION_LAST_ATTEMPT, handler)
+        hooks.emit_completion_last_attempt(ValueError("final"), attempt_number=3, max_attempts=3, is_last_attempt=True)
+
+        assert received["is_last_attempt"] is True
+
+    def test_handler_without_metadata_params_still_called(self):
+        """Old-style handlers that only accept error must still work."""
+        hooks = Hooks()
+        received: list = []
+
+        def handler(error: Exception):
+            received.append(error)
+
+        hooks.on(HookName.COMPLETION_LAST_ATTEMPT, handler)
+        err = ValueError("final")
+        hooks.emit_completion_last_attempt(err, attempt_number=3, max_attempts=3, is_last_attempt=True)
+
+        assert received == [err]


### PR DESCRIPTION
## Summary

Closes #2222

`completion:error` and `completion:last_attempt` handlers can now receive retry metadata as keyword arguments — `attempt_number`, `max_attempts`, and `is_last_attempt` — without any breaking changes.

## What changed

**`instructor/core/hooks.py`** — `CompletionErrorHandler` Protocol updated to document the kwargs that `retry.py` already passes:

```python
class CompletionErrorHandler(Protocol):
    def __call__(
        self,
        error: Exception,
        *,
        attempt_number: int = ...,
        max_attempts: int | None = ...,
        is_last_attempt: bool = ...,
    ) -> None: ...
```

No changes to `retry.py` — it already passes these kwargs to `emit_completion_error()` and `emit_completion_last_attempt()`. The existing `inspect.signature` fallback in `Hooks.emit()` means old-style handlers (`def handler(error)`) continue to work unchanged.

## Usage

```python
def on_error(
    error: Exception,
    *,
    attempt_number: int = 1,
    max_attempts: int | None = None,
    is_last_attempt: bool = False,
) -> None:
    severity = "ERROR" if is_last_attempt else "WARNING"
    print(f"[{severity}] attempt {attempt_number}/{max_attempts}: {error}")

client.on("completion:error", on_error)
client.on("completion:last_attempt", on_error)
```

## Tests

9 new unit tests in `tests/test_hooks_retry_metadata.py` — no real API calls needed:
- `attempt_number` forwarded correctly
- `max_attempts` forwarded (including `None` for unbounded)
- `is_last_attempt` is `False` for intermediate errors, `True` for last attempt
- Old-style handlers (`error`-only) still called without breaking