### PR TITLE
fix(gemini,vertexai): raise ConfigurationError with install hint when jsonref is absent

### DIFF
--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -107,7 +107,14 @@ def verify_no_unions(obj: dict[str, Any]) -> bool:  # noqa: ARG001
 
 
 def map_to_gemini_function_schema(obj: dict[str, Any]) -> dict[str, Any]:
-    import jsonref
+    try:
+        import jsonref
+    except ImportError as e:
+        raise ConfigurationError(
+            "The 'jsonref' package is required for Gemini/VertexAI provider support.\n"
+            "Install it with: uv pip install 'instructor[google-genai]'\n"
+            "or for VertexAI: uv pip install 'instructor[vertexai]'"
+        ) from e
 
     class FunctionSchema(BaseModel):
         description: str | None = None

--- a/instructor/v2/providers/vertexai/handlers.py
+++ b/instructor/v2/providers/vertexai/handlers.py
@@ -13,7 +13,16 @@ from collections.abc import (
 from typing import Any, cast, get_origin
 
 from pydantic import BaseModel
-import jsonref
+
+try:
+    import jsonref
+except ImportError as e:
+    from instructor.v2.core.errors import ConfigurationError
+
+    raise ConfigurationError(
+        "The 'jsonref' package is required for VertexAI provider support.\n"
+        "Install it with: uv pip install 'instructor[vertexai]'"
+    ) from e
 
 from instructor.v2.core.mode import Mode
 from instructor.v2.core.providers import Provider

--- a/tests/test_jsonref_optional_dependency.py
+++ b/tests/test_jsonref_optional_dependency.py
@@ -1,0 +1,18 @@
+import sys
+
+import pytest
+
+
+def test_map_to_gemini_function_schema_requires_jsonref(monkeypatch):
+    """ConfigurationError with install hint when jsonref is absent (Gemini schema path)."""
+    from instructor.v2.core.errors import ConfigurationError
+    from instructor.v2.providers.gemini.utils import map_to_gemini_function_schema
+
+    monkeypatch.setitem(sys.modules, "jsonref", None)
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        map_to_gemini_function_schema({"type": "object", "properties": {}})
+
+    msg = str(excinfo.value)
+    assert "instructor[google-genai]" in msg
+    assert "uv pip install" in msg


### PR DESCRIPTION
## Problem

When `instructor` is installed without the `[google-genai]` or `[vertexai]` extra, any call that reaches `map_to_gemini_function_schema` in `instructor/v2/providers/gemini/utils.py` fails with a raw, unhelpful error:

```
ModuleNotFoundError: No module named 'jsonref'
```

The stack trace points deep into instructor internals with no indication that the user simply needs to install the correct extra. The same issue affects `instructor/v2/providers/vertexai/handlers.py`, where `import jsonref` appears at module level.

`jsonref` is already declared as a dependency in both `instructor[google-genai]` and `instructor[vertexai]` extras in `pyproject.toml`, but users who install the provider SDKs separately (or who aren't aware of the extras) get a confusing error.

## Fix

- **`instructor/v2/providers/gemini/utils.py`**: Wraps the lazy `import jsonref` inside `map_to_gemini_function_schema` with a `try/except ImportError` that raises `ConfigurationError` with an actionable install hint.
- **`instructor/v2/providers/vertexai/handlers.py`**: Wraps the module-level `import jsonref` with the same pattern so the error is surfaced immediately on import with a clear message.

The error messages follow the same convention already established for the xAI provider (`test_xai_optional_dependency.py`): they name the missing package and provide the exact `uv pip install` command.

## Test

Adds `tests/test_jsonref_optional_dependency.py` which simulates `jsonref` being absent (via `monkeypatch.setitem(sys.modules, "jsonref", None)`) and asserts that `ConfigurationError` is raised with the install hint. Follows the same pattern as `test_xai_optional_dependency.py`.

## Prior art

No previous PRs address this issue. The xAI optional-dependency pattern (`test_xai_optional_dependency.py`, xai client's `try/except ImportError → sentinel`) was used as the template.

Fixes #2288