### PR TITLE
docs(genai): fix backwards compatibility mode docs

### DIFF
--- a/docs/integrations/genai.md
+++ b/docs/integrations/genai.md
@@ -31,7 +31,7 @@ We currently have two modes for Gemini
 
 !!! note "Backwards Compatibility"
 
-    The provider-specific modes (`Mode.TOOLS`, `Mode.JSON`, `Mode.JSON`) are still supported but emit deprecation warnings and map to the generic modes (`Mode.TOOLS`, `Mode.JSON`).
+    The legacy provider-specific modes (for example `Mode.GENAI_TOOLS`, `Mode.GENAI_JSON`) are still supported but emit deprecation warnings and map to the generic modes (`Mode.TOOLS`, `Mode.JSON`).
 
 ## Installation
 

--- a/docs/integrations/google.md
+++ b/docs/integrations/google.md
@@ -340,7 +340,7 @@ We provide several modes to make it easy to work with the different response mod
 
 !!! note "Backwards Compatibility"
 
-    Legacy provider-specific modes (for example `Mode.TOOLS`, `Mode.JSON`, `Mode.JSON`, `Mode.TOOLS`) are deprecated. They emit warnings and map to the generic modes.
+    Legacy provider-specific modes (for example `Mode.GENAI_TOOLS`, `Mode.GENAI_JSON`) are deprecated. They emit warnings and map to the generic modes (`Mode.TOOLS`, `Mode.JSON`).
 
 !!! info "Mode Selection"
     When using `from_provider`, the appropriate mode is automatically selected based on the provider and model capabilities.


### PR DESCRIPTION
Correct the mode deprecation note in Google GenAI docs. The deprecated modes are `GENAI_TOOLS` and `GENAI_JSON`, not `TOOLS` and `JSON` (which are the current generic modes).

This is consistent with the `DEPRECATED_TO_CORE` mapping in `instructor/v2/core/mode.py`.

Closes #2289

## AI Disclaimer

Generated with assistance from Claude Opus 4.7 (Anthropic).