### PR TITLE
perf(streaming): scan Iterable chunks incrementally to avoid O(n²) reparsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+- **Performance (Iterable streaming)**: `Iterable[...]` streaming now scans each incoming chunk incrementally (carrying brace depth and scan offset) instead of re-scanning the whole accumulated buffer on every chunk. This removes the O(n²) cost of parsing a large list element streamed token-by-token (~300× faster for a 4 KB object streamed one character at a time). Output is unchanged; verified against the previous algorithm over 300k differential fuzz cases.
+
 ---
 
 ## [1.15.2] - 2026-05-10

--- a/instructor/v2/dsl/iterable.py
+++ b/instructor/v2/dsl/iterable.py
@@ -90,15 +90,21 @@ class IterableBase:
     ) -> Generator[BaseModel, None, None]:
         started = False
         potential_object = ""
+        depth = 0
+        scanned = 0
         for chunk in json_chunks:
             potential_object += chunk
             if not started:
                 if "[" in chunk:
                     started = True
                     potential_object = chunk[chunk.find("[") + 1 :]
+                    depth = 0
+                    scanned = 0
 
             while True:
-                task_json, potential_object = cls.get_object(potential_object, 0)
+                task_json, potential_object, depth, scanned = cls._scan_for_object(
+                    potential_object, depth, scanned
+                )
                 if task_json:
                     assert cls.task_type is not None
                     obj = cls.extract_cls_task_type(task_json, **kwargs)
@@ -112,15 +118,21 @@ class IterableBase:
     ) -> AsyncGenerator[BaseModel, None]:
         started = False
         potential_object = ""
+        depth = 0
+        scanned = 0
         async for chunk in json_chunks:
             potential_object += chunk
             if not started:
                 if "[" in chunk:
                     started = True
                     potential_object = chunk[chunk.find("[") + 1 :]
+                    depth = 0
+                    scanned = 0
 
             while True:
-                task_json, potential_object = cls.get_object(potential_object, 0)
+                task_json, potential_object, depth, scanned = cls._scan_for_object(
+                    potential_object, depth, scanned
+                )
                 if task_json:
                     assert cls.task_type is not None
                     obj = cls.extract_cls_task_type(task_json, **kwargs)
@@ -172,6 +184,9 @@ class IterableBase:
 
     @staticmethod
     def get_object(s: str, stack: int) -> tuple[Optional[str], str]:
+        # Public (reachable as IterableBase.get_object) and the reference oracle
+        # that _scan_for_object is differential-tested against; keep its brace
+        # accounting byte-for-byte stable when refactoring.
         start_index = s.find("{")
         for i, c in enumerate(s):
             if c == "{":
@@ -181,6 +196,41 @@ class IterableBase:
                 if stack == 0:
                     return s[start_index : i + 1], s[i + 2 :]
         return None, s
