### PR TITLE
fix(templating): handle missing chat_history on Cohere first-turn calls

### DIFF
--- a/instructor/v2/core/templating.py
+++ b/instructor/v2/core/templating.py
@@ -111,7 +111,7 @@ def handle_templating(
         new_kwargs["message"] = apply_template(new_kwargs["message"], context)
         new_kwargs["chat_history"] = [
             process_message(message, context, provider)
-            for message in new_kwargs["chat_history"]
+            for message in new_kwargs.get("chat_history", [])
         ]
 
         return new_kwargs

--- a/tests/v2/test_templating.py
+++ b/tests/v2/test_templating.py
@@ -1,0 +1,14 @@
+import pytest
+from instructor.v2.core.templating import handle_templating
+from instructor.v2.core.mode import Mode
+
+
+def test_handle_templating_cohere_missing_chat_history():
+    """Cohere-style first-turn call with no chat_history key must not raise KeyError."""
+    result = handle_templating(
+        {"message": "Hello {{ name }}"},
+        mode=Mode.TOOLS,
+        context={"name": "World"},
+    )
+    assert result["message"] == "Hello World"
+    assert result["chat_history"] == []


### PR DESCRIPTION
## What's broken

On a first-turn Cohere call — kwargs has a `message` key but no `chat_history` key — `handle_templating()` raises a `KeyError` at line 114 because it iterates `new_kwargs["chat_history"]` without checking whether the key exists. Any caller omitting `chat_history` (the common case for a new conversation) hits this immediately.

## Why it happens

The list comprehension used direct key access (`new_kwargs["chat_history"]`) instead of a safe default, so a missing key raises `KeyError` rather than producing an empty list.

## Fix

Replaced `new_kwargs["chat_history"]` with `new_kwargs.get("chat_history", [])` so a missing key yields an empty list instead of raising.

## Test

Added `tests/v2/test_templating.py::test_handle_templating_cohere_missing_chat_history` which calls `handle_templating` with a Cohere-style dict missing `chat_history` and asserts the rendered message is returned with an empty history list.

Fixes #2331