### PR TITLE
docs(examples): fix duplicate word in CRM example prompt

### DIFF
--- a/examples/crm/run.py
+++ b/examples/crm/run.py
@@ -47,7 +47,7 @@ def query_crm(query: str) -> CRMSearchQuery:
                 "role": "system",
                 "content": """
             You are a world class CRM search career generator. 
-            You will take the user query and decompose it into a set of CRM queries queries.
+            You will take the user query and decompose it into a set of CRM queries.
             """,
             },
             {"role": "user", "content": query},


### PR DESCRIPTION
## Summary

Fixed a duplicate word ("queries queries" → "queries") in the system prompt of `examples/crm/run.py`.

Before:
> "You will take the user query and decompose it into a set of CRM queries queries."

After:
> "You will take the user query and decompose it into a set of CRM queries."

Small one-character fix, no behavior change. The duplicate word would also slightly degrade the prompt's quality when the example is run as-is.
