### PR TITLE
fix(anthropic): exclude None fields when serialising tool-use blocks on reask

### DIFF
--- a/instructor/providers/anthropic/utils.py
+++ b/instructor/providers/anthropic/utils.py
@@ -165,7 +165,7 @@ def reask_anthropic_tools(
     assistant_content = []
     tool_use_id = None
     for content in response.content:
-        assistant_content.append(content.model_dump())  # type: ignore
+        assistant_content.append(content.model_dump(exclude_none=True))  # type: ignore
         if content.type == "tool_use":
             tool_use_id = content.id
 

--- a/tests/test_anthropic_bedrock_caller.py
+++ b/tests/test_anthropic_bedrock_caller.py
@@ -1,0 +1,97 @@
+"""Test that reask_anthropic_tools excludes None fields when serializing content blocks.
+
+AWS Bedrock does not populate the `caller` field on ToolUseBlock — it returns
+caller=None.  When reask_anthropic_tools called content.model_dump() the
+resulting dict contained "caller": null, which the Anthropic API rejected with
+HTTP 400.
+
+GitHub Issue: https://github.com/instructor-ai/instructor/issues/2277
+"""
+
+import pytest
+
+from pydantic import ValidationError, BaseModel, field_validator
+
+anthropic = pytest.importorskip("anthropic", reason="anthropic package required")
+
+
+def _make_validation_error() -> ValidationError:
+    class M(BaseModel):
+        v: int = 0
+
+        @field_validator("v")
+        @classmethod
+        def always_fail(cls, val: int) -> int:
+            raise ValueError(f"forced failure: {val}")
+
+    try:
+        M(v=1)
+    except ValidationError as exc:
+        return exc
+    raise AssertionError("unreachable")  # pragma: no cover
+
+
+def _build_bedrock_message() -> "anthropic.types.Message":
+    from anthropic.types import Message, ToolUseBlock, Usage
+
+    return Message(
+        id="msg_bedrock_test",
+        content=[
+            ToolUseBlock(
+                id="toolu_bedrock_abc",
+                input={"summary": "hello"},
+                name="MyExtraction",
+                type="tool_use",
+                caller=None,  # Bedrock leaves this field unpopulated
+            )
+        ],
+        model="anthropic.claude-sonnet-4-6",
+        role="assistant",
+        stop_reason="tool_use",
+        stop_sequence=None,
+        type="message",
+        usage=Usage(input_tokens=10, output_tokens=10),
+    )
+
+
+class TestBedrockCallerNoneReask:
+    """Regression tests for Bedrock caller=None serialisation bug."""
+
+    def test_reask_does_not_include_null_caller(self):
+        """Assistant content dicts must not contain 'caller': None after reask."""
+        from instructor.providers.anthropic.utils import reask_anthropic_tools
+
+        kwargs = {
+            "messages": [{"role": "user", "content": "extract something"}],
+        }
+        response = _build_bedrock_message()
+        exception = _make_validation_error()
+
+        result = reask_anthropic_tools(kwargs, response, exception)
+
+        # Find the assistant turn that was appended
+        assistant_msgs = [m for m in result["messages"] if m.get("role") == "assistant"]
+        assert assistant_msgs, "reask must append an assistant message"
+
+        for block in assistant_msgs[0]["content"]:
+            assert "caller" not in block, (
+                f"'caller' field must be excluded when it is None, got: {block}"
+            )
+
+    def test_reask_tool_use_id_is_preserved(self):
+        """The tool_use_id in the follow-up user message must match the block id."""
+        from instructor.providers.anthropic.utils import reask_anthropic_tools
+
+        kwargs = {
+            "messages": [{"role": "user", "content": "extract something"}],
+        }
+        response = _build_bedrock_message()
+        exception = _make_validation_error()
+
+        result = reask_anthropic_tools(kwargs, response, exception)
+
+        user_msgs = [m for m in result["messages"] if m.get("role") == "user"]
+        # Last user message is the tool_result reask
+        tool_result_msg = user_msgs[-1]
+        assert isinstance(tool_result_msg["content"], list)
+        assert tool_result_msg["content"][0]["tool_use_id"] == "toolu_bedrock_abc"


### PR DESCRIPTION
## Describe your changes

`reask_anthropic_tools` builds the assistant message for retries by calling `content.model_dump()` on each content block from the previous response. `anthropic==0.88.0` added an optional `caller` field to `ToolUseBlock`; AWS Bedrock does not populate this field and returns `caller=None`. Calling `model_dump()` on that block produces `{"caller": null, ...}` in the assistant turn, which the Anthropic API rejects with HTTP 400 on every retry attempt after the first validation failure.

The fix changes `content.model_dump()` to `content.model_dump(exclude_none=True)`, which omits fields whose value is `None` and restores the wire format the API has always accepted. Both `ANTHROPIC_TOOLS` and `ANTHROPIC_REASONING_TOOLS` modes are fixed because they both delegate to the same `reask_anthropic_tools` handler.

## Issue ticket number and link

Fixes #2277

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.

## Summary

One-line change: `content.model_dump(exclude_none=True)` instead of `content.model_dump()` in the reask loop. Two regression tests added in `tests/test_anthropic_bedrock_caller.py` that construct a `Message` with `caller=None` and assert the serialised dict no longer carries the key.

## Local verification

```
$ cd /tmp/instructor
$ pre-commit run --files instructor/providers/anthropic/utils.py tests/test_anthropic_bedrock_caller.py
Run Linter Check (Ruff)..................................................Passed
Run Formatter (Ruff).....................................................Passed
Check uv.lock is up-to-date..........................(no files to check)Skipped
Verify dependencies can be installed.................(no files to check)Skipped
Export requirements.txt from pyproject.toml..........(no files to check)Skipped
Run Type Check (ty)......................................................Failed
- hook id: ty-check
- exit code: 1
(ty failures are all in pre-existing files; none in the changed files)

$ python -m pytest tests/test_anthropic_bedrock_caller.py tests/processing/test_anthropic_json.py tests/test_streaming_reask_bug.py -v
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-8.4.2, pluggy-1.6.0
collected 10 items

tests/test_anthropic_bedrock_caller.py::TestBedrockCallerNoneReask::test_reask_does_not_include_null_caller PASSED
tests/test_anthropic_bedrock_caller.py::TestBedrockCallerNoneReask::test_reask_tool_use_id_is_preserved PASSED
tests/processing/test_anthropic_json.py::test_parse_anthropic_json_strict_control_characters PASSED
tests/processing/test_anthropic_json.py::test_parse_anthropic_json_non_strict_preserves_control_characters PASSED
tests/test_streaming_reask_bug.py::TestStreamingReaskBug::test_reask_tools_with_stream_object_does_not_crash PASSED
tests/test_streaming_reask_bug.py::TestStreamingReaskBug::test_reask_anthropic_tools_with_stream_object PASSED
tests/test_streaming_reask_bug.py::TestStreamingReaskBug::test_reask_with_none_response PASSED
tests/test_streaming_reask_bug.py::TestStreamingReaskBug::test_reask_responses_tools_skips_reasoning_items_and_includes_details PASSED
tests/test_streaming_reask_bug.py::TestStreamingReaskBug::test_reask_md_json_with_stream_object PASSED
tests/test_streaming_reask_bug.py::TestStreamingReaskIntegration::test_streaming_with_retries_and_failing_validator SKIPPED

========================= 9 passed, 1 skipped in 0.96s =========================
=== LOCAL_TEST_PASSED ===
```

## Risk

The only observable change is that keys with `None` values are omitted from the serialised content-block dict. For the direct Anthropic API this is a no-op (the `caller` field is populated). For Bedrock, the previously rejected `"caller": null` key disappears. There is a theoretical risk that a future content-block type adds a field where `null` carries semantic meaning distinct from omission; if that happens, a targeted exclusion rather than `exclude_none=True` would be the right follow-up.
