### PR TITLE
build: bump litellm upper bound to 1.83.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ test-docs = [
     "pandas<3.0.0,>=2.2.0",
     "tabulate<1.0.0,>=0.9.0",
     "pydantic-extra-types<3.0.0,>=2.6.0",
-    "litellm>=1.35.31,<=1.83.4",
+    "litellm>=1.35.31,<=1.83.7",
     "mistralai<2.0.0,>=1.5.1",
 ]
 anthropic = ["anthropic==0.93.0", "xmltodict>=0.13,<1.1"]
@@ -93,7 +93,7 @@ bedrock = ["boto3<2.0.0,>=1.34.0"]
 mistral = ["mistralai<2.0.0,>=1.5.1"]
 perplexity = ["openai>=2.0.0,<3.0.0"]
 google-genai = ["google-genai>=1.5.0","jsonref<2.0.0,>=1.1.0"]
-litellm = ["litellm>=1.35.31,<=1.83.4"]
+litellm = ["litellm>=1.35.31,<=1.83.7"]
 xai = ["xai-sdk>=0.2.0 ; python_version >= '3.10'"]
 phonenumbers = ["phonenumbers>=8.13.33,<10.0.0"]
 graphviz = ["graphviz<1.0.0,>=0.20.3"]


### PR DESCRIPTION
## Summary
- bump the `litellm` upper bound from `1.83.4` to `1.83.7`
- update both the `test-docs` dependency group and the `litellm` extra

## Testing
- `python3 - <<'PY'
import tomllib
from pathlib import Path
with Path("pyproject.toml").open("rb") as f:
    tomllib.load(f)
print("ok")
PY`

Fixes #2290