### PR TITLE
fix(gemini): guard handle_gemini_json against empty or missing messages

### DIFF
--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -474,8 +474,9 @@ def handle_gemini_json(
         """
     )
 
-    if new_kwargs["messages"][0]["role"] != "system":
-        new_kwargs["messages"].insert(0, {"role": "system", "content": message})
+    messages = new_kwargs.get("messages") or []
+    if not messages or messages[0].get("role") != "system":
+        new_kwargs.setdefault("messages", []).insert(0, {"role": "system", "content": message})
     else:
         new_kwargs["messages"][0]["content"] += f"\n\n{message}"
 

--- a/tests/v2/test_gemini_utils_deterministic.py
+++ b/tests/v2/test_gemini_utils_deterministic.py
@@ -467,3 +467,21 @@ def test_handle_genai_tools_without_model_uses_message_conversion(
 
     assert model is None
     assert result["autodetect"] is True
+
+
+def test_handle_gemini_json_guards_empty_or_missing_messages() -> None:
+    """handle_gemini_json should not crash when 'messages' is missing or empty."""
+    # Missing "messages" key entirely
+    model, kwargs = utils.handle_gemini_json(Answer, {})
+    assert "messages" not in kwargs
+    assert isinstance(kwargs.get("contents"), list)
+
+    # Empty messages list
+    model, kwargs = utils.handle_gemini_json(
+        Answer, {"messages": []}
+    )
+    messages = kwargs.get("messages")
+    assert messages is not None
+    assert len(messages) > 0, "should have inserted a system prompt"
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"] is not None


### PR DESCRIPTION
## Summary

`handle_gemini_json` in `instructor/v2/providers/gemini/utils.py` crashed with `KeyError`/`IndexError` when `messages` was missing from kwargs or was an empty list.

## Root cause

The condition `if new_kwargs["messages"][0]["role"] != "system"` assumed messages is a non-empty list without any guard.

## Fix

Replace the unguarded access with defensive `.get()` and `.setdefault()` calls:

```python
messages = new_kwargs.get("messages") or []
if not messages or messages[0].get("role") != "system":
    new_kwargs.setdefault("messages", []).insert(0, {"role": "system", "content": message})
```

## Test

Added `test_handle_gemini_json_guards_empty_or_missing_messages` covering both the missing-key and empty-list cases.

Closes #2335