+
+    @staticmethod
+    def _scan_for_object(
+        buffer: str, depth: int, scanned: int
+    ) -> tuple[Optional[str], str, int, int]:
+        """Incrementally scan ``buffer`` for the next complete top-level object.
+
+        Resumes from ``scanned`` (the index up to which ``buffer`` has already
+        been brace-counted) carrying the running brace ``depth``, so each
+        appended chunk is examined only once instead of re-scanning the whole
+        growing buffer. This is behaviourally identical to calling
+        :meth:`get_object` from index 0 on every chunk (the buffer is
+        append-only while an object is incomplete, so a carried running depth
+        equals the depth recomputed from scratch) but runs in O(total chars)
+        rather than O(chars^2) over a streamed object.
+
+        Returns ``(object_str_or_None, remainder, depth, scanned)``. On a
+        completed object, ``remainder`` is the buffer past the separator that
+        follows the closing brace and ``depth``/``scanned`` reset to ``0`` for
+        the fresh remainder; when still incomplete, ``buffer`` is returned
+        unchanged with the carried ``depth`` and ``scanned == len(buffer)``.
+        """
+        start_index = buffer.find("{")
+        n = len(buffer)
+        i = scanned
+        while i < n:
+            c = buffer[i]
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    return buffer[start_index : i + 1], buffer[i + 2 :], 0, 0
+            i += 1
+        return None, buffer, depth, n
 
 
 def IterableModel(

--- a/tests/dsl/test_iterable_streaming.py
+++ b/tests/dsl/test_iterable_streaming.py
@@ -1,0 +1,164 @@
+"""Tests for IterableBase streaming object extraction.
+
+Covers behavior-preservation (the optimized incremental scanner must yield
+exactly what the original repeated-from-zero `get_object` algorithm yielded)
+and a complexity guard (an object streamed one character at a time must be
+scanned in O(n), not O(n^2)).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator
+
+import pytest
+from pydantic import BaseModel
+
+from instructor.v2.dsl.iterable import IterableBase, IterableModel
+
+
+class User(BaseModel):
+    name: str
+
+
+Multi = IterableModel(User)
+
+
+def chunked(s: str, size: int) -> list[str]:
+    return [s[i : i + size] for i in range(0, len(s), size)] or [""]
+
+
+def ref_stream(chunks: list[str], task_type: type[BaseModel]) -> list[BaseModel]:
+    """Reference implementation mirroring the ORIGINAL tasks_from_chunks,
+    built directly on the untouched public `get_object`. Used as the oracle
+    for behavior-preservation."""
+    started = False
+    potential = ""
+    out: list[BaseModel] = []
+    for chunk in chunks:
+        potential += chunk
+        if not started and "[" in chunk:
+            started = True
+            potential = chunk[chunk.find("[") + 1 :]
+        while True:
+            task_json, potential = IterableBase.get_object(potential, 0)
+            if task_json:
+                out.append(task_type.model_validate_json(task_json))
+            else:
+                break
+    return out
+
+
+PAYLOADS = [
+    '[{"name":"a"}]',
+    '[{"name":"a"},{"name":"b"}]',
+    '[{"name":"a"}, {"name":"b"}, {"name":"c"}]',
+    "[]",
+    '   [ {"name":"a"} ] ',
+    'prefix[{"name":"a"},{"name":"b"}]',
+    '[{"name":"a{b}c"}]',  # balanced braces inside a string value
+]
+
+CHUNK_SIZES = [1, 2, 3, 7, 10_000]
+
+
+@pytest.mark.parametrize("payload", PAYLOADS)
+@pytest.mark.parametrize("size", CHUNK_SIZES)
+def test_tasks_from_chunks_matches_reference(payload: str, size: int) -> None:
+    chunks = chunked(payload, size)
+    got = list(Multi.tasks_from_chunks(iter(chunks)))
+    expected = ref_stream(chunks, User)
+    assert [u.model_dump() for u in got] == [u.model_dump() for u in expected]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload", PAYLOADS)
+async def test_tasks_from_chunks_async_matches_reference(payload: str) -> None:
+    chunks = chunked(payload, 1)
+
+    async def agen() -> AsyncGenerator[str, None]:
+        for c in chunks:
+            yield c
+
+    got = [u async for u in Multi.tasks_from_chunks_async(agen())]
+    expected = ref_stream(chunks, User)
+    assert [u.model_dump() for u in got] == [u.model_dump() for u in expected]
+
+
+RAW_CASES = [
+    '{"a":1}',
+    '{"a":1}, {"b":2}]',
+    '{"a":{"b":2}}]',
+    '{"x":',
+    '   {"a":1}',
+    '{"a":"x}"}',  # quirk: brace inside a string ends the object early
+    '}{"a":1}',  # stray closing brace before the object
+    "nobraces",
+    "",
+    "{}",
+]
+
+
+@pytest.mark.parametrize("s", RAW_CASES)
+def test_scan_for_object_matches_get_object_from_scratch(s: str) -> None:
+    ref = IterableBase.get_object(s, 0)
+    obj, rem, _depth, _scanned = IterableBase._scan_for_object(s, 0, 0)
+    assert (obj, rem) == ref
+
+
+def _count_examined_chars(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    """Patch _scan_for_object with a wrapper that counts how many characters
+    the scanner reads via integer indexing. Returns the live counter dict."""
+    counter = {"n": 0}
+    real = IterableBase.__dict__["_scan_for_object"].__func__
+
+    class CountingStr(str):
+        def __getitem__(self, key: object) -> object:
+            if isinstance(key, int):
+                counter["n"] += 1
+            return str.__getitem__(self, key)  # type: ignore[index]
+
+    def counting(buffer: str, depth: int, scanned: int):
+        return real(CountingStr(buffer), depth, scanned)
+
+    monkeypatch.setattr(IterableBase, "_scan_for_object", staticmethod(counting))
+    return counter
+
+
+def test_incomplete_object_scanned_in_linear_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = "[" + json.dumps({"name": "x" * 4000}) + "]"
+    chunks = list(payload)  # one character per chunk
+
+    counter = _count_examined_chars(monkeypatch)
+    got = list(Multi.tasks_from_chunks(iter(chunks)))
+
+    assert len(got) == 1
+    assert got[0].name == "x" * 4000
+    assert counter["n"] <= 4 * len(payload), (
+        f"scanner examined {counter['n']} chars for {len(payload)}-char input; "
+        "expected O(n). Re-scanning the whole buffer each chunk is O(n^2)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_incomplete_object_scanned_in_linear_time_async(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = "[" + json.dumps({"name": "y" * 4000}) + "]"
+    chunks = list(payload)
+
+    async def agen() -> AsyncGenerator[str, None]:
+        for c in chunks:
+            yield c
+
+    counter = _count_examined_chars(monkeypatch)
+    got = [u async for u in Multi.tasks_from_chunks_async(agen())]
+
+    assert len(got) == 1
+    assert got[0].name == "y" * 4000
+    assert counter["n"] <= 4 * len(payload), (
+        f"scanner examined {counter['n']} chars for {len(payload)}-char input; "
+        "expected O(n)."
+    )


### PR DESCRIPTION
## Problem

`IterableBase.tasks_from_chunks` / `tasks_from_chunks_async` (used by `Iterable[...]` streaming across all providers via `from_streaming_response`) call `get_object()` once per streamed chunk:

```python
# instructor/v2/dsl/iterable.py
while True:
    task_json, potential_object = cls.get_object(potential_object, 0)
    ...
```

`get_object` re-scans the **entire accumulated buffer from index 0** every call (`for i, c in enumerate(s)`). While a single list element is still arriving, the buffer grows ~one chunk per iteration, so the *i*-th chunk re-scans `O(i)` characters. Over a list element of `n` characters streamed token-by-token that is `Σ O(i) = O(n²)` parsing work — quadratic in the size of the element.

## Solution

Add a private `_scan_for_object(buffer, depth, scanned)` that **resumes** scanning from the carried offset `scanned` with the carried brace `depth`, so each appended character is examined exactly once (`O(n)` total). The drivers thread `(depth, scanned)` across chunks and reset them to `(0, 0)` on the array-start reset and whenever an object completes (the remainder is a fresh slice).

`get_object` is left **byte-for-byte unchanged** — it is reachable public API (`IterableBase.get_object`) and now also serves as the differential-test oracle for the new scanner.

**Why it is behaviour-preserving:** while an object is incomplete the buffer is strictly append-only (it is only sliced on completion, where state resets). So a carried running brace-depth equals the depth recomputed from scratch, and resuming from `scanned` merely skips already-counted characters. Incremental scanning is therefore identical to re-scanning from `0` every chunk — just without the redundant work.

## Changes

| File | Change |
|---|---|
| `instructor/v2/dsl/iterable.py` | Add `_scan_for_object` (incremental, offset+depth carrying); rewrite `tasks_from_chunks` / `tasks_from_chunks_async` to thread `(depth, scanned)`; `get_object` unchanged (marked as the reference oracle) |
| `tests/dsl/test_iterable_streaming.py` | New: differential, equivalence, and complexity-guard tests (54 cases) |
| `CHANGELOG.md` | `[Unreleased]` entry |

## Performance

Benchmark: one object of the given size streamed **one character per chunk** (the streaming hot path). Speed = `timeit` min of 5 runs; RAM = `tracemalloc` peak. Python 3.12.13 on macOS — absolute numbers are dev-machine dependent; the **scaling** is the point.

### Speed (wall-clock)

| Object size | Before — `O(n²)` | After — `O(n)` | Speedup |
|---|---|---|---|
| 514 chars | 2.17 ms | 57.4 µs | **37.8×** |
| 1014 chars | 9.15 ms | 121.9 µs | **75.1×** |
| 2014 chars | 37.77 ms | 252.5 µs | **149.6×** |
| 4014 chars | 153.96 ms | 512.5 µs | **300.4×** |

The speedup **doubles as the input doubles** (37× → 75× → 150× → 300×) — the signature of an `O(n²)` → `O(n)` change.

### Peak RAM

| Object size | Before | After | Delta |
|---|---|---|---|
| 514 chars | 909 B | 809 B | ~same |
| 1014 chars | 1.4 KB | 1.3 KB | ~same |
| 2014 chars | 2.4 KB | 2.3 KB | ~same |
| 4014 chars | 4.3 KB | 4.2 KB | ~same |

RAM is unchanged — both versions hold the same growing buffer (`O(n)` space). This is a pure time win.

## Tests

54 new tests in `tests/dsl/test_iterable_streaming.py`, no API key required:

- **Differential** — the new driver's output is asserted equal to a reference driver built on the untouched `get_object`, across payloads × chunk sizes `{1, 2, 3, 7, 10000}`, sync and async.
- **Equivalence unit** — `_scan_for_object(s, 0, 0)` matches `get_object(s, 0)` exactly, including the brace-inside-string quirk and stray-closing-brace edge cases.
- **Complexity guard** — streams one large object one char at a time, counts characters examined via a `CountingStr`, and asserts `O(n)`. This guard was first watched to **fail** at 8.05M examinations for a 4 KB input on an intermediate quadratic implementation, then pass after the fix, proving it actually detects regressions.

Additionally verified out-of-band (not committed): a **300,000-case randomized differential fuzz** over arbitrary chunked inputs (alphabet incl. `{ } [ ] , "`) found **0 divergences** between the old and new scanners. `ruff`, `ruff format`, and `ty` are clean. The only existing callers of the drivers (`xai/client.py`) use the unchanged public signatures.
