### PR TITLE
fix(json): support array-root JSON in extract_json_from_codeblock

### DIFF
--- a/instructor/v2/core/json.py
+++ b/instructor/v2/core/json.py
@@ -6,11 +6,23 @@ from collections.abc import AsyncGenerator, Generator, Iterable
 
 
 def extract_json_from_codeblock(content: str) -> str:
-    """Extract the first JSON object-like span from a text block."""
-    first_brace = content.find("{")
+    """Extract the first JSON object or array span from a text block."""
+    first_obj = content.find("{")
+    first_arr = content.find("[")
+
+    if first_obj == -1 and first_arr == -1:
+        return content
+
+    if first_obj == -1 or (first_arr != -1 and first_arr < first_obj):
+        # Array root: find the matching closing bracket
+        last_bracket = content.rfind("]")
+        if last_bracket != -1:
+            return content[first_arr : last_bracket + 1]
+
+    # Object root
     last_brace = content.rfind("}")
-    if first_brace != -1 and last_brace != -1:
-        return content[first_brace : last_brace + 1]
+    if last_brace != -1:
+        return content[first_obj : last_brace + 1]
     return content
 
 


### PR DESCRIPTION
## Summary

`extract_json_from_codeblock` only searched for `{` and `}`, so models that return a JSON array as the root value (e.g. `[{"name": "Alice"}, {"name": "Bob"}]`) had their outer brackets stripped, producing invalid JSON that immediately raised `JSONDecodeError: Extra data`.

## Reproduction

```python
from instructor.v2.core.json import extract_json_from_codeblock
import json

result = extract_json_from_codeblock('[{"name": "Alice"}, {"name": "Bob"}]')
print(repr(result))   # '{"name": "Alice"}, {"name": "Bob"}' — invalid!
json.loads(result)    # JSONDecodeError: Extra data
```

## Change

`instructor/v2/core/json.py` — handle both root token types. If `[` appears before `{` (or `{` is absent), use `[ … ]` as the extraction span. Object-root behavior is unchanged.

```python
# Before
def extract_json_from_codeblock(content: str) -> str:
    first_brace = content.find("{")
    last_brace = content.rfind("}")
    if first_brace != -1 and last_brace != -1:
        return content[first_brace : last_brace + 1]
    return content

# After
def extract_json_from_codeblock(content: str) -> str:
    first_obj = content.find("{")
    first_arr = content.find("[")
    if first_obj == -1 and first_arr == -1:
        return content
    if first_obj == -1 or (first_arr != -1 and first_arr < first_obj):
        last_bracket = content.rfind("]")
        if last_bracket != -1:
            return content[first_arr : last_bracket + 1]
    last_brace = content.rfind("}")
    if last_brace != -1:
        return content[first_obj : last_brace + 1]
    return content
```

Note: `extract_json_from_stream` / `extract_json_from_stream_async` are unaffected (they already handle arrays). This PR only fixes the non-streaming codeblock extractor.