### PR TITLE
feat(hooks): pass attempt_number to parse:error handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+- **Hooks**: `parse:error` now passes `attempt_number` to handlers, so you can tell which retry a Pydantic validation failed on. Handlers that only accept `error` keep working unchanged.
+
 ---
 
 ## [1.15.2] - 2026-05-10

--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -14,10 +14,10 @@ Hooks let you intercept and handle events during the completion and parsing proc
 | `completion:kwargs` | Arguments passed to completion | `def handler(*args, **kwargs)` |
 | `completion:response` | Raw API response received | `def handler(response)` |
 | `completion:error` | Error during a retry attempt | `def handler(error, *, attempt_number, max_attempts, is_last_attempt)` |
-| `parse:error` | Pydantic validation failed | `def handler(error)` |
+| `parse:error` | Pydantic validation failed | `def handler(error, *, attempt_number)` |
 | `completion:last_attempt` | Final retry attempt exhausted | `def handler(error, *, attempt_number, max_attempts, is_last_attempt)` |
 
-`completion:error` and `completion:last_attempt` handlers receive optional retry metadata as keyword arguments. Old-style handlers that only accept `error` continue to work — the metadata is silently dropped for backward compatibility.
+`completion:error`, `completion:last_attempt`, and `parse:error` handlers receive optional retry metadata as keyword arguments. Old-style handlers that only accept `error` continue to work — the metadata is silently dropped for backward compatibility. `parse:error` carries `attempt_number`, letting you tell whether a schema validation failed on the first attempt or a later retry.
 
 ## Registering and Removing Hooks
 

--- a/instructor/v2/core/hooks.py
+++ b/instructor/v2/core/hooks.py
@@ -191,14 +191,17 @@ class Hooks:
         """
         self.emit(HookName.COMPLETION_LAST_ATTEMPT, error, **kwargs)
 
-    def emit_parse_error(self, error: Exception) -> None:
+    def emit_parse_error(self, error: Exception, **kwargs: Any) -> None:
         """
         Emit a parse error event.
 
         Args:
             error: The exception to pass to handlers
