### PR TITLE
fix(docs): remove inaccurate backwards compatibility notes in Google provider docs

### DIFF
--- a/docs/integrations/genai.md
+++ b/docs/integrations/genai.md
@@ -29,9 +29,7 @@ We currently have two modes for Gemini
 
     This filtering happens automatically and requires no additional configuration. For more information about Gemini's thinking feature, see the [official documentation](https://ai.google.dev/gemini-api/docs/thinking).
 
-!!! note "Backwards Compatibility"
 
-    The provider-specific modes (`Mode.TOOLS`, `Mode.JSON`, `Mode.JSON`) are still supported but emit deprecation warnings and map to the generic modes (`Mode.TOOLS`, `Mode.JSON`).
 
 ## Installation
 
@@ -550,7 +548,7 @@ print(response)
     **As of July 11, 2025, Google GenAI does not support streaming with tool/function calling or structured outputs for regular models.** 
     
     - `Mode.TOOLS` and `Mode.JSON` do not support streaming with regular models
-    - To use streaming, you must use `Partial[YourModel]` explicitly or switch to other modes like `Mode.JSON`
+    - To use streaming, you must use `Partial[YourModel]` explicitly 
     - Alternatively, set `stream=False` to disable streaming
 
 Streaming allows you to process responses incrementally rather than waiting for the complete result. This is extremely useful for making UI changes feel instant and responsive.

--- a/docs/integrations/google.md
+++ b/docs/integrations/google.md
@@ -338,9 +338,7 @@ We provide several modes to make it easy to work with the different response mod
 1. `instructor.Mode.TOOLS` : This uses Gemini's tool calling API to return structured outputs (default)
 2. `instructor.Mode.JSON` : This uses Gemini's JSON schema mode for structured outputs
 
-!!! note "Backwards Compatibility"
 
-    Legacy provider-specific modes (for example `Mode.TOOLS`, `Mode.JSON`, `Mode.JSON`, `Mode.TOOLS`) are deprecated. They emit warnings and map to the generic modes.
 
 !!! info "Mode Selection"
     When using `from_provider`, the appropriate mode is automatically selected based on the provider and model capabilities.

--- a/docs/integrations/vertex.md
+++ b/docs/integrations/vertex.md
@@ -242,7 +242,9 @@ from vertexai.generative_models import GenerativeModel
 
 vertexai.init(project="your-project", location="us-central1")
 
-client = instructor.from_provider("google/gemini-2.5-flash", vertexai=True),
+client = instructor.from_provider(
+    "google/gemini-2.5-flash",
+    vertexai=True,
     mode=instructor.Mode.TOOLS,
 )
 ```


### PR DESCRIPTION
Fixes #2289

The Google/GenAI provider docs had several inaccuracies:

- Backwards compatibility note in `genai.md` referenced duplicate/wrong mode names (`Mode.JSON` listed twice, `Mode.TOOLS` listed twice)
- Same misleading note existed in `google.md`  
- Streaming limitation note in `genai.md` contradicted itself by suggesting switching to `Mode.JSON` as a workaround, while also stating `Mode.JSON` doesn't support streaming
- Syntax error in `vertex.md` deprecated code example (misplaced closing parenthesis)