### PR TITLE
fix(retry): emit hook attempt metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Hooks**: Emit documented retry metadata from `completion:error` and `completion:last_attempt` hooks in v2 retry paths.
+
 ---
 
 ## [1.15.2] - 2026-05-10

--- a/instructor/v2/core/retry.py
+++ b/instructor/v2/core/retry.py
@@ -84,6 +84,41 @@ def _initialize_usage(provider: Provider | Mode) -> Any:
     return total_usage
 
 
+def _max_attempts_from_stop(stop: Any) -> int | None:
+    max_attempt_number = getattr(stop, "max_attempt_number", None)
+    if isinstance(max_attempt_number, int):
+        return max_attempt_number
+
+    # `stop_after_attempt(...) | stop_after_delay(...)` is represented as
+    # `stop_any`; the attempt cap is still useful metadata for hooks.
+    if stop.__class__.__name__ != "stop_any":
+        return None
+
+    child_max_attempt_numbers = [
+        child_max_attempt_number
+        for child_stop in getattr(stop, "stops", ())
+        if (child_max_attempt_number := _max_attempts_from_stop(child_stop)) is not None
+    ]
+    if not child_max_attempt_numbers:
+        return None
+    return min(child_max_attempt_numbers)
+
+
+def _max_attempts_from_retrying(retrying: Retrying | AsyncRetrying) -> int | None:
+    return _max_attempts_from_stop(retrying.stop)
+
+
+def _retry_metadata(
+    attempt_number: int, max_attempts: int | None, *, force_last: bool = False
+) -> dict[str, Any]:
+    return {
+        "attempt_number": attempt_number,
+        "max_attempts": max_attempts,
+        "is_last_attempt": force_last
+        or (max_attempts is not None and attempt_number >= max_attempts),
+    }
+
+
 def retry_sync_v2(
     func: Callable[..., Any],
     response_model: type[T_Model] | None,
@@ -140,6 +175,9 @@ def retry_sync_v2(
 
     failed_attempts: list[FailedAttempt] = []
     last_exception: Exception | None = None
+    last_error_metadata: dict[str, Any] | None = None
+    last_attempt_hook_emitted = False
+    max_attempts = _max_attempts_from_retrying(max_retries_instance)
     total_usage = _initialize_usage(provider)
 
     try:
@@ -154,10 +192,14 @@ def retry_sync_v2(
                 except IncompleteOutputException:
                     raise
                 except Exception as e:
-                    logger.error(
-                        f"API call failed on attempt "
-                        f"{attempt.retry_state.attempt_number}: {e}"
-                    )
+                    attempt_number = attempt.retry_state.attempt_number
+                    last_error_metadata = _retry_metadata(attempt_number, max_attempts)
+                    if hooks:
+                        hooks.emit_completion_error(e, **last_error_metadata)
+                        if last_error_metadata["is_last_attempt"]:
+                            hooks.emit_completion_last_attempt(e, **last_error_metadata)
+                            last_attempt_hook_emitted = True
+                    logger.error(f"API call failed on attempt {attempt_number}: {e}")
                     raise
 
                 if hooks:
@@ -180,12 +222,13 @@ def retry_sync_v2(
                         f"Successfully parsed response on attempt "
                         f"{attempt.retry_state.attempt_number}"
                     )
-                    return _finalize_parsed_response(parsed, response)  # type: ignore
+                    return _finalize_parsed_response(parsed, response)
 
                 except IncompleteOutputException:
                     raise
                 except ValidationError as e:
                     attempt_number = attempt.retry_state.attempt_number
+                    last_error_metadata = _retry_metadata(attempt_number, max_attempts)
                     logger.debug(f"Validation error on attempt {attempt_number}: {e}")
                     failed_attempts.append(
                         FailedAttempt(
@@ -198,6 +241,9 @@ def retry_sync_v2(
 
                     if hooks:
                         hooks.emit_parse_error(e)
+                        if last_error_metadata["is_last_attempt"]:
+                            hooks.emit_completion_last_attempt(e, **last_error_metadata)
+                            last_attempt_hook_emitted = True
 
                     # Prepare reask using registry
                     kwargs = handlers.reask_handler(
@@ -215,6 +261,13 @@ def retry_sync_v2(
         # Max retries exceeded or non-validation error occurred
         if last_exception is None:
             last_exception = e
+
+        if hooks and last_error_metadata is not None and not last_attempt_hook_emitted:
+            last_error_metadata = {
+                **last_error_metadata,
+                "is_last_attempt": True,
+            }
+            hooks.emit_completion_last_attempt(last_exception, **last_error_metadata)
 
         logger.error(
             f"Max retries exceeded. Total attempts: {len(failed_attempts)}, "
@@ -356,6 +409,9 @@ async def retry_async_v2(
 
     failed_attempts: list[FailedAttempt] = []
     last_exception: Exception | None = None
+    last_error_metadata: dict[str, Any] | None = None
+    last_attempt_hook_emitted = False
+    max_attempts = _max_attempts_from_retrying(max_retries_instance)
     total_usage = _initialize_usage(provider)
 
     try:
@@ -370,10 +426,14 @@ async def retry_async_v2(
                 except IncompleteOutputException:
                     raise
                 except Exception as e:
-                    logger.error(
-                        f"API call failed on attempt "
-                        f"{attempt.retry_state.attempt_number}: {e}"
-                    )
+                    attempt_number = attempt.retry_state.attempt_number
+                    last_error_metadata = _retry_metadata(attempt_number, max_attempts)
+                    if hooks:
+                        hooks.emit_completion_error(e, **last_error_metadata)
+                        if last_error_metadata["is_last_attempt"]:
+                            hooks.emit_completion_last_attempt(e, **last_error_metadata)
+                            last_attempt_hook_emitted = True
+                    logger.error(f"API call failed on attempt {attempt_number}: {e}")
                     raise
 
                 if hooks:
@@ -396,12 +456,13 @@ async def retry_async_v2(
                         f"Successfully parsed response on attempt "
                         f"{attempt.retry_state.attempt_number}"
                     )
-                    return _finalize_parsed_response(parsed, response)  # type: ignore
+                    return _finalize_parsed_response(parsed, response)
 
                 except IncompleteOutputException:
                     raise
                 except ValidationError as e:
                     attempt_number = attempt.retry_state.attempt_number
+                    last_error_metadata = _retry_metadata(attempt_number, max_attempts)
                     logger.debug(f"Validation error on attempt {attempt_number}: {e}")
                     failed_attempts.append(
                         FailedAttempt(
@@ -414,6 +475,9 @@ async def retry_async_v2(
 
                     if hooks:
                         hooks.emit_parse_error(e)
+                        if last_error_metadata["is_last_attempt"]:
+                            hooks.emit_completion_last_attempt(e, **last_error_metadata)
+                            last_attempt_hook_emitted = True
 
                     # Prepare reask using registry
                     kwargs = handlers.reask_handler(
@@ -431,6 +495,13 @@ async def retry_async_v2(
         # Max retries exceeded or non-validation error occurred
         if last_exception is None:
             last_exception = e
+
+        if hooks and last_error_metadata is not None and not last_attempt_hook_emitted:
+            last_error_metadata = {
+                **last_error_metadata,
+                "is_last_attempt": True,
+            }
+            hooks.emit_completion_last_attempt(last_exception, **last_error_metadata)
 
         logger.error(
             f"Max retries exceeded. Total attempts: {len(failed_attempts)}, "

--- a/tests/v2/test_retry_runtime.py
+++ b/tests/v2/test_retry_runtime.py
@@ -14,6 +14,7 @@ from tenacity import (
 
 from instructor import Mode, Provider
 from instructor.v2.core.errors import InstructorRetryException
+from instructor.v2.core.hooks import Hooks
 from instructor.v2.core.retry import (
     _finalize_parsed_response,
     _initialize_usage,
@@ -318,3 +319,197 @@ async def test_retry_async_v2_raises_retry_exception_after_validation_error(
 
     assert exc_info.value.n_attempts == 1
     assert parser_calls == ["first"]
+
+
+def test_retry_sync_v2_emits_completion_error_attempt_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+    legacy_errors: list[Exception] = []
+    completion_errors: list[dict[str, Any]] = []
+    last_attempts: list[dict[str, Any]] = []
+
+    def fake_func(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError(f"boom {calls}")
+
+    def no_validate(_provider: Provider, _mode: Mode) -> None:
+        return None
+
+    def get_handlers(_provider: Provider, _mode: Mode) -> SimpleNamespace:
+        return SimpleNamespace(
+            response_parser=lambda **_kwargs: Answer(value=1),
+            reask_handler=lambda **kwargs: kwargs["kwargs"],
+        )
+
+    hooks = Hooks()
+    hooks.on("completion:error", lambda error: legacy_errors.append(error))
+
+    def on_completion_error(
+        error: Exception,
+        *,
+        attempt_number: int,
+        max_attempts: int | None,
+        is_last_attempt: bool,
+    ) -> None:
+        completion_errors.append(
+            {
+                "error": error,
+                "attempt_number": attempt_number,
+                "max_attempts": max_attempts,
+                "is_last_attempt": is_last_attempt,
+            }
+        )
+
+    def on_last_attempt(
+        error: Exception,
+        *,
+        attempt_number: int,
+        max_attempts: int | None,
+        is_last_attempt: bool,
+    ) -> None:
+        last_attempts.append(
+            {
+                "error": error,
+                "attempt_number": attempt_number,
+                "max_attempts": max_attempts,
+                "is_last_attempt": is_last_attempt,
+            }
+        )
+
+    hooks.on("completion:error", on_completion_error)
+    hooks.on("completion:last_attempt", on_last_attempt)
+
+    monkeypatch.setattr(
+        "instructor.v2.core.retry.RegistryValidationMixin.validate_mode_registration",
+        no_validate,
+    )
+    monkeypatch.setattr(
+        "instructor.v2.core.retry.mode_registry.get_handlers",
+        get_handlers,
+    )
+
+    with pytest.raises(InstructorRetryException):
+        retry_sync_v2(
+            func=fake_func,
+            response_model=Answer,
+            provider=Provider.OPENAI,
+            mode=Mode.TOOLS,
+            context=None,
+            max_retries=Retrying(
+                stop=stop_after_attempt(2),
+                retry=retry_if_exception_type(RuntimeError),
+                reraise=True,
+            ),
+            args=(),
+            kwargs={"messages": [{"role": "user", "content": "first"}]},
+            strict=True,
+            hooks=hooks,
+        )
+
+    assert calls == 2
+    assert len(legacy_errors) == 2
+    assert [event["attempt_number"] for event in completion_errors] == [1, 2]
+    assert [event["max_attempts"] for event in completion_errors] == [2, 2]
+    assert [event["is_last_attempt"] for event in completion_errors] == [False, True]
+    assert len(last_attempts) == 1
+    assert last_attempts[0]["attempt_number"] == 2
+    assert last_attempts[0]["max_attempts"] == 2
+    assert last_attempts[0]["is_last_attempt"] is True
+
+
+@pytest.mark.asyncio
+async def test_retry_async_v2_emits_completion_error_attempt_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+    completion_errors: list[dict[str, Any]] = []
+    last_attempts: list[dict[str, Any]] = []
+
+    async def fake_func(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError(f"boom {calls}")
+
+    def no_validate(_provider: Provider, _mode: Mode) -> None:
+        return None
+
+    def get_handlers(_provider: Provider, _mode: Mode) -> SimpleNamespace:
+        return SimpleNamespace(
+            response_parser=lambda **_kwargs: Answer(value=1),
+            reask_handler=lambda **kwargs: kwargs["kwargs"],
+        )
+
+    hooks = Hooks()
+
+    def on_completion_error(
+        error: Exception,
+        *,
+        attempt_number: int,
+        max_attempts: int | None,
+        is_last_attempt: bool,
+    ) -> None:
+        completion_errors.append(
+            {
+                "error": error,
+                "attempt_number": attempt_number,
+                "max_attempts": max_attempts,
+                "is_last_attempt": is_last_attempt,
+            }
+        )
+
+    def on_last_attempt(
+        error: Exception,
+        *,
+        attempt_number: int,
+        max_attempts: int | None,
+        is_last_attempt: bool,
+    ) -> None:
+        last_attempts.append(
+            {
+                "error": error,
+                "attempt_number": attempt_number,
+                "max_attempts": max_attempts,
+                "is_last_attempt": is_last_attempt,
+            }
+        )
+
+    hooks.on("completion:error", on_completion_error)
+    hooks.on("completion:last_attempt", on_last_attempt)
+
+    monkeypatch.setattr(
+        "instructor.v2.core.retry.RegistryValidationMixin.validate_mode_registration",
+        no_validate,
+    )
+    monkeypatch.setattr(
+        "instructor.v2.core.retry.mode_registry.get_handlers",
+        get_handlers,
+    )
+
+    with pytest.raises(InstructorRetryException):
+        await retry_async_v2(
+            func=fake_func,
+            response_model=Answer,
+            provider=Provider.OPENAI,
+            mode=Mode.TOOLS,
+            context=None,
+            max_retries=AsyncRetrying(
+                stop=stop_after_attempt(2),
+                retry=retry_if_exception_type(RuntimeError),
+                reraise=True,
+            ),
+            args=(),
+            kwargs={"messages": [{"role": "user", "content": "first"}]},
+            strict=True,
+            hooks=hooks,
+        )
+
+    assert calls == 2
+    assert [event["attempt_number"] for event in completion_errors] == [1, 2]
+    assert [event["max_attempts"] for event in completion_errors] == [2, 2]
+    assert [event["is_last_attempt"] for event in completion_errors] == [False, True]
+    assert len(last_attempts) == 1
+    assert last_attempts[0]["attempt_number"] == 2
+    assert last_attempts[0]["max_attempts"] == 2
+    assert last_attempts[0]["is_last_attempt"] is True


### PR DESCRIPTION
## Describe your changes

Emit retry metadata from the documented `completion:error` and `completion:last_attempt` hooks in v2 retry paths.

## Issue ticket number and link

Fixes #2222

## Changes

- Adds shared retry metadata helpers for attempt number, max attempts, and final-attempt detection.
- Emits `completion:error` metadata for retryable completion call failures in sync and async retry paths.
- Emits `completion:last_attempt` once when retry handling reaches its final failure, including validation exhaustion.
- Adds sync and async regression tests, including legacy one-argument hook compatibility.
- Updates the changelog.

## Testing

- `uv run pytest tests/v2/test_retry_runtime.py`
- `uv run ruff check instructor/v2/core/retry.py tests/v2/test_retry_runtime.py`
- `uv run ty check instructor/v2/core/retry.py`

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.