### PR TITLE
fix(multimodal): Image.autodetect returns None instead of raising

### DIFF
--- a/instructor/v2/core/multimodal.py
+++ b/instructor/v2/core/multimodal.py
@@ -91,6 +91,11 @@ class Image(BaseModel):
         if isinstance(source, Path):
             return cls.from_path(source)
 
+        raise ValueError(
+            f"Unsupported image source type: {type(source).__name__}. "
+            "Expected a str (URL, file path, or base64 data) or pathlib.Path."
+        )
+
     @classmethod
     def autodetect_safely(cls, source: Union[str, Path]) -> Union[Image, str]:  # noqa: UP007
         """Safely attempt to autodetect an image from a source string or path.

--- a/tests/v2/test_core_multimodal_runtime.py
+++ b/tests/v2/test_core_multimodal_runtime.py
@@ -165,3 +165,15 @@ def test_audio_from_path_normalizes_windows_wav_and_aac_mime_types(
 
     assert wav_audio.media_type == "audio/wav"
     assert aac_audio.media_type == "audio/aac"
+
+
+def test_image_autodetect_raises_on_unsupported_source_type() -> None:
+    # Non-str/non-Path sources (e.g. bytes) previously fell through and
+    # implicitly returned None, causing a confusing AttributeError downstream.
+    with pytest.raises(ValueError, match="Unsupported image source type"):
+        Image.autodetect(b"\xff\xd8\xff")  # type: ignore[arg-type]
+
+
+def test_image_autodetect_returns_image_for_valid_str_source() -> None:
+    image = Image.autodetect("data:image/png;base64,AA==")
+    assert isinstance(image, Image)


### PR DESCRIPTION
## What's broken

`Image.autodetect` is typed `-> Image` but only has `str` and `Path` branches. A source of any other type (e.g. `bytes`) falls through and implicitly returns `None`, so callers hit a misleading error:

```python
>>> from instructor.v2.core.multimodal import Image
>>> Image.autodetect(b"\xff\xd8\xff").source
AttributeError: 'NoneType' object has no attribute 'source'
```

This surfaces through `ImageWithCacheControl.from_image_params` on the public `convert_messages(..., autodetect_images=True)` path, whose guard does not type-check `source`.

## Why it happens

The method has no final `else`/`raise`, so unsupported types return `None`.

## Fix

Raise `ValueError` on the fall-through, matching `Audio.autodetect` which already does this. `autodetect_safely` catches `ValueError`, so its graceful behavior is preserved.

## Test

Added a case asserting `Image.autodetect(b"...")` raises `ValueError` (previously returned `None` then `AttributeError` downstream); a valid str source still returns an `Image`.

Fixes #2344