### PR TITLE
fix(bedrock): strip think tags and fix reask crash for reasoning models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **Bedrock**: Strip `<think>...</think>` blocks from Bedrock responses in both `BEDROCK_JSON` and `MD_JSON` modes before JSON extraction, fixing parse failures with reasoning models such as Kimi K2 Thinking ([#2076](https://github.com/567-labs/instructor/issues/2076))
+- **Bedrock/MD_JSON**: `reask_md_json` no longer raises `AttributeError: 'dict' object has no attribute 'choices'` when retrying after a validation failure with a Bedrock converse dict response ([#2076](https://github.com/567-labs/instructor/issues/2076))
 - **Templating (GenAI/VertexAI)**: `process_message` no longer crashes with `TypeError: Can't compile non template nodes` when multimodal messages contain image/URI/bytes Parts alongside `validation_context`. Non-text Parts (where `part.text` is `None`) now pass through unchanged. ([#2253](https://github.com/567-labs/instructor/issues/2253))
 
 ---

--- a/instructor/processing/function_calls.py
+++ b/instructor/processing/function_calls.py
@@ -71,7 +71,9 @@ def _extract_text_content(completion: Any) -> str:
     # Bedrock format
     if isinstance(completion, dict) and "output" in completion:
         try:
-            return completion.get("output").get("message").get("content")[0].get("text")
+            text = completion.get("output").get("message").get("content")[0].get("text")
+            # Strip <think>...</think> blocks emitted by reasoning models before extraction
+            return re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
         except (AttributeError, IndexError):
             pass
 
@@ -447,6 +449,10 @@ class OpenAISchema(BaseModel):
                     raw_response=completion,
                 )
             text = text_content["text"]
+            # Strip <think>...</think> blocks emitted by reasoning models (e.g. Kimi K2)
+            # before attempting JSON extraction; the think block may itself contain
+            # braces that would confuse the JSON extractor.
+            text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
             match = re.search(r"```?json(.*?)```?", text, re.DOTALL)
             if match:
                 text = match.group(1).strip()

--- a/instructor/providers/bedrock/utils.py
+++ b/instructor/providers/bedrock/utils.py
@@ -42,6 +42,21 @@ def generate_bedrock_schema(response_model: type[Any]) -> dict[str, Any]:
     }
 
 
+def _strip_think_tags(text: str) -> str:
+    """
+    Strip <think>...</think> blocks from model output.
+
+    Some Bedrock models (e.g. Kimi K2 Thinking) prepend a reasoning block
+    wrapped in <think> tags before emitting the actual response.  These tags
+    must be removed before attempting JSON extraction; otherwise the first
+    '{' / last '}' found by the extractor may land inside the think block and
+    produce invalid JSON.
+    """
+    import re
+
+    return re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+
+
 def reask_bedrock_json(
     kwargs: dict[str, Any],
     response: Any,

--- a/instructor/providers/openai/utils.py
+++ b/instructor/providers/openai/utils.py
@@ -162,6 +162,23 @@ def reask_md_json(
     """
     kwargs = kwargs.copy()
 
+    # Handle Bedrock dict responses (no .choices attribute) before stream check,
+    # because dicts also fail hasattr(response, "choices").
+    if isinstance(response, dict) and "output" in response:
+        reask_msgs = [response["output"]["message"]]
+        reask_msgs.append(
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "text": f"Correct your JSON ONLY RESPONSE, based on the following errors:\n{exception}"
+                    }
+                ],
+            }
+        )
+        kwargs["messages"].extend(reask_msgs)
+        return kwargs
+
     # Handle Stream objects which don't have choices attribute
     if _is_stream_response(response):
         kwargs["messages"].append(

--- a/tests/llm/test_bedrock/test_think_tags.py
+++ b/tests/llm/test_bedrock/test_think_tags.py
@@ -1,0 +1,162 @@
+"""Tests for think-tag stripping in Bedrock response parsing.
+
+Bedrock reasoning models (e.g. Kimi K2 Thinking) prefix their actual response
+with a <think>...</think> block.  These tests verify that instructor strips those
+tags before attempting JSON extraction so that both BEDROCK_JSON and MD_JSON
+modes work without spurious retries.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from instructor.processing.function_calls import openai_schema
+
+
+class _User(BaseModel):
+    name: str
+    age: int
+
+
+User = openai_schema(_User)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal Bedrock converse() response dict
+# ---------------------------------------------------------------------------
+
+def _bedrock_response(text: str) -> dict:
+    return {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": text}],
+            }
+        },
+        "stopReason": "end_turn",
+    }
+
+
+# ---------------------------------------------------------------------------
+# parse_bedrock_json — BEDROCK_JSON mode
+# ---------------------------------------------------------------------------
+
+class TestParseBedrockJsonThinkTags:
+    def test_plain_json_no_think_tags(self):
+        response = _bedrock_response('{"name": "Jason", "age": 10}')
+        user = User.parse_bedrock_json(response)
+        assert user.name == "Jason"
+        assert user.age == 10
+
+    def test_think_tags_before_json(self):
+        text = "<think>Let me figure out the answer...</think>\n{\"name\": \"Jason\", \"age\": 10}"
+        response = _bedrock_response(text)
+        user = User.parse_bedrock_json(response)
+        assert user.name == "Jason"
+        assert user.age == 10
+
+    def test_think_tags_with_braces_inside(self):
+        """Think block may contain braces that would confuse naive JSON extraction."""
+        text = (
+            "<think>I'll return {\"key\": \"value\"} as the structure.</think>\n"
+            '{"name": "Alice", "age": 30}'
+        )
+        response = _bedrock_response(text)
+        user = User.parse_bedrock_json(response)
+        assert user.name == "Alice"
+        assert user.age == 30
+
+    def test_think_tags_with_json_in_codeblock(self):
+        text = (
+            "<think>Reasoning goes here.</think>\n"
+            "```json\n{\"name\": \"Bob\", \"age\": 25}\n```"
+        )
+        response = _bedrock_response(text)
+        user = User.parse_bedrock_json(response)
+        assert user.name == "Bob"
+        assert user.age == 25
+
+    def test_multiline_think_block(self):
+        text = (
+            "<think>\n"
+            "Line one of reasoning.\n"
+            "Line two with {json-like} content.\n"
+            "</think>\n"
+            '{"name": "Carol", "age": 22}'
+        )
+        response = _bedrock_response(text)
+        user = User.parse_bedrock_json(response)
+        assert user.name == "Carol"
+        assert user.age == 22
+
+
+# ---------------------------------------------------------------------------
+# _extract_text_content — used by parse_json / MD_JSON path
+# ---------------------------------------------------------------------------
+
+class TestExtractTextContentThinkTags:
+    """_extract_text_content strips think tags so parse_json (MD_JSON) works."""
+
+    def test_strips_think_tags_from_bedrock_dict(self):
+        from instructor.processing.function_calls import _extract_text_content
+
+        text = "<think>Thinking...</think>\n{\"name\": \"Dave\", \"age\": 40}"
+        response = _bedrock_response(text)
+        extracted = _extract_text_content(response)
+        assert "<think>" not in extracted
+        assert "Dave" in extracted
+
+    def test_no_think_tags_passes_through(self):
+        from instructor.processing.function_calls import _extract_text_content
+
+        text = '{"name": "Eve", "age": 35}'
+        response = _bedrock_response(text)
+        extracted = _extract_text_content(response)
+        assert extracted == text
+
+
+# ---------------------------------------------------------------------------
+# reask_md_json — retry path for MD_JSON with Bedrock dict response
+# ---------------------------------------------------------------------------
+
+class TestReaskMdJsonBedrockDict:
+    def test_reask_extends_messages_with_bedrock_dict(self):
+        from instructor.providers.openai.utils import reask_md_json
+
+        response = _bedrock_response('{"bad": "json"}')
+        kwargs = {
+            "messages": [{"role": "user", "content": [{"text": "Tell me about Jason"}]}],
+        }
+        exception = ValueError("name field required")
+
+        initial_len = len(kwargs["messages"])
+        new_kwargs = reask_md_json(kwargs, response, exception)
+
+        # Three messages: original + assistant (from response) + user correction
+        assert len(new_kwargs["messages"]) == initial_len + 2
+        # Last message is a Bedrock-format user correction
+        last = new_kwargs["messages"][-1]
+        assert last["role"] == "user"
+        assert isinstance(last["content"], list)
+        assert "name field required" in last["content"][0]["text"]
+
+    def test_reask_with_openai_response_unchanged(self):
+        """Non-Bedrock responses still use the existing choices-based path."""
+        from unittest.mock import MagicMock
+        from instructor.providers.openai.utils import reask_md_json
+
+        message = MagicMock()
+        message.role = "assistant"
+        message.content = '{"bad": "json"}'
+        message.tool_calls = None
+        message.function_call = None
+
+        response = MagicMock()
+        response.choices = [MagicMock(message=message)]
+
+        kwargs = {"messages": [{"role": "user", "content": "hi"}]}
+        exception = ValueError("age required")
+        initial_len = len(kwargs["messages"])
+
+        new_kwargs = reask_md_json(kwargs, response, exception)
+        # Should not crash and should extend messages by at least 1
+        assert len(new_kwargs["messages"]) > initial_len


### PR DESCRIPTION
Fixes #2076

## Problem

Reasoning models on AWS Bedrock (e.g. Kimi K2 Thinking) prefix their text response with a `<think>...</think>` block before emitting the actual JSON. The JSON extractor (`extract_json_from_codeblock`) finds the first `{` and last `}` in the whole response, which may land inside the think block and produce invalid JSON. This causes repeated validation failures and costly retries.

A second related bug: when `Mode.MD_JSON` is used with `from_bedrock()` and a validation error fires, `reask_md_json` tries to access `response.choices[0]`. Bedrock responses are plain dicts (no `.choices`), so this raises:
```
AttributeError: 'dict' object has no attribute 'choices'
```
Because `dict` also lacks `.choices`, Bedrock responses were incorrectly hitting the stream-response branch and the assistant turn was silently dropped from the retry message list.

## Solution

**1. Think-tag stripping** (`instructor/processing/function_calls.py`)
- `parse_bedrock_json` (used by `BEDROCK_JSON` mode): strip `<think>…</think>` before code-block extraction and JSON parse.
- `_extract_text_content` (used by `parse_json` / `MD_JSON` mode): strip think tags when the completion is a Bedrock dict.

**2. Bedrock-aware reask** (`instructor/providers/openai/utils.py`)
- `reask_md_json`: check for Bedrock dict responses (`isinstance(response, dict) and "output" in response`) *before* the stream-response guard so they are handled with the correct Bedrock message format instead of crashing.

## Testing

9 new unit tests in `tests/llm/test_bedrock/test_think_tags.py` cover:
- Plain JSON with no think tags (regression guard)
- Think tags before JSON
- Think tags that themselves contain braces (the core failure case)
- Think tags combined with markdown code-fence responses
- Multi-line think blocks
- `_extract_text_content` stripping for the MD_JSON path
- `reask_md_json` with a Bedrock dict response (asserts correct Bedrock-format correction message)
- `reask_md_json` with a normal OpenAI response (unchanged behavior)

```
9 passed in 26.82s
```