### PR TITLE
feat: emit attempt metadata in completion:error and completion:last_attempt hooks

### DIFF
--- a/instructor/v2/core/hooks.py
+++ b/instructor/v2/core/hooks.py
@@ -34,7 +34,14 @@ class CompletionResponseHandler(Protocol):
 class CompletionErrorHandler(Protocol):
     """Protocol for completion error and last attempt handlers."""
 
-    def __call__(self, error: Exception) -> None: ...
+    def __call__(
+        self,
+        error: Exception,
+        *,
+        attempt_number: int = ...,
+        max_attempts: int | None = ...,
+        is_last_attempt: bool = ...,
+    ) -> None: ...
 
 
 class ParseErrorHandler(Protocol):

--- a/instructor/v2/core/retry.py
+++ b/instructor/v2/core/retry.py
@@ -125,6 +125,7 @@ def retry_sync_v2(
     handlers = mode_registry.get_handlers(provider, mode)
 
     # Setup retrying
+    max_attempts: int | None = max_retries if isinstance(max_retries, int) else None
     if isinstance(max_retries, int):
         stop_condition = stop_after_attempt(max(max_retries, 1))
         timeout = kwargs.get("timeout")
@@ -154,10 +155,18 @@ def retry_sync_v2(
                 except IncompleteOutputException:
                     raise
                 except Exception as e:
+                    attempt_number = attempt.retry_state.attempt_number
                     logger.error(
                         f"API call failed on attempt "
-                        f"{attempt.retry_state.attempt_number}: {e}"
+                        f"{attempt_number}: {e}"
                     )
+                    if hooks:
+                        hooks.emit_completion_error(
+                            e,
+                            attempt_number=attempt_number,
+                            max_attempts=max_attempts,
+                            is_last_attempt=False,
+                        )
                     raise
 
                 if hooks:
@@ -220,6 +229,14 @@ def retry_sync_v2(
             f"Max retries exceeded. Total attempts: {len(failed_attempts)}, "
             f"Last error: {last_exception}"
         )
+
+        if hooks:
+            hooks.emit_completion_last_attempt(
+                last_exception,
+                attempt_number=len(failed_attempts),
+                max_attempts=max_attempts,
+                is_last_attempt=True,
+            )
 
         raise InstructorRetryException(
             str(last_exception),
@@ -341,6 +358,7 @@ async def retry_async_v2(
     handlers = mode_registry.get_handlers(provider, mode)
 
     # Setup retrying
+    max_attempts: int | None = max_retries if isinstance(max_retries, int) else None
     if isinstance(max_retries, int):
         stop_condition = stop_after_attempt(max(max_retries, 1))
         timeout = kwargs.get("timeout")
@@ -370,10 +388,18 @@ async def retry_async_v2(
                 except IncompleteOutputException:
                     raise
                 except Exception as e:
+                    attempt_number = attempt.retry_state.attempt_number
                     logger.error(
                         f"API call failed on attempt "
-                        f"{attempt.retry_state.attempt_number}: {e}"
+                        f"{attempt_number}: {e}"
                     )
+                    if hooks:
+                        hooks.emit_completion_error(
+                            e,
+                            attempt_number=attempt_number,
+                            max_attempts=max_attempts,
+                            is_last_attempt=False,
+                        )
                     raise
 
                 if hooks:
@@ -436,6 +462,14 @@ async def retry_async_v2(
             f"Max retries exceeded. Total attempts: {len(failed_attempts)}, "
             f"Last error: {last_exception}"
         )
+
+        if hooks:
+            hooks.emit_completion_last_attempt(
+                last_exception,
+                attempt_number=len(failed_attempts),
+                max_attempts=max_attempts,
+                is_last_attempt=True,
+            )
 
         raise InstructorRetryException(
             str(last_exception),

--- a/tests/v2/test_retry_runtime.py
+++ b/tests/v2/test_retry_runtime.py
@@ -318,3 +318,65 @@ async def test_retry_async_v2_raises_retry_exception_after_validation_error(
 
     assert exc_info.value.n_attempts == 1
     assert parser_calls == ["first"]
+
+
+def test_hooks_emit_completion_error_and_last_attempt_with_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """emit_completion_error fires per-attempt; emit_completion_last_attempt fires once on exhaustion."""
+    error_events: list[dict[str, Any]] = []
+    last_attempt_events: list[dict[str, Any]] = []
+
+    def fake_func(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("api down")
+
+    def no_validate(_provider: Provider, _mode: Mode) -> None:
+        return None
+
+    def get_handlers(_provider: Provider, _mode: Mode) -> SimpleNamespace:
+        return SimpleNamespace(
+            response_parser=lambda **_kw: Answer(value=1),
+            reask_handler=lambda kw, _r, _e: kw,
+        )
+
+    def initialize_usage(_provider: Provider) -> dict[str, int]:
+        return {"tokens": 0}
+
+    monkeypatch.setattr(
+        "instructor.v2.core.retry.RegistryValidationMixin.validate_mode_registration",
+        no_validate,
+    )
+    monkeypatch.setattr("instructor.v2.core.retry.mode_registry.get_handlers", get_handlers)
+    monkeypatch.setattr("instructor.v2.core.retry._initialize_usage", initialize_usage)
+
+    hooks = SimpleNamespace(
+        emit_completion_arguments=lambda **_kw: None,
+        emit_completion_error=lambda err, **meta: error_events.append({"err": err, **meta}),
+        emit_completion_last_attempt=lambda err, **meta: last_attempt_events.append(
+            {"err": err, **meta}
+        ),
+    )
+
+    with pytest.raises(InstructorRetryException):
+        retry_sync_v2(
+            func=fake_func,
+            response_model=Answer,
+            provider=Provider.OPENAI,
+            mode=Mode.TOOLS,
+            context=None,
+            max_retries=2,
+            args=(),
+            kwargs={"messages": [{"role": "user", "content": "hi"}]},
+            strict=True,
+            hooks=hooks,
+        )
+
+    assert len(error_events) >= 1
+    for ev in error_events:
+        assert "attempt_number" in ev
+        assert ev["max_attempts"] == 2
+        assert ev["is_last_attempt"] is False
+
+    assert len(last_attempt_events) == 1
+    assert last_attempt_events[0]["is_last_attempt"] is True
+    assert last_attempt_events[0]["max_attempts"] == 2


### PR DESCRIPTION
## Summary

Resolves #2222.

`completion:error` and `completion:last_attempt` were defined in the hooks API but **never called** from the retry loop. This PR wires both into `retry_sync_v2` and `retry_async_v2` and passes attempt metadata as keyword arguments.

## Changes

### `retry.py`
- `emit_completion_error` now fires for each API-level exception with:
  - `attempt_number`: current tenacity attempt counter
  - `max_attempts`: int if `max_retries` was an int, else `None`
  - `is_last_attempt=False`
- `emit_completion_last_attempt` fires once on retry exhaustion with:
  - `attempt_number`: total failed attempts
  - `max_attempts`: same as above
  - `is_last_attempt=True`

### `hooks.py`
- `CompletionErrorHandler` protocol updated to document the new optional kwargs.

## Backwards compatibility

Existing handlers that accept only `error: Exception` continue to work — `emit()` already uses `inspect.signature` to detect whether kwargs should be forwarded.

## Example

```python
def on_error(error, *, attempt_number, max_attempts, is_last_attempt):
    level = logging.ERROR if is_last_attempt else logging.WARNING
    logger.log(level, "API error on attempt %d/%s: %s", attempt_number, max_attempts, error)

client.on("completion:error", on_error)
client.on("completion:last_attempt", on_error)
```