### PR TITLE
fix(gemini): clarify missing jsonref dependency

### DIFF
--- a/instructor/providers/gemini/utils.py
+++ b/instructor/providers/gemini/utils.py
@@ -161,7 +161,13 @@ def map_to_gemini_function_schema(obj: dict[str, Any]) -> dict[str, Any]:
 
     Ref: https://ai.google.dev/api/python/google/generativeai/protos/Schema
     """
-    import jsonref
+    try:
+        import jsonref
+    except ModuleNotFoundError as err:
+        raise ConfigurationError(
+            "jsonref is required for Gemini schema generation. "
+            'Install it with `pip install "instructor[google-genai]"`.'
+        ) from err
 
     class FunctionSchema(BaseModel):
         description: str | None = None

--- a/tests/test_gemini_dependency_guidance.py
+++ b/tests/test_gemini_dependency_guidance.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+
+import pytest
+
+from instructor.core.exceptions import ConfigurationError
+from instructor.providers.gemini.utils import map_to_gemini_function_schema
+
+
+def test_map_to_gemini_function_schema_reports_missing_jsonref_dependency():
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    }
+    original_import = __import__
+
+    def mocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "jsonref":
+            raise ModuleNotFoundError("No module named 'jsonref'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", side_effect=mocked_import):
+        with pytest.raises(ConfigurationError, match='instructor\\[google-genai\\]'):
+            map_to_gemini_function_schema(schema)


### PR DESCRIPTION
## Summary
- raise a `ConfigurationError` with install guidance when Gemini schema generation is used without `jsonref`
- point users to the `instructor[google-genai]` extra instead of surfacing a bare `ModuleNotFoundError`
- add a regression test for the missing dependency path

## Testing
- `python3 -m pytest tests/test_gemini_dependency_guidance.py`
- `python3 -m ruff check instructor/providers/gemini/utils.py tests/test_gemini_dependency_guidance.py`

Fixes #2288