+            **kwargs: Optional metadata (attempt_number). Handlers that only
+                accept ``error`` keep working: ``emit`` falls back to passing
+                positional args when the handler signature can't bind kwargs.
         """
-        self.emit(HookName.PARSE_ERROR, error)
+        self.emit(HookName.PARSE_ERROR, error, **kwargs)
 
     def off(
         self,

--- a/instructor/v2/core/retry.py
+++ b/instructor/v2/core/retry.py
@@ -197,7 +197,7 @@ def retry_sync_v2(
                     last_exception = e
 
                     if hooks:
-                        hooks.emit_parse_error(e)
+                        hooks.emit_parse_error(e, attempt_number=attempt_number)
 
                     # Prepare reask using registry
                     kwargs = handlers.reask_handler(
@@ -413,7 +413,7 @@ async def retry_async_v2(
                     last_exception = e
 
                     if hooks:
-                        hooks.emit_parse_error(e)
+                        hooks.emit_parse_error(e, attempt_number=attempt_number)
 
                     # Prepare reask using registry
                     kwargs = handlers.reask_handler(

--- a/tests/v2/test_retry_runtime.py
+++ b/tests/v2/test_retry_runtime.py
@@ -79,7 +79,12 @@ def test_retry_sync_v2_reasks_after_validation_error(
 ) -> None:
     calls: list[dict[str, Any]] = []
     parser_calls: list[str] = []
-    emitted: dict[str, list[Any]] = {"args": [], "responses": [], "errors": []}
+    emitted: dict[str, list[Any]] = {
+        "args": [],
+        "responses": [],
+        "errors": [],
+        "error_kwargs": [],
+    }
 
     def fake_func(*_args: Any, **kwargs: Any) -> dict[str, Any]:
         calls.append(dict(kwargs))
@@ -104,7 +109,10 @@ def test_retry_sync_v2_reasks_after_validation_error(
     hooks = SimpleNamespace(
         emit_completion_arguments=lambda **kwargs: emitted["args"].append(kwargs),
         emit_completion_response=lambda response: emitted["responses"].append(response),
-        emit_parse_error=lambda error: emitted["errors"].append(error),
+        emit_parse_error=lambda error, **kwargs: (
+            emitted["errors"].append(error),
+            emitted["error_kwargs"].append(kwargs),
+        ),
     )
 
     def no_validate(_provider: Provider, _mode: Mode) -> None:
@@ -165,6 +173,34 @@ def test_retry_sync_v2_reasks_after_validation_error(
     assert len(emitted["responses"]) == 2
     assert len(emitted["errors"]) == 1
     assert isinstance(emitted["errors"][0], ValidationError)
+    # parse:error now carries the retry attempt number as metadata.
+    assert emitted["error_kwargs"] == [{"attempt_number": 1}]
+
+
+def test_emit_parse_error_supports_old_and_new_style_handlers() -> None:
+    """emit_parse_error passes attempt_number to handlers that accept it, while
+    legacy handlers that only take ``error`` keep working unchanged."""
+    from instructor.v2.core.hooks import Hooks
+
+    hooks = Hooks()
+    error = _validation_error()
+
+    old_style: list[ValidationError] = []
+    new_style: list[tuple[ValidationError, int]] = []
+
+    def legacy_handler(err: ValidationError) -> None:
+        old_style.append(err)
+
+    def metadata_handler(err: ValidationError, *, attempt_number: int) -> None:
+        new_style.append((err, attempt_number))
+
+    hooks.on("parse:error", legacy_handler)
+    hooks.on("parse:error", metadata_handler)
+
+    hooks.emit_parse_error(error, attempt_number=3)
+
+    assert old_style == [error]
+    assert new_style == [(error, 3)]
 
 
 def test_retry_sync_v2_raises_instructor_retry_exception_after_exhaustion(


### PR DESCRIPTION
## Problem

`parse:error` is the only error hook that actually fires in the v2 retry loop (`completion:error` / `completion:last_attempt` are defined but never emitted). Yet it received only the exception:

```python
def handler(error): ...
```

So a handler can read *what* failed validation (via `error.errors()`), but not *which retry attempt* it failed on. With `max_retries=7`, you can't tell whether a field fails on attempt 1 or only gives up at 7 — exactly the question you need answered when calibrating retries or instrumenting flaky schema validation. The `attempt_number` is already available at the emission site; it just wasn't being passed through.

## Change

Pass `attempt_number` to `parse:error` handlers from both retry sites (sync `retry_sync_v2` and async `retry_async_v2`):

```python
def handler(error, *, attempt_number): ...
```

## Backward compatible by design

No new mechanism — `Hooks.emit` already tries to bind kwargs to the handler signature and falls back to positional-only (`handler(*args)`) when it can't. Existing handlers that only accept `error` keep working unchanged; the metadata is silently dropped for them.

## Scope

Intentionally limited to `attempt_number`. `max_attempts` / `is_last_attempt` are **not** included because they can't be reliably derived at parse-fail time when `max_retries` is a custom `Retrying` / `AsyncRetrying` instance (the `stop` condition is a black box evaluated *after* the attempt). `attempt_number` is the one value that's always available and correct.

## Tests

- Updated `test_retry_sync_v2_reasks_after_validation_error` to assert the emitted `attempt_number`.
- Added `test_emit_parse_error_supports_old_and_new_style_handlers` exercising the real `Hooks` class with both an old-style `(error)` handler and a new-style `(error, *, attempt_number)` handler.

`tests/v2/test_retry_runtime.py` — 7 passed. `ruff check` / `ruff format` clean.

## Docs / CHANGELOG

Updated the hooks table + prose in `docs/concepts/hooks.md` and added a `[Unreleased]` CHANGELOG entry.
