### PR TITLE
fix(gemini): raise helpful ImportError when jsonref is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 - **Templating (GenAI/VertexAI)**: `process_message` no longer crashes with `TypeError: Can't compile non template nodes` when multimodal messages contain image/URI/bytes Parts alongside `validation_context`. Non-text Parts (where `part.text` is `None`) now pass through unchanged. ([#2253](https://github.com/567-labs/instructor/issues/2253))
+- **Gemini (GenAI)**: `map_to_gemini_function_schema` now raises a helpful `ImportError` pointing to `pip install 'instructor[google-genai]'` when `jsonref` is missing, instead of surfacing a bare `ModuleNotFoundError` deep in the call stack. ([#2288](https://github.com/567-labs/instructor/issues/2288))
 
 ---
 

--- a/instructor/providers/gemini/utils.py
+++ b/instructor/providers/gemini/utils.py
@@ -161,7 +161,13 @@ def map_to_gemini_function_schema(obj: dict[str, Any]) -> dict[str, Any]:
 
     Ref: https://ai.google.dev/api/python/google/generativeai/protos/Schema
     """
-    import jsonref
+    try:
+        import jsonref
+    except ImportError as e:
+        raise ImportError(
+            "The 'jsonref' package is required for Gemini structured outputs. "
+            "Install it with: pip install 'instructor[google-genai]'"
+        ) from e
 
     class FunctionSchema(BaseModel):
         description: str | None = None

--- a/tests/genai/test_jsonref_missing.py
+++ b/tests/genai/test_jsonref_missing.py
@@ -1,0 +1,30 @@
+"""Tests for the helpful ImportError raised when jsonref is missing.
+
+See https://github.com/567-labs/instructor/issues/2288.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+def test_map_to_gemini_function_schema_raises_helpful_error_without_jsonref(monkeypatch):
+    """If `jsonref` cannot be imported, the user should see an actionable
+    message pointing to the `[google-genai]` extra rather than a bare
+    ModuleNotFoundError surfacing deep in the call stack.
+    """
+    # Force `import jsonref` inside map_to_gemini_function_schema to raise.
+    # monkeypatch.setitem restores the original sys.modules entry after the
+    # test, so this doesn't leak across the suite.
+    monkeypatch.setitem(sys.modules, "jsonref", None)
+
+    from instructor.providers.gemini.utils import map_to_gemini_function_schema
+
+    with pytest.raises(ImportError) as excinfo:
+        map_to_gemini_function_schema({"type": "object", "properties": {}})
+
+    msg = str(excinfo.value)
+    assert "jsonref" in msg
+    assert "instructor[google-genai]" in msg


### PR DESCRIPTION
## What

`map_to_gemini_function_schema` now wraps its lazy `import jsonref` in a `try/except` and raises an `ImportError` that points at the `[google-genai]` extra when the package is missing.

Resolves #2288.

## Why

Today, users who install plain `instructor` and use a Gemini model hit a bare `ModuleNotFoundError: No module named 'jsonref'` four frames deep in the schema-conversion path (see the stack trace in #2288). The error gives no hint that the fix is `pip install 'instructor[google-genai]'`.

Adding `jsonref` to the core `dependencies` would solve the user-facing symptom but it conflicts with the project's explicit "minimal core" philosophy (see `CLAUDE.md` → Dependency Management). Keeping it as an extra and surfacing a helpful error is the more idiomatic fix and matches how peer libraries (langchain, llama-index) handle optional providers.

## How

1. Wrap `import jsonref` in `instructor/providers/gemini/utils.py` (`map_to_gemini_function_schema`) with `try/except ImportError`, re-raising with a message that names the extra to install.
2. Add a unit test in `tests/genai/test_jsonref_missing.py` that monkeypatches `sys.modules["jsonref"] = None` and asserts the helpful `ImportError` is raised. Uses the same `sys.modules` patching pattern already in `tests/test_auto_client.py`.
3. Add a `[Unreleased]` entry under `### Fixed` in `CHANGELOG.md` per the contribution guide.

## Why this scope and not "move jsonref to core deps"

The reporter framed the bug as "missing required dep", but `CLAUDE.md` calls out a "minimal core" policy and `jsonref` is currently listed as an opt-in dep under `vertexai` and `google-genai` extras (`pyproject.toml` lines 88, 95). A helpful error preserves that architecture while removing the user-visible footgun. Happy to flip the PR to a `pyproject.toml` change instead if maintainers prefer that direction.

The same `import jsonref` exists at module scope in `instructor/providers/vertexai/client.py:10`. That import is already gated by the conditional `find_spec` machinery in `instructor/__init__.py`, so the bare import there is reachable only when the user already has `vertexai` available, which transitively brings `jsonref`. Leaving it untouched in this PR; happy to address in a follow-up if maintainers want symmetric treatment.

## Test plan

- [x] `python3 -m py_compile` on all modified files
- [x] Local sanity check that the wrapped import path raises an `ImportError` whose message contains `instructor[google-genai]`
- [ ] CI runs `tests/genai/test_jsonref_missing.py` on push