### PR TITLE
fix(templating): KeyError when Cohere message has no chat_history

### DIFF
--- a/instructor/v2/core/templating.py
+++ b/instructor/v2/core/templating.py
@@ -111,7 +111,7 @@ def handle_templating(
         new_kwargs["message"] = apply_template(new_kwargs["message"], context)
         new_kwargs["chat_history"] = [
             process_message(message, context, provider)
-            for message in new_kwargs["chat_history"]
+            for message in new_kwargs.get("chat_history", [])
         ]
 
         return new_kwargs

--- a/tests/v2/test_core_provider_dispatch.py
+++ b/tests/v2/test_core_provider_dispatch.py
@@ -68,6 +68,17 @@ def test_process_message_dispatches_to_provider_modules(
     assert calls == [(message, {"name": "Ada"})]
 
 
+def test_handle_templating_cohere_message_without_chat_history() -> None:
+    """handle_templating must not raise KeyError when 'chat_history' is absent."""
+    result = templating.handle_templating(
+        {"message": "Hello {{ name }}"},
+        mode=Mode.TOOLS,
+        context={"name": "World"},
+    )
+    assert result["message"] == "Hello World"
+    assert result["chat_history"] == []
+
+
 def test_initialize_usage_dispatches_anthropic_to_provider_module(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What's broken

`handle_templating()` raises `KeyError: 'chat_history'` whenever a caller uses a Cohere provider with a Jinja2 template context and an initial message that has no prior conversation history. This is the normal first-turn case — the Cohere API treats `chat_history` as an optional field that defaults to an empty list, so it is valid to supply `kwargs = {"message": "Hello {{ name }}"}` without the key.

## Why it happens

Line 114 of `instructor/v2/core/templating.py` unconditionally reads `new_kwargs["chat_history"]` whenever `"message"` is present, without checking whether the key exists.

## Fix

Changed `new_kwargs["chat_history"]` to `new_kwargs.get("chat_history", [])` on line 114. One-character-class change; no refactoring.

## Test

Added `test_handle_templating_cohere_message_without_chat_history` in `tests/v2/test_core_provider_dispatch.py`. It calls `handle_templating` with `{"message": "Hello {{ name }}"}` (no `chat_history`) and asserts the returned dict has the rendered message and an empty `chat_history` list, with no exception raised.

Fixes #2331