### PR TITLE
fix(cohere): guard handle_templating against missing chat_history key

### DIFF
--- a/instructor/v2/core/templating.py
+++ b/instructor/v2/core/templating.py
@@ -111,7 +111,7 @@ def handle_templating(
         new_kwargs["message"] = apply_template(new_kwargs["message"], context)
         new_kwargs["chat_history"] = [
             process_message(message, context, provider)
-            for message in new_kwargs["chat_history"]
+            for message in new_kwargs.get("chat_history", [])
         ]
 
         return new_kwargs


### PR DESCRIPTION
## Summary

`handle_templating()` in `instructor/v2/core/templating.py` raised `KeyError` when used with a Cohere provider, Jinja2 template context, and a `"message"` key but no `"chat_history"` key.

## Root cause

Line 112 unconditionally accessed `new_kwargs["chat_history"]`, but the Cohere API treats `chat_history` as optional (defaults to an empty list).

## Fix

```python
- for message in new_kwargs["chat_history"]
+ for message in new_kwargs.get("chat_history", [])
```

A one-line change that defaults to an empty list when chat_history is absent.

Closes #2331