### PR TITLE
fix(utils): guard empty/absent messages in handle_gemini_json

### DIFF
--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -474,10 +474,11 @@ def handle_gemini_json(
         """
     )
 
-    if new_kwargs["messages"][0]["role"] != "system":
-        new_kwargs["messages"].insert(0, {"role": "system", "content": message})
+    messages = new_kwargs.get("messages") or []
+    if not messages or messages[0]["role"] != "system":
+        new_kwargs.setdefault("messages", []).insert(0, {"role": "system", "content": message})
     else:
-        new_kwargs["messages"][0]["content"] += f"\n\n{message}"
+        messages[0]["content"] += f"\n\n{message}"
 
     new_kwargs["generation_config"] = new_kwargs.get("generation_config", {}) | {
         "response_mime_type": "application/json"

--- a/tests/v2/test_gemini_utils_deterministic.py
+++ b/tests/v2/test_gemini_utils_deterministic.py
@@ -467,3 +467,19 @@ def test_handle_genai_tools_without_model_uses_message_conversion(
 
     assert model is None
     assert result["autodetect"] is True
+
+
+def test_handle_gemini_json_empty_or_absent_messages_does_not_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(utils, "_default_safety_thresholds", lambda: None)
+
+    # Empty messages list must not raise IndexError
+    model, kwargs = utils.handle_gemini_json(Answer, {"messages": []})
+    assert model is Answer
+    assert kwargs["generation_config"]["response_mime_type"] == "application/json"
+
+    # Missing messages key must not raise KeyError
+    model2, kwargs2 = utils.handle_gemini_json(Answer, {})
+    assert model2 is Answer
+    assert kwargs2["generation_config"]["response_mime_type"] == "application/json"


### PR DESCRIPTION
## What's broken

`handle_gemini_json` crashes when called with an empty or absent `messages` list. Line 477 unconditionally accesses `new_kwargs["messages"][0]["role"]`, raising `IndexError: list index out of range` for `{"messages": []}` and `KeyError: 'messages'` when the key is missing entirely. Both are reachable from normal caller code.

## Why it happens

The condition had no guard before indexing into `messages`, assuming the list was always non-empty.

## Fix

Replaced the bare index with `messages = new_kwargs.get("messages") or []` and changed the condition to `not messages or messages[0]["role"] != "system"` so an empty or missing list safely inserts the system prompt rather than crashing.

## Test

Added `test_handle_gemini_json_empty_or_absent_messages_does_not_raise` to `tests/v2/test_gemini_utils_deterministic.py`. It calls `handle_gemini_json` with both `{"messages": []}` and `{}` and asserts no exception is raised and the response mime type is set correctly.

Fixes #2335