### PR TITLE
fix(gemini,vertexai): raise descriptive ImportError when jsonref is missing

### DIFF
--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -107,7 +107,14 @@ def verify_no_unions(obj: dict[str, Any]) -> bool:  # noqa: ARG001
 
 
 def map_to_gemini_function_schema(obj: dict[str, Any]) -> dict[str, Any]:
-    import jsonref
+    try:
+        import jsonref
+    except ImportError as e:
+        raise ImportError(
+            "jsonref is required for Gemini/GenAI tool calling. "
+            "Install it with: pip install jsonref  "
+            "or via the extras: pip install 'instructor[google-genai]'"
+        ) from e
 
     class FunctionSchema(BaseModel):
         description: str | None = None

--- a/instructor/v2/providers/vertexai/handlers.py
+++ b/instructor/v2/providers/vertexai/handlers.py
@@ -13,7 +13,6 @@ from collections.abc import (
 from typing import Any, cast, get_origin
 
 from pydantic import BaseModel
-import jsonref
 
 from instructor.v2.core.mode import Mode
 from instructor.v2.core.providers import Provider
@@ -173,6 +172,15 @@ def parse_vertexai_json(
 
 
 def _create_gemini_json_schema(model: type[BaseModel]) -> dict[str, Any]:
+    try:
+        import jsonref
+    except ImportError as e:
+        raise ImportError(
+            "jsonref is required for VertexAI tool calling. "
+            "Install it with: pip install jsonref  "
+            "or via the extras: pip install 'instructor[vertexai]'"
+        ) from e
+
     if get_origin(model) is not None:
         raise TypeError(f"Expected concrete model class, got type hint {model}")
 

--- a/tests/v2/test_gemini_utils_deterministic.py
+++ b/tests/v2/test_gemini_utils_deterministic.py
@@ -467,3 +467,12 @@ def test_handle_genai_tools_without_model_uses_message_conversion(
 
     assert model is None
     assert result["autodetect"] is True
+
+
+def test_map_to_gemini_function_schema_raises_import_error_when_jsonref_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(sys.modules, "jsonref", None)
+
+    with pytest.raises(ImportError, match="instructor\\[google-genai\\]"):
+        utils.map_to_gemini_function_schema({"type": "object", "properties": {}})

--- a/tests/v2/test_vertexai_runtime.py
+++ b/tests/v2/test_vertexai_runtime.py
@@ -224,3 +224,13 @@ def test_vertexai_schema_helper_rejects_type_hints(
 
     with pytest.raises(TypeError, match="Expected concrete model class"):
         handlers._create_gemini_json_schema(list[Weather])
+
+
+def test_create_gemini_json_schema_raises_import_error_when_jsonref_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handlers = _install_fake_vertexai(monkeypatch)
+    monkeypatch.setitem(sys.modules, "jsonref", None)
+
+    with pytest.raises(ImportError, match="instructor\\[vertexai\\]"):
+        handlers._create_gemini_json_schema(Weather)


### PR DESCRIPTION
## Describe your changes

`map_to_gemini_function_schema` (in `instructor/v2/providers/gemini/utils.py`) and
`_create_gemini_json_schema` (in `instructor/v2/providers/vertexai/handlers.py`) each
call `import jsonref` without any fallback. When a user installs `instructor` without
the `[google-genai]` or `[vertexai]` extra, they hit a bare
`ModuleNotFoundError: No module named 'jsonref'` — no indication of which extra to
install or how to resolve it.

This PR wraps both bare imports in `try/except ImportError` blocks that re-raise with an
actionable message pointing the user at the correct install command
(`pip install 'instructor[google-genai]'` or `pip install 'instructor[vertexai]'`).
The change is identical in spirit to the existing `xai_sdk` optional-import guard added
in `tests/test_xai_optional_dependency.py`. Two new unit tests (one per file) use
`monkeypatch.setitem(sys.modules, "jsonref", None)` to simulate the missing package and
assert the new error message is present.

## Issue ticket number and link

Fixes #2288

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.

## Local verification

```
$ cd /tmp/instructor
$ uv run ruff check instructor examples tests
All checks passed!
ruff check exit: 0

$ uv run ruff format --check instructor examples tests
491 files already formatted
ruff format exit: 0

$ uv run pre-commit run --files \
    instructor/v2/providers/gemini/utils.py \
    instructor/v2/providers/vertexai/handlers.py \
    tests/v2/test_gemini_utils_deterministic.py \
    tests/v2/test_vertexai_runtime.py
Run Linter Check (Ruff)..................................................Passed
Run Formatter (Ruff).....................................................Passed
Check uv.lock is up-to-date..........................(no files to check)Skipped
Run Type Check (ty)......................................................Passed

$ uv run pytest tests/v2/test_gemini_utils_deterministic.py tests/v2/test_vertexai_runtime.py tests/test_lazy_imports.py tests/v2/test_optional_dependency_imports.py -v
============================= test session starts ==============================
platform linux -- Python 3.11.15
collected 28 items

tests/v2/test_gemini_utils_deterministic.py::test_transform_to_gemini_prompt_merges_system_messages PASSED
tests/v2/test_gemini_utils_deterministic.py::test_extract_genai_system_message_validates_edge_cases PASSED
tests/v2/test_gemini_utils_deterministic.py::test_convert_to_genai_messages_supports_strings_existing_content_and_media PASSED
tests/v2/test_gemini_utils_deterministic.py::test_handle_genai_message_conversion_extracts_system_and_contents PASSED
tests/v2/test_gemini_utils_deterministic.py::test_handle_vertexai_wrappers_use_provider_helpers PASSED
tests/v2/test_gemini_utils_deterministic.py::test_handle_vertexai_parallel_tools_rejects_streaming PASSED
tests/v2/test_gemini_utils_deterministic.py::test_handle_gemini_json_adds_schema_prompt PASSED
tests/v2/test_gemini_utils_deterministic.py::test_handle_gemini_tools_sets_tool_config PASSED
tests/v2/test_gemini_utils_deterministic.py::test_update_gemini_kwargs_applies_safety_defaults PASSED
tests/v2/test_gemini_utils_deterministic.py::test_handle_gemini_json_rejects_model_kwarg PASSED
tests/v2/test_gemini_utils_deterministic.py::test_update_genai_kwargs_merges_generation_safety_and_user_config PASSED
tests/v2/test_gemini_utils_deterministic.py::test_handle_genai_structured_outputs_builds_config PASSED
tests/v2/test_gemini_utils_deterministic.py::test_handle_genai_tools_builds_tool_declaration PASSED
tests/v2/test_gemini_utils_deterministic.py::test_handle_genai_tools_without_model_uses_message_conversion PASSED
tests/v2/test_gemini_utils_deterministic.py::test_map_to_gemini_function_schema_raises_import_error_when_jsonref_missing PASSED
tests/v2/test_vertexai_runtime.py::test_vertexai_parallel_model_validates_registered_calls PASSED
tests/v2/test_vertexai_runtime.py::test_vertexai_parallel_model_skips_empty_candidates PASSED
tests/v2/test_vertexai_runtime.py::test_vertexai_message_parsers_and_reask_helpers PASSED
tests/v2/test_vertexai_runtime.py::test_vertexai_process_helpers_build_tools_and_config PASSED
tests/v2/test_vertexai_runtime.py::test_vertexai_schema_helper_rejects_type_hints PASSED
tests/v2/test_vertexai_runtime.py::test_create_gemini_json_schema_raises_import_error_when_jsonref_missing PASSED
tests/test_lazy_imports.py::test_top_level_exports_load_lazily PASSED
tests/test_lazy_imports.py::test_top_level_openai_factory_uses_v2_module PASSED
tests/test_lazy_imports.py::test_mode_export_stays_lightweight PASSED
tests/test_lazy_imports.py::test_v2_module_export_stays_lightweight PASSED
tests/v2/test_optional_dependency_imports.py::test_anthropic_factory_reports_missing_sdk PASSED
tests/v2/test_optional_dependency_imports.py::test_genai_factory_exposes_normalized_mode PASSED
tests/v2/test_optional_dependency_imports.py::test_openai_connection_errors_only_skip_outside_strict_provider_runs PASSED

======================== 28 passed, 1 warning in 2.33s =========================
=== LOCAL_TEST_PASSED ===
```

## Risk

Only changes error-handling code paths for missing-package scenarios. When `jsonref` IS
installed (the common case), both functions behave identically to before — the try block
succeeds and no extra overhead is added. Users who already use `instructor[google-genai]`
or `instructor[vertexai]` will never see the new message.
