### PR TITLE
feat(hooks): fire completion:error and completion:last_attempt with attempt metadata

### DIFF
--- a/instructor/v2/core/retry.py
+++ b/instructor/v2/core/retry.py
@@ -55,6 +55,16 @@ def _finalize_parsed_response(parsed: Any, response: Any) -> Any:
     return parsed
 
 
+def _attempt_metadata(attempt_number: int, max_attempts: int | None) -> dict[str, Any]:
+    return {
+        "attempt_number": attempt_number,
+        "max_attempts": max_attempts,
+        "is_last_attempt": (
+            max_attempts is not None and attempt_number >= max_attempts
+        ),
+    }
+
+
 def _initialize_usage(provider: Provider | Mode) -> Any:
     from openai.types.completion_usage import (
         CompletionTokensDetails,
@@ -135,8 +145,10 @@ def retry_sync_v2(
             retry=retry_if_exception_type(ValidationError),
             reraise=True,
         )
+        max_attempts: int | None = max(max_retries, 1)
     else:
         max_retries_instance = max_retries
+        max_attempts = None
 
     failed_attempts: list[FailedAttempt] = []
     last_exception: Exception | None = None
@@ -154,10 +166,12 @@ def retry_sync_v2(
                 except IncompleteOutputException:
                     raise
                 except Exception as e:
-                    logger.error(
-                        f"API call failed on attempt "
-                        f"{attempt.retry_state.attempt_number}: {e}"
-                    )
+                    attempt_number = attempt.retry_state.attempt_number
+                    logger.error(f"API call failed on attempt {attempt_number}: {e}")
+                    if hooks:
+                        hooks.emit_completion_error(
+                            e, **_attempt_metadata(attempt_number, max_attempts)
+                        )
                     raise
 
                 if hooks:
@@ -198,6 +212,9 @@ def retry_sync_v2(
 
                     if hooks:
                         hooks.emit_parse_error(e)
+                        hooks.emit_completion_error(
+                            e, **_attempt_metadata(attempt_number, max_attempts)
+                        )
 
                     # Prepare reask using registry
                     kwargs = handlers.reask_handler(
@@ -220,6 +237,17 @@ def retry_sync_v2(
             f"Max retries exceeded. Total attempts: {len(failed_attempts)}, "
             f"Last error: {last_exception}"
         )
+
+        if hooks:
+            last_attempt_number = (
+                failed_attempts[-1].attempt_number if failed_attempts else 1
+            )
+            hooks.emit_completion_last_attempt(
+                last_exception,
+                attempt_number=last_attempt_number,
+                max_attempts=max_attempts,
+                is_last_attempt=True,
+            )
 
         raise InstructorRetryException(
             str(last_exception),
@@ -351,8 +379,10 @@ async def retry_async_v2(
             retry=retry_if_exception_type(ValidationError),
             reraise=True,
         )
+        max_attempts: int | None = max(max_retries, 1)
     else:
         max_retries_instance = max_retries
+        max_attempts = None
 
     failed_attempts: list[FailedAttempt] = []
     last_exception: Exception | None = None
@@ -370,10 +400,12 @@ async def retry_async_v2(
                 except IncompleteOutputException:
                     raise
                 except Exception as e:
-                    logger.error(
-                        f"API call failed on attempt "
-                        f"{attempt.retry_state.attempt_number}: {e}"
-                    )
+                    attempt_number = attempt.retry_state.attempt_number
+                    logger.error(f"API call failed on attempt {attempt_number}: {e}")
+                    if hooks:
+                        hooks.emit_completion_error(
+                            e, **_attempt_metadata(attempt_number, max_attempts)
+                        )
                     raise
 
                 if hooks:
@@ -414,6 +446,9 @@ async def retry_async_v2(
 
                     if hooks:
                         hooks.emit_parse_error(e)
+                        hooks.emit_completion_error(
+                            e, **_attempt_metadata(attempt_number, max_attempts)
+                        )
 
                     # Prepare reask using registry
                     kwargs = handlers.reask_handler(
@@ -436,6 +471,17 @@ async def retry_async_v2(
             f"Max retries exceeded. Total attempts: {len(failed_attempts)}, "
             f"Last error: {last_exception}"
         )
+
+        if hooks:
+            last_attempt_number = (
+                failed_attempts[-1].attempt_number if failed_attempts else 1
+            )
+            hooks.emit_completion_last_attempt(
+                last_exception,
+                attempt_number=last_attempt_number,
+                max_attempts=max_attempts,
+                is_last_attempt=True,
+            )
 
         raise InstructorRetryException(
             str(last_exception),

--- a/tests/v2/test_retry_runtime.py
+++ b/tests/v2/test_retry_runtime.py
@@ -105,6 +105,8 @@ def test_retry_sync_v2_reasks_after_validation_error(
         emit_completion_arguments=lambda **kwargs: emitted["args"].append(kwargs),
         emit_completion_response=lambda response: emitted["responses"].append(response),
         emit_parse_error=lambda error: emitted["errors"].append(error),
+        emit_completion_error=lambda _error, **_kw: None,
+        emit_completion_last_attempt=lambda _error, **_kw: None,
     )
 
     def no_validate(_provider: Provider, _mode: Mode) -> None:
@@ -318,3 +320,313 @@ async def test_retry_async_v2_raises_retry_exception_after_validation_error(
 
     assert exc_info.value.n_attempts == 1
     assert parser_calls == ["first"]
+
+
+def _stub_retry_dependencies(
+    monkeypatch: pytest.MonkeyPatch, parser: Any, reask: Any
+) -> None:
+    def no_validate(_provider: Provider, _mode: Mode) -> None:
+        return None
+
+    def get_handlers(_provider: Provider, _mode: Mode) -> SimpleNamespace:
+        return SimpleNamespace(response_parser=parser, reask_handler=reask)
+
+    def update_usage(response: Any, total_usage: Any) -> Any:
+        assert total_usage == {"tokens": 0}
+        return response
+
+    def initialize_usage(_provider: Provider) -> dict[str, int]:
+        return {"tokens": 0}
+
+    monkeypatch.setattr(
+        "instructor.v2.core.retry.RegistryValidationMixin.validate_mode_registration",
+        no_validate,
+    )
+    monkeypatch.setattr(
+        "instructor.v2.core.retry.mode_registry.get_handlers",
+        get_handlers,
+    )
+    monkeypatch.setattr(
+        "instructor.v2.core.retry.update_total_usage",
+        update_usage,
+    )
+    monkeypatch.setattr(
+        "instructor.v2.core.retry._initialize_usage",
+        initialize_usage,
+    )
+
+
+def test_retry_sync_v2_emits_completion_error_metadata_on_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error_events: list[dict[str, Any]] = []
+
+    def fake_func(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"payload": kwargs["messages"][-1]["content"]}
+
+    def always_fail_parser(**_kwargs: Any) -> Answer:
+        raise _validation_error()
+
+    def reask_kwargs(
+        kwargs: dict[str, Any], response: Any, exception: ValidationError
+    ) -> dict[str, Any]:
+        assert response is not None and isinstance(exception, ValidationError)
+        return {
+            **kwargs,
+            "messages": [*kwargs["messages"], {"role": "user", "content": "retry"}],
+        }
+
+    _stub_retry_dependencies(monkeypatch, always_fail_parser, reask_kwargs)
+
+    hooks = SimpleNamespace(
+        emit_completion_arguments=lambda **_kwargs: None,
+        emit_completion_response=lambda _response: None,
+        emit_parse_error=lambda _error: None,
+        emit_completion_error=lambda error, **kw: error_events.append(
+            {"error": error, **kw}
+        ),
+        emit_completion_last_attempt=lambda _error, **_kw: None,
+    )
+
+    with pytest.raises(InstructorRetryException):
+        retry_sync_v2(
+            func=fake_func,
+            response_model=Answer,
+            provider=Provider.OPENAI,
+            mode=Mode.TOOLS,
+            context=None,
+            max_retries=3,
+            args=(),
+            kwargs={"messages": [{"role": "user", "content": "first"}]},
+            strict=True,
+            hooks=hooks,
+        )
+
+    assert [event["attempt_number"] for event in error_events] == [1, 2, 3]
+    assert all(event["max_attempts"] == 3 for event in error_events)
+    assert [event["is_last_attempt"] for event in error_events] == [False, False, True]
+    assert all(isinstance(event["error"], ValidationError) for event in error_events)
+
+
+def test_retry_sync_v2_emits_completion_last_attempt_after_exhaustion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    last_attempt_events: list[dict[str, Any]] = []
+
+    def fake_func(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"payload": kwargs["messages"][-1]["content"]}
+
+    def always_fail_parser(**_kwargs: Any) -> Answer:
+        raise _validation_error()
+
+    def reask_kwargs(
+        kwargs: dict[str, Any], response: Any, exception: ValidationError
+    ) -> dict[str, Any]:
+        assert response is not None and isinstance(exception, ValidationError)
+        return {
+            **kwargs,
+            "messages": [*kwargs["messages"], {"role": "user", "content": "retry"}],
+        }
+
+    _stub_retry_dependencies(monkeypatch, always_fail_parser, reask_kwargs)
+
+    hooks = SimpleNamespace(
+        emit_completion_arguments=lambda **_kwargs: None,
+        emit_completion_response=lambda _response: None,
+        emit_parse_error=lambda _error: None,
+        emit_completion_error=lambda _error, **_kw: None,
+        emit_completion_last_attempt=lambda error, **kw: last_attempt_events.append(
+            {"error": error, **kw}
+        ),
+    )
+
+    with pytest.raises(InstructorRetryException):
+        retry_sync_v2(
+            func=fake_func,
+            response_model=Answer,
+            provider=Provider.OPENAI,
+            mode=Mode.TOOLS,
+            context=None,
+            max_retries=2,
+            args=(),
+            kwargs={"messages": [{"role": "user", "content": "first"}]},
+            strict=True,
+            hooks=hooks,
+        )
+
+    assert len(last_attempt_events) == 1
+    event = last_attempt_events[0]
+    assert event["attempt_number"] == 2
+    assert event["max_attempts"] == 2
+    assert event["is_last_attempt"] is True
+    assert isinstance(event["error"], ValidationError)
+
+
+def test_retry_sync_v2_emits_completion_error_on_api_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error_events: list[dict[str, Any]] = []
+    last_attempt_events: list[dict[str, Any]] = []
+
+    def boom(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("network unreachable")
+
+    def never_called_parser(**_kwargs: Any) -> Answer:
+        raise AssertionError("parser must not be reached")
+
+    def never_called_reask(
+        _kwargs: dict[str, Any], _response: Any, _exception: ValidationError
+    ) -> dict[str, Any]:
+        raise AssertionError("reask must not be reached")
+
+    _stub_retry_dependencies(monkeypatch, never_called_parser, never_called_reask)
+
+    hooks = SimpleNamespace(
+        emit_completion_arguments=lambda **_kwargs: None,
+        emit_completion_response=lambda _response: None,
+        emit_parse_error=lambda _error: None,
+        emit_completion_error=lambda error, **kw: error_events.append(
+            {"error": error, **kw}
+        ),
+        emit_completion_last_attempt=lambda error, **kw: last_attempt_events.append(
+            {"error": error, **kw}
+        ),
+    )
+
+    with pytest.raises(InstructorRetryException):
+        retry_sync_v2(
+            func=boom,
+            response_model=Answer,
+            provider=Provider.OPENAI,
+            mode=Mode.TOOLS,
+            context=None,
+            max_retries=2,
+            args=(),
+            kwargs={"messages": [{"role": "user", "content": "first"}]},
+            strict=True,
+            hooks=hooks,
+        )
+
+    # Non-validation errors are not retried by default; both hooks fire once each.
+    assert len(error_events) == 1
+    assert error_events[0]["attempt_number"] == 1
+    assert error_events[0]["max_attempts"] == 2
+    assert isinstance(error_events[0]["error"], RuntimeError)
+
+    assert len(last_attempt_events) == 1
+    assert last_attempt_events[0]["is_last_attempt"] is True
+    assert isinstance(last_attempt_events[0]["error"], RuntimeError)
+
+
+def test_retry_sync_v2_attempt_metadata_keeps_legacy_handler_signature_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from instructor.v2.core.hooks import Hooks
+
+    legacy_errors: list[Exception] = []
+    legacy_last: list[Exception] = []
+
+    def legacy_on_error(error: Exception) -> None:
+        legacy_errors.append(error)
+
+    def legacy_on_last_attempt(error: Exception) -> None:
+        legacy_last.append(error)
+
+    hooks = Hooks()
+    hooks.on("completion:error", legacy_on_error)
+    hooks.on("completion:last_attempt", legacy_on_last_attempt)
+
+    def fake_func(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"payload": kwargs["messages"][-1]["content"]}
+
+    def always_fail_parser(**_kwargs: Any) -> Answer:
+        raise _validation_error()
+
+    def reask_kwargs(
+        kwargs: dict[str, Any], response: Any, exception: ValidationError
+    ) -> dict[str, Any]:
+        assert response is not None and isinstance(exception, ValidationError)
+        return {
+            **kwargs,
+            "messages": [*kwargs["messages"], {"role": "user", "content": "retry"}],
+        }
+
+    _stub_retry_dependencies(monkeypatch, always_fail_parser, reask_kwargs)
+
+    with pytest.raises(InstructorRetryException):
+        retry_sync_v2(
+            func=fake_func,
+            response_model=Answer,
+            provider=Provider.OPENAI,
+            mode=Mode.TOOLS,
+            context=None,
+            max_retries=2,
+            args=(),
+            kwargs={"messages": [{"role": "user", "content": "first"}]},
+            strict=True,
+            hooks=hooks,
+        )
+
+    assert len(legacy_errors) == 2
+    assert len(legacy_last) == 1
+    assert all(isinstance(err, ValidationError) for err in legacy_errors)
+    assert isinstance(legacy_last[0], ValidationError)
+
+
+@pytest.mark.asyncio
+async def test_retry_async_v2_emits_attempt_metadata_on_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error_events: list[dict[str, Any]] = []
+    last_attempt_events: list[dict[str, Any]] = []
+
+    async def fake_func(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"payload": kwargs["messages"][-1]["content"]}
+
+    def always_fail_parser(**_kwargs: Any) -> Answer:
+        raise _validation_error()
+
+    def reask_kwargs(
+        kwargs: dict[str, Any], response: Any, exception: ValidationError
+    ) -> dict[str, Any]:
+        assert response is not None and isinstance(exception, ValidationError)
+        return {
+            **kwargs,
+            "messages": [*kwargs["messages"], {"role": "user", "content": "retry"}],
+        }
+
+    _stub_retry_dependencies(monkeypatch, always_fail_parser, reask_kwargs)
+
+    hooks = SimpleNamespace(
+        emit_completion_arguments=lambda **_kwargs: None,
+        emit_completion_response=lambda _response: None,
+        emit_parse_error=lambda _error: None,
+        emit_completion_error=lambda error, **kw: error_events.append(
+            {"error": error, **kw}
+        ),
+        emit_completion_last_attempt=lambda error, **kw: last_attempt_events.append(
+            {"error": error, **kw}
+        ),
+    )
+
+    with pytest.raises(InstructorRetryException):
+        await retry_async_v2(
+            func=fake_func,
+            response_model=Answer,
+            provider=Provider.OPENAI,
+            mode=Mode.TOOLS,
+            context=None,
+            max_retries=2,
+            args=(),
+            kwargs={"messages": [{"role": "user", "content": "first"}]},
+            strict=True,
+            hooks=hooks,
+        )
+
+    assert [event["attempt_number"] for event in error_events] == [1, 2]
+    assert all(event["max_attempts"] == 2 for event in error_events)
+    assert [event["is_last_attempt"] for event in error_events] == [False, True]
+
+    assert len(last_attempt_events) == 1
+    assert last_attempt_events[0]["attempt_number"] == 2
+    assert last_attempt_events[0]["is_last_attempt"] is True


### PR DESCRIPTION
## Describe your changes

`completion:error` and `completion:last_attempt` were already declared on the `Hooks` API (`emit_completion_error` and `emit_completion_last_attempt` exist on `Hooks` and accept `**kwargs`), but neither hook is fired from `retry_sync_v2` or `retry_async_v2`. Any user-registered handler for these two events sits dormant today.

This wires both up and threads attempt metadata through as keyword arguments:

- `completion:error` fires from both the API-call failure path and the validation-error path inside the retry loop, with `error`, `attempt_number`, `max_attempts`, `is_last_attempt`.
- `completion:last_attempt` fires once from the outer `except` right before raising `InstructorRetryException`, with the final exception and the same metadata (`is_last_attempt=True`).

A handler can now distinguish an intermediate retryable error from the final failure without keeping its own shadow counter, which was the original ask in the issue. Both sync and async paths get the same treatment so the behaviour is symmetric.

### Backward compatibility

`Hooks.emit` already does `inspect.signature(handler).bind(...)` and falls back to calling the handler without the new kwargs when it can't bind them, so an existing `def on_error(error): ...` registration keeps working unchanged. The tests cover this — see `test_retry_sync_v2_attempt_metadata_keeps_legacy_handler_signature_compatible`.

### \`max_attempts\` semantics

\`max_attempts\` is \`None\` when the caller passes a \`Retrying\`/\`AsyncRetrying\` instance directly, since extracting the attempt limit from an arbitrary \`stop\` callable isn't reliable. When \`max_retries\` is an \`int\`, \`max_attempts\` is set to \`max(max_retries, 1)\`. In the \`None\` case \`is_last_attempt\` stays \`False\` on intermediate \`completion:error\` events, but \`completion:last_attempt\` still fires with \`is_last_attempt=True\` on exhaustion, which is the more important signal.

### Test note

While writing the new tests I had to wire the mock \`reask_handler\` parameters as \`kwargs, response, exception\` (positional names matching the call site) rather than \`_response\`/\`_exception\`, otherwise tenacity exhausts after a single attempt because the reask call raises \`TypeError\` on keyword binding. I didn't touch the two pre-existing tests that still use that pattern.

## Issue ticket number and link

Closes #2222

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.

## Local verification

\`\`\`
\$ pytest tests/v2/test_retry_runtime.py -v
========== 11 passed in 0.03s ==========

\$ pytest tests/v2/ --deselect tests/v2/test_provider_modes.py -q
========== 1418 passed, 109 skipped, 111 deselected ==========

\$ pre-commit run --files instructor/v2/core/retry.py tests/v2/test_retry_runtime.py
Run Linter Check (Ruff)..................................................Passed
Run Formatter (Ruff).....................................................Passed
\`\`\`

Ruff lint, Ruff format, and the 11 new + 6 existing retry-runtime tests all pass. \`ty check instructor/v2/core/retry.py\` reports the same 2 pre-existing \`unused-type-ignore-comment\` diagnostics with and without this branch — happy to clean those up in a separate PR if it'd help.