### PR TITLE
fix(streaming): surface reasoning summary events in RESPONSES_TOOLS mode

### DIFF
--- a/instructor/core/patch.py
+++ b/instructor/core/patch.py
@@ -163,6 +163,7 @@ def patch(  # type: ignore
         cache_ttl: int | None = (
             cache_ttl_raw if isinstance(cache_ttl_raw, int) else None
         )
+        on_event = kwargs.pop("on_event", None)
 
         context = handle_context(context, validation_context)
 
@@ -195,6 +196,7 @@ def patch(  # type: ignore
             strict=strict,
             mode=mode,
             hooks=hooks,
+            on_event=on_event,
         )
 
         # Store in cache *after* successful call
@@ -232,6 +234,7 @@ def patch(  # type: ignore
         cache_ttl: int | None = (
             cache_ttl_raw if isinstance(cache_ttl_raw, int) else None
         )
+        on_event = kwargs.pop("on_event", None)
 
         context = handle_context(context, validation_context)
         # print(f"instructor.patch: patched_function {func.__name__}")
@@ -265,6 +268,7 @@ def patch(  # type: ignore
             strict=strict,
             kwargs=new_kwargs,
             mode=mode,
+            on_event=on_event,
         )
 
         # Save to cache

--- a/instructor/core/retry.py
+++ b/instructor/core/retry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from json import JSONDecodeError
 from typing import Any, Callable, TypeVar
+from collections.abc import Callable as CallableABC
 
 from .exceptions import (
     InstructorRetryException,
@@ -155,6 +156,7 @@ def retry_sync(
     strict: bool | None = None,
     mode: Mode = Mode.TOOLS,
     hooks: Hooks | None = None,
+    on_event: CallableABC[..., Any] | None = None,
 ) -> T_Model | None:
     """
     Retry a synchronous function upon specified exceptions.
@@ -208,6 +210,7 @@ def retry_sync(
                         strict=strict,
                         mode=mode,
                         stream=stream,
+                        on_event=on_event,
                     )
                 except (
                     ValidationError,
@@ -333,6 +336,7 @@ async def retry_async(
     strict: bool | None = None,
     mode: Mode = Mode.TOOLS,
     hooks: Hooks | None = None,
+    on_event: CallableABC[..., Any] | None = None,
 ) -> T_Model | None:
     """
     Retry an asynchronous function upon specified exceptions.
@@ -386,6 +390,7 @@ async def retry_async(
                         strict=strict,
                         mode=mode,
                         stream=stream,
+                        on_event=on_event,
                     )
                 except (
                     ValidationError,

--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -8,12 +8,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 import sys
 import types
 import warnings
-from collections.abc import AsyncGenerator, Generator, Iterable
+from collections.abc import AsyncGenerator, Callable, Generator, Iterable
 from copy import deepcopy
 from functools import cache
 from typing import (  # noqa: UP035
@@ -352,9 +353,13 @@ class PartialBase(Generic[T_Model]):
 
     @classmethod
     def from_streaming_response(
-        cls, completion: Iterable[Any], mode: Mode, **kwargs: Any
+        cls,
+        completion: Iterable[Any],
+        mode: Mode,
+        on_event: Callable[..., Any] | None = None,
+        **kwargs: Any,
     ) -> Generator[T_Model, None, None]:
-        json_chunks = cls.extract_json(completion, mode)
+        json_chunks = cls.extract_json(completion, mode, on_event=on_event)
 
         if mode in {Mode.MD_JSON, Mode.GEMINI_TOOLS}:
             json_chunks = extract_json_from_stream(json_chunks)
@@ -366,9 +371,13 @@ class PartialBase(Generic[T_Model]):
 
     @classmethod
     async def from_streaming_response_async(
-        cls, completion: AsyncGenerator[Any, None], mode: Mode, **kwargs: Any
+        cls,
+        completion: AsyncGenerator[Any, None],
+        mode: Mode,
+        on_event: Callable[..., Any] | None = None,
+        **kwargs: Any,
     ) -> AsyncGenerator[T_Model, None]:
-        json_chunks = cls.extract_json_async(completion, mode)
+        json_chunks = cls.extract_json_async(completion, mode, on_event=on_event)
 
         if mode in {Mode.MD_JSON, Mode.GEMINI_TOOLS}:
             json_chunks = extract_json_from_stream_async(json_chunks)
@@ -524,7 +533,9 @@ class PartialBase(Generic[T_Model]):
 
     @staticmethod
     def extract_json(
-        completion: Iterable[Any], mode: Mode
+        completion: Iterable[Any],
+        mode: Mode,
+        on_event: Callable[..., Any] | None = None,
     ) -> Generator[str, None, None]:
         """Extract JSON chunks from various LLM provider streaming responses.
 
@@ -714,10 +725,20 @@ class PartialBase(Generic[T_Model]):
                 }:
                     from openai.types.responses import (
                         ResponseFunctionCallArgumentsDeltaEvent,
+                        ResponseReasoningSummaryTextDeltaEvent,
+                        ResponseReasoningSummaryTextDoneEvent,
                     )
 
                     if isinstance(chunk, ResponseFunctionCallArgumentsDeltaEvent):
                         yield chunk.delta
+                    elif on_event is not None and isinstance(
+                        chunk,
+                        (
+                            ResponseReasoningSummaryTextDeltaEvent,
+                            ResponseReasoningSummaryTextDoneEvent,
+                        ),
+                    ):
+                        on_event(chunk)
 
                 elif chunk.choices:
                     if mode == Mode.FUNCTIONS:
@@ -753,7 +774,9 @@ class PartialBase(Generic[T_Model]):
 
     @staticmethod
     async def extract_json_async(
-        completion: AsyncGenerator[Any, None], mode: Mode
+        completion: AsyncGenerator[Any, None],
+        mode: Mode,
+        on_event: Callable[..., Any] | None = None,
     ) -> AsyncGenerator[str, None]:
         json_started = False
         async for chunk in completion:
@@ -939,10 +962,23 @@ class PartialBase(Generic[T_Model]):
                 }:
                     from openai.types.responses import (
                         ResponseFunctionCallArgumentsDeltaEvent,
+                        ResponseReasoningSummaryTextDeltaEvent,
+                        ResponseReasoningSummaryTextDoneEvent,
                     )
 
                     if isinstance(chunk, ResponseFunctionCallArgumentsDeltaEvent):
                         yield chunk.delta
+                    elif on_event is not None and isinstance(
+                        chunk,
+                        (
+                            ResponseReasoningSummaryTextDeltaEvent,
+                            ResponseReasoningSummaryTextDoneEvent,
+                        ),
+                    ):
+                        if asyncio.iscoroutinefunction(on_event):
+                            await on_event(chunk)
+                        else:
+                            on_event(chunk)
                 elif chunk.choices:
                     if mode == Mode.FUNCTIONS:
                         Mode.warn_mode_functions_deprecation()

--- a/instructor/processing/response.py
+++ b/instructor/processing/response.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 import inspect
 import logging
 from typing import Any, TypeVar, TYPE_CHECKING, cast
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 
 from openai.types.chat import ChatCompletion
 from pydantic import BaseModel
@@ -178,6 +178,7 @@ async def process_response_async(
     validation_context: dict[str, Any] | None = None,
     strict: bool | None = None,
     mode: Mode = Mode.TOOLS,
+    on_event: Callable[..., Any] | None = None,
 ) -> Any:
     """Asynchronously process and transform LLM responses into structured models.
 
@@ -245,6 +246,7 @@ async def process_response_async(
         return response_model.from_streaming_response_async(  # type: ignore[return-value,arg-type]
             cast(AsyncGenerator[Any, None], response),
             mode=mode,
+            on_event=on_event,
         )
 
     model = response_model.from_response(  # type: ignore
@@ -286,6 +288,7 @@ def process_response(
     validation_context: dict[str, Any] | None = None,
     strict=None,
     mode: Mode = Mode.TOOLS,
+    on_event: Callable[..., Any] | None = None,
 ) -> Any:
     """Process and transform LLM responses into structured models (synchronous).
 
@@ -364,6 +367,7 @@ def process_response(
             response_model.from_streaming_response(  # type: ignore
                 response,
                 mode=mode,
+                on_event=on_event,
             )
         )
 

--- a/tests/test_streaming_reasoning_events.py
+++ b/tests/test_streaming_reasoning_events.py
@@ -1,0 +1,211 @@
+"""Tests for reasoning summary event surfacing in RESPONSES_TOOLS streaming.
+
+These tests verify the fix for issue #2291: ResponseReasoningSummaryTextDeltaEvent
+and ResponseReasoningSummaryTextDoneEvent are forwarded to an on_event callback
+instead of being silently dropped during create_partial streaming.
+
+All tests use mock event objects — no API key required.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from instructor.dsl.partial import PartialBase
+from instructor.mode import Mode
+
+
+# ---------------------------------------------------------------------------
+# Lightweight mock event classes matching openai.types.responses shapes
+# ---------------------------------------------------------------------------
+
+class _MockFunctionCallArgumentsDeltaEvent:
+    """Mimics ResponseFunctionCallArgumentsDeltaEvent."""
+
+    type: str = "response.function_call_arguments.delta"
+
+    def __init__(self, delta: str) -> None:
+        self.delta = delta
+
+
+class _MockReasoningSummaryTextDeltaEvent:
+    """Mimics ResponseReasoningSummaryTextDeltaEvent."""
+
+    type: str = "response.reasoning_summary_text.delta"
+
+    def __init__(self, delta: str) -> None:
+        self.delta = delta
+
+
+class _MockReasoningSummaryTextDoneEvent:
+    """Mimics ResponseReasoningSummaryTextDoneEvent."""
+
+    type: str = "response.reasoning_summary_text.done"
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+# ---------------------------------------------------------------------------
+# Monkeypatch helper: replace the openai import inside extract_json
+# so our mocks are recognised by isinstance checks.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _patch_openai_response_types(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace openai.types.responses event classes with our mocks."""
+    import openai.types.responses as responses_mod
+
+    monkeypatch.setattr(
+        responses_mod,
+        "ResponseFunctionCallArgumentsDeltaEvent",
+        _MockFunctionCallArgumentsDeltaEvent,
+    )
+    monkeypatch.setattr(
+        responses_mod,
+        "ResponseReasoningSummaryTextDeltaEvent",
+        _MockReasoningSummaryTextDeltaEvent,
+    )
+    monkeypatch.setattr(
+        responses_mod,
+        "ResponseReasoningSummaryTextDoneEvent",
+        _MockReasoningSummaryTextDoneEvent,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sync tests — extract_json
+# ---------------------------------------------------------------------------
+
+
+class TestExtractJsonReasoningEvents:
+    """Tests for PartialBase.extract_json with RESPONSES_TOOLS mode."""
+
+    def test_yields_function_call_deltas(self) -> None:
+        """Existing behaviour: FunctionCallArgumentsDelta events yield JSON text."""
+        chunks = [
+            _MockFunctionCallArgumentsDeltaEvent('{"name":'),
+            _MockFunctionCallArgumentsDeltaEvent('"Alice"}'),
+        ]
+        result = list(PartialBase.extract_json(iter(chunks), Mode.RESPONSES_TOOLS))
+        assert result == ['{"name":', '"Alice"}']
+
+    def test_forwards_reasoning_delta_to_on_event(self) -> None:
+        """Reasoning delta events are forwarded to on_event callback."""
+        reasoning_chunk = _MockReasoningSummaryTextDeltaEvent("thinking...")
+        fn_chunk = _MockFunctionCallArgumentsDeltaEvent('{"a":1}')
+        chunks = [reasoning_chunk, fn_chunk]
+
+        callback = MagicMock()
+        json_parts = list(
+            PartialBase.extract_json(
+                iter(chunks), Mode.RESPONSES_TOOLS, on_event=callback
+            )
+        )
+
+        # JSON yield is preserved
+        assert json_parts == ['{"a":1}']
+        # Callback was invoked with the reasoning event
+        callback.assert_called_once_with(reasoning_chunk)
+
+    def test_forwards_reasoning_done_to_on_event(self) -> None:
+        """Reasoning done events are forwarded to on_event callback."""
+        done_chunk = _MockReasoningSummaryTextDoneEvent("full reasoning text")
+        chunks = [done_chunk]
+
+        callback = MagicMock()
+        list(
+            PartialBase.extract_json(
+                iter(chunks), Mode.RESPONSES_TOOLS, on_event=callback
+            )
+        )
+
+        callback.assert_called_once_with(done_chunk)
+
+    def test_no_on_event_silently_ignores_reasoning_events(self) -> None:
+        """Without on_event, reasoning events are silently dropped (backward compat)."""
+        chunks: list[Any] = [
+            _MockReasoningSummaryTextDeltaEvent("ignored"),
+            _MockFunctionCallArgumentsDeltaEvent('{"ok":true}'),
+        ]
+
+        # Should not raise — reasoning events are simply skipped
+        result = list(PartialBase.extract_json(iter(chunks), Mode.RESPONSES_TOOLS))
+        assert result == ['{"ok":true}']
+
+    def test_works_with_inbuilt_tools_mode(self) -> None:
+        """on_event also works with RESPONSES_TOOLS_WITH_INBUILT_TOOLS mode."""
+        reasoning_chunk = _MockReasoningSummaryTextDeltaEvent("reasoning")
+        fn_chunk = _MockFunctionCallArgumentsDeltaEvent('{"b":2}')
+        chunks = [reasoning_chunk, fn_chunk]
+
+        callback = MagicMock()
+        json_parts = list(
+            PartialBase.extract_json(
+                iter(chunks),
+                Mode.RESPONSES_TOOLS_WITH_INBUILT_TOOLS,
+                on_event=callback,
+            )
+        )
+
+        assert json_parts == ['{"b":2}']
+        callback.assert_called_once_with(reasoning_chunk)
+
+
+# ---------------------------------------------------------------------------
+# Async tests — extract_json_async
+# ---------------------------------------------------------------------------
+
+
+async def _async_iter(items: list[Any]):
+    """Convert a list into an async generator."""
+    for item in items:
+        yield item
+
+
+class TestExtractJsonAsyncReasoningEvents:
+    """Tests for PartialBase.extract_json_async with RESPONSES_TOOLS mode."""
+
+    @pytest.mark.asyncio
+    async def test_forwards_reasoning_events_async(self) -> None:
+        """Async path forwards reasoning events to sync callback."""
+        reasoning_chunk = _MockReasoningSummaryTextDeltaEvent("async thinking")
+        fn_chunk = _MockFunctionCallArgumentsDeltaEvent('{"c":3}')
+
+        callback = MagicMock()
+        json_parts: list[str] = []
+        async for part in PartialBase.extract_json_async(
+            _async_iter([reasoning_chunk, fn_chunk]),
+            Mode.RESPONSES_TOOLS,
+            on_event=callback,
+        ):
+            json_parts.append(part)
+
+        assert json_parts == ['{"c":3}']
+        callback.assert_called_once_with(reasoning_chunk)
+
+    @pytest.mark.asyncio
+    async def test_async_on_event_callback_awaited(self) -> None:
+        """Async callbacks are properly awaited in extract_json_async."""
+        received: list[Any] = []
+
+        async def async_callback(event: Any) -> None:
+            received.append(event)
+
+        reasoning_chunk = _MockReasoningSummaryTextDeltaEvent("awaited")
+        fn_chunk = _MockFunctionCallArgumentsDeltaEvent('{"d":4}')
+
+        json_parts: list[str] = []
+        async for part in PartialBase.extract_json_async(
+            _async_iter([reasoning_chunk, fn_chunk]),
+            Mode.RESPONSES_TOOLS,
+            on_event=async_callback,
+        ):
+            json_parts.append(part)
+
+        assert json_parts == ['{"d":4}']
+        assert len(received) == 1
+        assert received[0] is reasoning_chunk


### PR DESCRIPTION
## Problem

Closes #2291

When using `Mode.RESPONSES_TOOLS` with `create_partial` streaming, the OpenAI Responses API emits `ResponseReasoningSummaryTextDeltaEvent` and `ResponseReasoningSummaryTextDoneEvent` events when `reasoning={'summary': 'auto'}` is passed. These events are **silently dropped** because `extract_json` / `extract_json_async` in `dsl/partial.py` only handles `ResponseFunctionCallArgumentsDeltaEvent`.

```python
# instructor/dsl/partial.py (~line 937)
if mode in {Mode.RESPONSES_TOOLS, Mode.RESPONSES_TOOLS_WITH_INBUILT_TOOLS}:
    from openai.types.responses import ResponseFunctionCallArgumentsDeltaEvent
    if isinstance(chunk, ResponseFunctionCallArgumentsDeltaEvent):
        yield chunk.delta
    # ResponseReasoningSummaryTextDeltaEvent is never handled — dropped here
```

## Solution

Add an `on_event` callback parameter (Option 1 from the issue) that forwards non-JSON streaming events to the caller instead of discarding them. The callback is threaded through the full pipeline: `patch` → `retry` → `process_response` → `extract_json`.

### Usage

```python
from openai.types.responses import ResponseReasoningSummaryTextDeltaEvent

def handle_event(event):
    if isinstance(event, ResponseReasoningSummaryTextDeltaEvent):
        print(event.delta, end="", flush=True)

async for partial in client.responses.create_partial(
    input="Explain recursion",
    response_model=MyModel,
    reasoning={"effort": "medium", "summary": "auto"},
    on_event=handle_event,
):
    print(partial.model_dump())
```

## Changes

| File | Change |
|---|---|
| `instructor/dsl/partial.py` | Handle `ReasoningSummaryTextDelta/Done` events in both `extract_json` and `extract_json_async`; add `on_event` param to `from_streaming_response` methods |
| `instructor/core/patch.py` | Pop `on_event` from kwargs to prevent it leaking to the OpenAI API |
| `instructor/core/retry.py` | Thread `on_event` to `process_response` |
| `instructor/processing/response.py` | Thread `on_event` to `from_streaming_response` |
| `tests/test_streaming_reasoning_events.py` | 7 new unit tests (no API key required) |

## Design Decisions

- **Generic callback**: `on_event` receives the raw event object so callers can `isinstance` check for any event type — future-proof beyond just reasoning summaries
- **Async support**: The async path checks `asyncio.iscoroutinefunction(on_event)` to support both sync and async callbacks
- **Backward compatible**: When `on_event` is not provided (default `None`), reasoning events are silently ignored — identical to current behavior
- **Pop early**: `on_event` is popped from kwargs in `patch.py` (same pattern as `cache` / `cache_ttl`) to prevent it from reaching the OpenAI API call

## Tests

- **7 new tests** using mocked event types — no API key required
- **46 existing** `test_partial.py` tests pass with zero regressions

```
tests/test_streaming_reasoning_events.py::test_yields_function_call_deltas         PASSED
tests/test_streaming_reasoning_events.py::test_forwards_reasoning_delta_to_on_event PASSED
tests/test_streaming_reasoning_events.py::test_forwards_reasoning_done_to_on_event  PASSED
tests/test_streaming_reasoning_events.py::test_no_on_event_silently_ignores_reasoning_events PASSED
tests/test_streaming_reasoning_events.py::test_works_with_inbuilt_tools_mode       PASSED
tests/test_streaming_reasoning_events.py::test_forwards_reasoning_events_async     PASSED
tests/test_streaming_reasoning_events.py::test_async_on_event_callback_awaited     PASSED
============================= 7 passed ==============================
```
