### PR TITLE
fix: raise ValueError on unsupported autodetect types and add webp mime registration

### DIFF
--- a/instructor/v2/core/multimodal.py
+++ b/instructor/v2/core/multimodal.py
@@ -16,6 +16,7 @@ from typing import (
 from pathlib import Path
 from urllib.parse import urlparse
 import mimetypes
+mimetypes.add_type("image/webp", ".webp")
 import requests
 from pydantic import BaseModel, Field
 
@@ -90,6 +91,8 @@ class Image(BaseModel):
 
         if isinstance(source, Path):
             return cls.from_path(source)
+
+        raise ValueError("Unsupported source type")
 
     @classmethod
     def autodetect_safely(cls, source: Union[str, Path]) -> Union[Image, str]:  # noqa: UP007
@@ -279,6 +282,8 @@ class Audio(BaseModel):
 
         if isinstance(source, Path):
             return cls.from_path(source)
+
+        raise ValueError("Unsupported source type")
 
     @classmethod
     def autodetect_safely(cls, source: Union[str, Path]) -> Union[Audio, str]:  # noqa: UP007
@@ -470,6 +475,8 @@ class PDF(BaseModel):
             return cls.from_raw_base64(source)
         elif isinstance(source, Path):
             return cls.from_path(source)
+
+        raise ValueError("Unsupported source type")
 
     @classmethod
     def autodetect_safely(cls, source: Union[str, Path]) -> Union[PDF, str]:  # noqa: UP007

--- a/tests/multimodal/test_multimodal.py
+++ b/tests/multimodal/test_multimodal.py
@@ -362,6 +362,15 @@ def test_image_autodetect_invalid_input():
     assert Image.autodetect_safely("hello") == "hello"
 
 
+def test_image_autodetect_unsupported_type():
+    with pytest.raises(ValueError, match="Unsupported source type"):
+        Image.autodetect(b"not a string or path")
+    with pytest.raises(ValueError, match="Unsupported source type"):
+        Audio.autodetect(b"not a string or path")
+    with pytest.raises(ValueError, match="Unsupported source type"):
+        PDF.autodetect(b"not a string or path")
+
+
 def test_image_autodetect_empty_file(tmp_path):
     empty_file = tmp_path / "empty.jpg"
     empty_file.touch()


### PR DESCRIPTION
This PR addresses two small issues:
1. `Image.autodetect`, `Audio.autodetect`, and `PDF.autodetect` would silently return `None` when given unsupported source types (such as raw `bytes`). They now raise a `ValueError` to prevent silent failures down the line.
2. Python's `mimetypes` library doesn't register `.webp` on clean Windows environments by default, causing local multimodal unit tests to fail. Added an explicit `mimetypes.add_type("image/webp", ".webp")` call at module import to ensure consistent behavior across platforms.