### PR TITLE
docs(v2): document provider-owned client architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Changed
+- **Provider architecture**: Native provider factories now declare SDK client contracts and delegate shared validation, mode normalization, sync/async selection, streaming dispatch, patching, and wrapper construction to one implementation.
+- **Provider tests**: Replace repeated provider client suites with manifest-driven behavioral contracts, including async streaming parity.
+
 ### Fixed
+- **Hooks**: Emit `completion:error` and `completion:last_attempt` consistently for raw and structured provider failures, including attempt metadata.
+- **Documentation**: Correct Mistral and Bedrock async examples and clarify that provider-specific native-client helpers remain supported.
 - **v2 cleanup**: Consolidate small provider/runtime fixes for Gemini JSON prompts, Cohere templating, JSON array extraction, iterable streaming, missing `jsonref` dependency guidance, retry semantics and hook metadata, and multimodal autodetection.
 
 ### Tests / CI

--- a/docs/blog/posts/whats-new-in-v2.md
+++ b/docs/blog/posts/whats-new-in-v2.md
@@ -5,7 +5,7 @@ categories:
   - instructor
 comments: true
 date: 2026-05-11
-description: "What changed in Instructor v2, how the migration works, and why the new provider architecture is easier to extend and maintain."
+description: "A technical tour of Instructor v2: provider-owned dispatch, executable capability contracts, compatibility facades, streaming, and typed results."
 draft: false
 slug: whats-new-in-instructor-v2
 tags:
@@ -17,27 +17,22 @@ tags:
 
 # What's new in Instructor v2?
 
-Instructor v2 is a large internal rewrite with a deliberately conservative public goal: the library should feel familiar to existing users, while becoming much easier to extend, reason about, and type-check.
+Instructor's public job is simple: pass a Pydantic model to an LLM client and
+get validated Python data back. Instructor v2 keeps that API, but changes how
+the library implements it. Provider packages, or an explicitly shared
+wire-compatible implementation, now own the SDK construction, wire format,
+streaming events, tool schema, and validation reask payload.
 
-The previous architecture accumulated a lot of provider-specific behavior in shared modules. That worked, but it made the codebase harder to grow. Adding a provider could mean touching response parsing, retry logic, multimodal handling, mode normalization, and client setup in several unrelated places.
-
-V2 moves that logic into a provider-owned architecture. The external API stays recognizable. The internals become more explicit.
+This is not only a directory move. It changes the unit of correctness. In v2,
+support for a feature is declared for a provider, registered by that
+provider's handlers, and exercised by tests generated from the same
+declaration.
 
 <!-- more -->
 
-## The short version
+## The user-facing path stays short
 
-V2 changes five things:
-
-1. Provider-specific behavior lives with the provider.
-2. Runtime dispatch goes through a registry of provider and mode handlers.
-3. Old public modules remain as compatibility facades where that preserves the upgrade path.
-4. Provider capabilities are described from one manifest instead of duplicated across routing and tests.
-5. Sync, async, streaming, partials, and public return types are much easier to validate consistently.
-
-## What stays familiar
-
-The core usage model is still the one Instructor users already know:
+The common call still looks like this:
 
 ```python
 import instructor
@@ -49,201 +44,347 @@ class User(BaseModel):
     age: int
 
 
-client = instructor.from_provider("openai/gpt-5-nano")
-
+client = instructor.from_provider("openai/gpt-4o-mini")
 user = client.create(
-    messages=[{"role": "user", "content": "Extract Jason, age 36."}],
     response_model=User,
+    messages=[{"role": "user", "content": "Extract: Jason is 36"}],
 )
 ```
 
-That remains the heart of the library:
+Async construction remains the same decision expressed once:
 
-- define a Pydantic model
-- create a provider-backed Instructor client
-- ask for structured output
-- receive validated Python objects
+```python
+async_client = instructor.from_provider(
+    "anthropic/claude-sonnet-4-6",
+    async_client=True,
+)
+user = await async_client.create(
+    response_model=User,
+    messages=[{"role": "user", "content": "Extract: Jason is 36"}],
+)
+```
 
-V2 is designed so that existing concepts such as retries, partials, iterables, multimodal inputs, and provider-specific client factories remain recognizable instead of being replaced wholesale.
+The technical path behind those calls is now:
 
-## What changed under the hood
+```text
+"anthropic/claude-sonnet-4-6"
+  -> alias lookup in ProviderSpec
+  -> lazy import of instructor.v2.providers.anthropic.client
+  -> build_from_model(...)
+  -> handler lookup for Provider.ANTHROPIC + Mode
+  -> request preparation, response parsing, streaming, and reasks
+  -> typed User result
+```
 
-### 1. Providers now own provider behavior
+The first three steps construct a client. The provider and mode handler owns
+everything that changes the provider's payload or response interpretation.
 
-In v1, provider-specific request formatting, response parsing, and reask logic could end up spread across shared modules.
+## Why a provider-owned architecture?
 
-In v2, that logic lives under:
+Structured output is not one transport feature. It includes:
+
+- converting a Pydantic schema into the provider's tool or JSON-schema shape
+- translating `Image`, `Audio`, and `PDF` values into SDK payloads
+- extracting JSON fragments from each provider's streaming events
+- deciding which validation error message or tool result to send on a retry
+- initializing sync and async SDK clients with provider-specific credentials
+
+Those operations may begin with the same Python model, but they do not end in
+the same request. Anthropic tools use `input_schema`. OpenAI tools use a
+function object. Google GenAI builds `types.FunctionDeclaration` and
+`GenerateContentConfig`. Vertex AI and legacy Gemini have different SDK
+surfaces again.
+
+V2 puts those decisions under:
 
 ```text
 instructor/v2/providers/<provider>/
 ```
 
-A provider package can own:
+Shared core code still owns shared mechanics: the client wrapper, retry
+orchestration, validation primitives, the handler registry, common media
+value types, and compatibility entrypoints. It no longer needs to be the
+place where every provider's wire-format branch accumulates.
 
-- client factories
-- request preparation
-- response parsing
-- validation reasks
-- streaming extraction
-- templating
-- multimodal encoding
-- usage handling
+## `from_provider()` is now dispatch, not construction policy
 
-This gives each provider a clear home and keeps shared runtime modules from slowly becoming giant provider switchboards.
+The model-string factory previously had to know how to build many kinds of
+SDK clients directly. In v2, `auto_client.py` performs four operations:
 
-### 2. Modes dispatch through registered handlers
+1. Split `"provider/model"` into an alias and model name.
+2. Resolve the alias through `ProviderSpec`.
+3. Lazily import the builder module named by that spec.
+4. Call its `build_from_model(...)` function with common arguments.
 
-V2 introduces a registry keyed by provider and mode. Instead of branching through one large shared path, the runtime asks:
+A simplified form of the implementation is:
 
 ```python
-handlers = mode_registry.get_handlers(provider, mode)
+provider_enum = ALIAS_TO_PROVIDER.get(provider_name)
+spec = PROVIDER_SPECS.get(provider_enum)
+module = importlib.import_module(spec.model_builder_module)
+
+return module.build_from_model(
+    provider=spec.provider,
+    model_name=model_name,
+    async_client=async_client,
+    mode=mode,
+    api_key=api_key,
+    kwargs=kwargs,
+)
 ```
 
-Those handlers define how to:
+That reduction is measurable in code size: the v2 `auto_client.py` is now 181
+lines. More importantly, adding or fixing provider construction no longer
+means extending a central factory branch.
 
-- prepare the provider request
-- parse the response
-- build a reask after validation fails
-- extract streaming chunks when needed
+V2 does share construction when the behavior is genuinely identical.
+OpenAI-compatible endpoints can use `compatible_model_builder(...)`, a
+higher-order builder that handles an OpenAI wire-compatible client, base URL,
+API key environment variable, and default mode. Providers that need special
+credentials or client classes, such as Azure OpenAI or Databricks, retain
+specialized construction inside the OpenAI provider builder instead of being
+forced into the generic path.
 
-This makes behavior more explicit. It also means provider support can be extended without adding another round of conditional logic to the middle of the library.
+## `ProviderSpec` is executable documentation
 
-### 3. Retry and reask logic is modular again
+Provider support is represented by an immutable specification. The important
+parts are:
 
-Instructor retries failed validations. That behavior is essential, but providers do not all want the same retry payload.
+```python
+@dataclass(frozen=True)
+class ProviderCapabilities:
+    partial_stream_modes: tuple[Mode, ...] = ()
+    iterable_stream_modes: tuple[Mode, ...] = ()
+    multimodal_inputs: tuple[str, ...] = ()
+    explicit_parallel_tools: bool = False
 
-V2 keeps the generic retry loop in shared runtime code, while moving provider-specific reask formatting to the owning provider handler. That gives us the right split:
 
-- shared orchestration stays shared
-- wire-format behavior stays local
-
-This matters for providers whose follow-up messages, tool payloads, or structured-output conventions differ in small but important ways.
-
-### 4. Compatibility becomes intentional
-
-One concern with a migration this broad is upgrade pain. V2 takes the opposite route: compatibility is explicit.
-
-Old public modules under paths such as:
-
-```text
-instructor/core
-instructor/processing
-instructor/dsl
-instructor/validation
+@dataclass(frozen=True)
+class ProviderSpec:
+    aliases: tuple[str, ...]
+    handler_module: str | None
+    supported_modes: tuple[Mode, ...]
+    unsupported_modes: tuple[Mode, ...]
+    legacy_modes: Mapping[Mode, Mode]
+    client_module: str | None
+    sdk_module: str | None
+    capabilities: ProviderCapabilities
+    builder_module: str | None = None
 ```
 
-remain as thin compatibility facades where users still need those imports. The real runtime behavior moves under `instructor/v2`.
+This is a contract, not a marketing list. It distinguishes four different
+questions:
 
-That gives us two useful properties at once:
+- Can the provider construct an Instructor client?
+- Which core modes can its handlers execute?
+- Which older mode names should normalize with compatibility behavior?
+- Which user-visible features have conformance coverage?
 
-- existing import paths keep working where possible
-- new implementation work has one obvious home
+For example, the current contract declares:
 
-The same idea applies to legacy modes. Older provider-specific mode names can normalize into the smaller core mode system, preserving behavior while reducing long-term surface area.
+| Provider path | Modes in the contract | Streaming contract | Typed multimodal inputs |
+| --- | --- | --- | --- |
+| `openai/...` | tools, JSON, JSON schema, Markdown JSON, parallel tools, Responses tools | partial and iterable, including Responses tools where declared | image, audio, PDF |
+| `anthropic/...` | tools, JSON, JSON schema, parallel tools | partial for tools/JSON/JSON schema; iterable for tools | image, PDF |
+| `google/...` | tools, JSON | partial and iterable for both declared modes | image, audio, PDF |
+| `gemini/...` | tools, Markdown JSON | partial only | none declared |
+| `vertexai/...` | tools, Markdown JSON, parallel tools | partial for tools and Markdown JSON | none declared |
+| `xai/...` | tools, JSON schema, Markdown JSON, parallel tools | partial and iterable only for the declared streaming modes | none declared |
 
-### 5. Provider capabilities come from one manifest
+An empty capability is meaningful. It means the shared v2 conformance suite
+does not promise that feature for that provider.
 
-V2 adds a provider specification layer that records:
+## Handlers own request, response, stream, and reask behavior
 
-- provider aliases
-- handler modules
-- supported modes
-- unsupported modes
-- legacy mode normalization
-- public factory bindings
-- optional SDK requirements
+Modes are registered against a provider:
 
-That manifest becomes the single place to understand what a provider supports. It also drives tests and runtime wiring, which means fewer duplicated lists and fewer places for support claims to drift.
-
-## Why this is better
-
-### New providers are easier to add
-
-The path is clearer:
-
-1. add the provider spec
-2. implement provider handlers
-3. wire the client factory
-4. rely on shared registry and retry machinery
-
-The codebase no longer asks each new provider to thread behavior through unrelated shared modules.
-
-### Existing providers are easier to make feature-complete
-
-Streaming, partials, schema conversion, and reasks often expose the places where a provider integration is shallow. V2 gives those features a provider-local place to live, so it is easier to finish the implementation instead of leaving small one-off gaps in shared utilities.
-
-### Type inference is more trustworthy
-
-The v2 migration also tightens public typing around:
-
-- sync clients
-- async clients
-- partial streaming
-- iterable streaming
-- completion-returning helpers
-- provider factory return types
-
-That matters because Instructor users often lean on the IDE to understand the shape of returned data. V2 makes those guarantees easier to test directly.
-
-### Imports can stay lightweight
-
-Optional provider SDKs should not become a hidden tax for everyone else. The v2 public surface uses lazy exports and provider-local loading so importing Instructor does not eagerly drag every provider dependency into memory.
-
-This is especially important for a library that wants to support many providers without forcing every user into the largest possible environment.
-
-## What changes for contributors
-
-The main contributor habit shift is simple:
-
-- put provider-specific behavior in the provider package
-- keep shared runtime modules provider-agnostic
-- add reusable coverage to parametrized v2 tests where possible
-- reserve provider-specific tests for genuinely provider-specific behavior
-
-That last point matters. The v2 test suite is being pushed toward a smaller, more reusable structure:
-
-- one parametrized suite for common client behavior
-- one for handler registration
-- one for shared provider/mode dispatch expectations
-- provider-specific files only where the behavior is actually unique
-
-The new parametrized suites reduce repeated provider boilerplate and centralize the shared client and handler assertions.
-
-## A concrete mental model
-
-If you want one picture of v2, use this:
-
-```text
-public factory
-  -> provider spec
-  -> provider client
-  -> registry lookup by provider + mode
-  -> request / response / reask handlers
-  -> typed Instructor result
+```python
+@register_mode_handler(Provider.ANTHROPIC, Mode.TOOLS)
+class AnthropicToolsHandler(AnthropicHandlerBase):
+    ...
 ```
 
-V1 made many of those steps work implicitly. V2 keeps the user-facing simplicity, but makes the implementation shape visible enough to maintain.
+A mode handler is the local place for four related operations:
 
-## Is this a breaking change?
+- `prepare_request(...)` turns a response model and user kwargs into the SDK
+  request shape.
+- `parse_response(...)` converts the provider response into the requested
+  Pydantic type.
+- streaming extractors expose provider event chunks to `Partial` and
+  `Iterable` processing.
+- `handle_reask(...)` constructs the provider's correction request after
+  validation fails.
 
-The migration is designed to preserve the common public workflows and import paths where practical. That does not mean no code moved. A lot moved. But the migration is intentionally built around:
+The retry loop remains shared because retry orchestration is generic. The
+reask payload is local because sending an Anthropic tool error is not the same
+operation as sending a GenAI function response or an OpenAI tool message.
 
-- compatibility facades
-- normalized legacy modes
-- preserved factory names
-- continued support for existing structured-output workflows
+The ownership boundary is visible in specific implementations:
 
-The main breaking-pressure points are internal, not user-facing. The library is stricter about ownership boundaries because that is what keeps the public API stable over time.
+| Provider family | Provider-owned work in v2 |
+| --- | --- |
+| Anthropic | Anthropic tool schema generation, parallel tool schemas, media conversion callbacks, streaming extraction, and reask payloads |
+| OpenAI and compatible handlers | OpenAI function/JSON schema shapes, Responses tool events, OpenAI media conversion, and compatible mode registration |
+| Google GenAI | `GenerateContentConfig`, function declarations, content/media conversion, stream extraction, and GenAI reasks |
+| Mistral | Mistral message conversion and stream parsing, with explicit compatible media encoder reuse where the wire shape matches |
 
-## Why now
+There is still intentional reuse inside provider families. Several
+OpenAI-compatible providers register the OpenAI handler implementation rather
+than copying equivalent wire logic. The GenAI handler uses Google
+schema/message utilities currently located in
+`instructor.v2.providers.gemini.utils`. That is Google-specific reuse, not a
+claim that the two SDKs expose identical public behavior: `google/...`,
+`gemini/...`, and `vertexai/...` have separate provider specs and separate
+declared capabilities. The `google/...` path targets `google.genai`;
+`gemini/...` remains the legacy `google.generativeai` integration, and
+`generative-ai/...` is a compatibility alias for the GenAI builder.
 
-Instructor has grown from an OpenAI-focused structured-output helper into a broad provider toolkit. That growth is good, but the implementation needed to catch up with the product surface.
+## Multimodal values stay common; encoders do not
 
-V2 is the cleanup that makes the next phase healthier:
+Users should not need a new `Image` class for every provider. V2 therefore
+keeps common media value types in core. The conversion boundary changed:
+active handlers pass provider-local encoders into the shared message walker.
 
-- easier provider work
-- more consistent feature parity
-- better typing
-- less duplicated routing logic
-- more focused tests
-- lighter imports
+For example, Anthropic passes `media_to_anthropic` and `image_from_params`
+when converting messages. OpenAI passes its own encoders. GenAI produces
+Google `Part` content through its provider module. This preserves a common
+input API without asking core code to produce every provider's final wire
+payload.
+
+Compatibility wrappers remain in shared modules for public imports that
+already exist. They forward into provider-owned implementations; the active
+Anthropic, Gemini, GenAI, and OpenAI-compatible request paths updated in this
+refactor no longer need a core compatibility schema surface to build provider
+requests.
+
+## Compatibility is lazy, not eager
+
+V2 is intended to be a practical upgrade, so older provider factory and
+utility imports continue to exist. The facade modules use module-level
+`__getattr__` resolution:
+
+```python
+__getattr__ = make_getattr("anthropic", ("client",))
+```
+
+Importing `instructor.providers.anthropic.client` therefore does not import
+the v2 Anthropic implementation or the optional Anthropic SDK until a
+forwarded symbol is actually accessed. Subprocess tests block optional SDK
+imports and verify that legacy client facades can still be imported.
+
+This boundary also has a measurable import effect in fresh Python processes:
+
+| Import | Before this refactor | After this refactor |
+| --- | ---: | ---: |
+| `import instructor` | `0.01s`, `17.5 MB` RSS | `0.01s`, `17.4 MB` RSS |
+| `from instructor import Mode` | `0.03s`, `20.7 MB` RSS | `0.02s`, `19.5 MB` RSS |
+| `import instructor.providers.anthropic.client` | `0.55s`, `79.2 MB` RSS | `0.02s`, `19.6 MB` RSS |
+
+These numbers are an implementation comparison, not a promise that every
+machine will have identical timings. The guarantee enforced in tests is the
+architectural one: compatibility imports do not eagerly require optional
+provider SDKs.
+
+## Tests now follow the feature contract
+
+The test suite reads the same provider specifications used by runtime
+dispatch. A shared matrix derives:
+
+- provider and mode registration cases
+- partial streaming cases
+- iterable streaming cases
+- typed multimodal cases
+- explicit parallel-tools cases
+
+The conformance tests then execute each advertised feature. If a provider
+adds a streaming mode to `ProviderCapabilities`, it joins the streaming
+contract tests. If it removes that declaration, the public feature claim is
+removed with it. Unique SDK request shapes can still have provider-specific
+tests; repeated capability bookkeeping no longer needs a hand-maintained list
+per test file.
+
+These are deterministic contract tests: they use representative stream events
+and media values to prove handler registration and conversion behavior without
+calling hosted models. They do not by themselves claim that every provider
+and model performs equally well in production.
+
+The migration also adds two guardrails beyond runtime tests:
+
+- public sync and async factory inference is checked with `assert_type(...)`
+  and Pyright, including `from_provider(..., async_client=True)`;
+- deterministic lazy-import tests protect the optional-SDK boundary described
+  above.
+
+## Benchmarking model and mode combinations
+
+V2 also includes a live benchmark example for the question deterministic
+contracts cannot answer: for a particular extraction task, which configured
+model and mode combination is fast and reliable?
+
+```bash
+uv run python examples/v2-model-mode-benchmark/run.py --trials 3
+```
+
+The runner derives mode cells from `ProviderSpec`, uses each provider's
+configured default model when one exists, and emits one result per model/mode
+cell. Cells are reported as skipped when the model has no configured default,
+its optional SDK is unavailable, or its required API-key environment variable
+is absent. Providers that authenticate through a cloud credential chain, such
+as Bedrock or Vertex AI, require explicit `--allow-cloud-auth` so the runner
+does not guess whether ambient credentials are valid. That makes the default
+run safe in a partial local environment without turning missing keys into
+failed comparisons.
+
+To compare selected models rather than the defaults:
+
+```bash
+uv run python examples/v2-model-mode-benchmark/run.py \
+  --model openai/gpt-4o-mini \
+  --model anthropic/claude-sonnet-4-6 \
+  --mode TOOLS \
+  --mode JSON_SCHEMA \
+  --trials 5 \
+  --markdown-out benchmark-results.md \
+  --json-out benchmark-results.json
+```
+
+The benchmark records success rate and latency for a small typed extraction
+probe, then ranks completed cells by correctness first and median latency
+second. It is a harness for comparing a supplied workload, not a universal
+model leaderboard; a meaningful decision should replace or extend the probe
+with representative application examples.
+
+## What upgrading code requires
+
+For most applications, no architectural knowledge is required. Existing
+factory paths remain compatibility entrypoints, while new code can prefer the
+model-string form:
+
+```python
+# Existing factory style remains supported.
+client = instructor.from_anthropic(anthropic_client)
+
+# Recommended v2 construction path.
+client = instructor.from_provider("anthropic/claude-sonnet-4-6")
+```
+
+Older provider-specific modes normalize to the smaller v2 mode vocabulary
+where a mapping exists. New code should select core modes such as
+`Mode.TOOLS`, `Mode.JSON_SCHEMA`, `Mode.MD_JSON`, or
+`Mode.PARALLEL_TOOLS`, and check the integration guide for provider-specific
+support before depending on streaming or multimodal behavior.
+
+For contributors, the rule is stricter:
+
+1. Put provider SDK construction in that provider's client module.
+2. Put wire schemas, streaming events, and reask payloads in that provider's
+   handler or helper modules.
+3. Declare supported user-visible behavior in `ProviderSpec`.
+4. Add shared conformance coverage through the manifest, and add one-off tests
+   only for genuinely unique behavior.
+5. Keep core exports only when they represent shared machinery or compatibility
+   that users already import.
+
+That is the technical change in v2: Instructor still presents one typed
+structured-output workflow, while its implementation stops pretending every
+provider reaches that workflow through the same protocol.

--- a/docs/concepts/citation.md
+++ b/docs/concepts/citation.md
@@ -185,6 +185,6 @@ Use CitationMixin when:
 ## See Also
 
 - [Validation](./validation.md) - Learn about validation in Instructor
-- [Context-Based Validation](./validation.md#context-based-validation) - Using context for validation
+- [Custom Validators](./validation.md#custom-validators) - Using context for validation
 - [Citation Examples](../examples/exact_citations.md) - More citation examples
 - [RAG Patterns](../blog/posts/rag-and-beyond.md) - Building RAG systems with Instructor

--- a/docs/concepts/from_provider.md
+++ b/docs/concepts/from_provider.md
@@ -331,13 +331,21 @@ client = instructor.from_provider("openai/gpt-4o-mini")
 
 ### from_provider vs. Provider-Specific Functions
 
-Provider-specific helpers were removed. Use `from_provider` for all clients:
+Provider-specific helpers remain supported for applications that already construct
+native SDK clients. Use `from_provider` when a model string is the most convenient
+entrypoint; use `from_openai`, `from_anthropic`, and the other `from_*` helpers when
+you need to configure the underlying SDK client directly.
 
 ```python
 import instructor
 
 openai_client = instructor.from_provider("openai/gpt-4o-mini")
 anthropic_client = instructor.from_provider("anthropic/claude-3-5-sonnet")
+
+# Existing native-client factories remain public compatibility entrypoints.
+from openai import OpenAI
+
+native_client = instructor.from_openai(OpenAI())
 ```
 
 ## Troubleshooting

--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -19,6 +19,11 @@ Hooks let you intercept and handle events during the completion and parsing proc
 
 `completion:error` and `completion:last_attempt` handlers receive optional retry metadata as keyword arguments. Old-style handlers that only accept `error` continue to work — the metadata is silently dropped for backward compatibility.
 
+For custom Tenacity policies, `max_attempts` is populated when the policy uses a
+direct `stop_after_attempt` limit. With predicate- or delay-based stop conditions,
+the runtime may not know that an error is terminal when `completion:error` is
+emitted; use `completion:last_attempt` as the authoritative exhaustion signal.
+
 ## Registering and Removing Hooks
 
 ```python

--- a/docs/concepts/migration.md
+++ b/docs/concepts/migration.md
@@ -100,7 +100,7 @@ user = await client.create(...)
 ### Anthropic
 
 ```python
-# Before (removed)
+# Before (still supported)
 import anthropic
 from instructor import from_anthropic
 
@@ -115,7 +115,7 @@ user = client.create(...)
 ### Google/Gemini
 
 ```python
-# Before (removed)
+# Before (still supported)
 import google.genai as genai
 from instructor import from_genai
 
@@ -188,13 +188,16 @@ anthropic_client = instructor.from_provider("anthropic/claude-3-5-sonnet")
 
 ## Backward Compatibility
 
-Legacy helpers have been removed:
+V2 keeps the established v1 factory and patch import paths as lazy
+compatibility facades. Existing applications do not need a flag-day rewrite:
 
-- `instructor.patch()` → Use `from_provider` instead
-- `instructor.apatch()` → Use `from_provider` with `async_client=True`
-- `from_openai()`, `from_anthropic()`, etc. → Use `from_provider`
+- `instructor.patch()` and `instructor.apatch()` continue to work.
+- `from_openai()`, `from_anthropic()`, and other provider factories continue to work.
+- Provider-specific legacy modes normalize to the corresponding core modes with
+  deprecation warnings.
 
-Update all call sites before upgrading.
+Prefer `from_provider()` and core modes in new code because their capability
+contract and type surface receive the new conformance checks.
 
 ## See Also
 

--- a/docs/concepts/mode-migration.md
+++ b/docs/concepts/mode-migration.md
@@ -31,7 +31,7 @@ Use this table to replace legacy modes:
 | `FUNCTIONS` | `TOOLS` |
 | `TOOLS_STRICT` | `TOOLS` |
 | `ANTHROPIC_TOOLS` | `TOOLS` |
-| `ANTHROPIC_JSON` | `MD_JSON` |
+| `ANTHROPIC_JSON` | `JSON` |
 | `COHERE_TOOLS` | `TOOLS` |
 | `COHERE_JSON_SCHEMA` | `JSON_SCHEMA` |
 | `XAI_TOOLS` | `TOOLS` |
@@ -99,7 +99,7 @@ from instructor import Mode
 
 client = instructor.from_provider(
     "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
-    mode=Mode.BEDROCK_TOOLS,
+    mode=Mode.TOOLS,
 )
 ```
 

--- a/docs/concepts/provider-architecture-parity.md
+++ b/docs/concepts/provider-architecture-parity.md
@@ -1,0 +1,198 @@
+# Provider Architecture and Parity Inventory
+
+This page records the provider architecture introduced by the
+`provider-owned-clients` change and the compatibility decisions verified on
+June 7, 2026. The measured baseline is commit `0212d8833cba`, immediately
+before the shared native-client factory migration.
+
+The implementation, documentation, and deterministic contract tests are split
+into three reviewable changes. The documentation and tests changes both target
+the same core implementation commit; the test evidence and measurements below
+are supplied by the companion tests change rather than duplicated here.
+
+## Architecture decisions
+
+- `ProviderSpec` is the provider control plane. It declares aliases, canonical
+  provider identity, supported and legacy modes, handler modules, builders,
+  capabilities, dependency errors, and the native client contract.
+- `ClientSpec` is an internal declarative contract for native sync and async SDK
+  types, create and stream method paths, model fallback behavior, and legacy
+  validation precedence. It is not a public export.
+- `create_instructor()` is the single implementation of native client
+  validation, mode normalization, sync/async selection, method resolution,
+  stream switching, patching, model defaults, and wrapper construction.
+- The mode registry remains the single runtime lookup for request, re-ask,
+  response, sync stream, async stream, message, and template handlers. Legacy
+  provider ownership and normalization are derived from `ProviderSpec`.
+- `retry_sync_v2()` and `retry_async_v2()` own validation retries, re-asks,
+  usage accumulation, hook emission, error propagation, and final response
+  attachment for every retained provider.
+- Provider modules retain only SDK construction and behavior that cannot be
+  expressed by the common contract. OpenAI Responses, xAI, and LiteLLM remain
+  explicit compatibility exceptions.
+
+## Public export inventory
+
+Every name in `instructor.__all__` remains available. Optional factories remain
+conditional on their SDK being importable, matching the previous behavior.
+
+| Export | Result |
+| --- | --- |
+| `Instructor` | Preserved |
+| `AsyncInstructor` | Preserved |
+| `Image` | Preserved |
+| `Audio` | Preserved |
+| `from_openai` | Preserved |
+| `from_anyscale` | Preserved |
+| `from_together` | Preserved |
+| `from_databricks` | Preserved |
+| `from_deepseek` | Preserved |
+| `from_openrouter` | Preserved |
+| `from_litellm` | Preserved |
+| `from_vertexai` | Preserved; deprecated provider guidance is unchanged |
+| `from_provider` | Preserved |
+| `Provider` | Preserved |
+| `ResponseSchema` | Preserved |
+| `response_schema` | Preserved |
+| `OpenAISchema` | Preserved |
+| `CitationMixin` | Preserved |
+| `IterableModel` | Preserved |
+| `Maybe` | Preserved |
+| `Partial` | Preserved |
+| `openai_schema` | Preserved |
+| `generate_openai_schema` | Preserved |
+| `generate_anthropic_schema` | Preserved |
+| `generate_gemini_schema` | Preserved |
+| `Mode` | Preserved |
+| `patch` | Preserved |
+| `apatch` | Preserved |
+| `FinetuneFormat` | Preserved |
+| `Instructions` | Preserved |
+| `BatchProcessor` | Preserved |
+| `BatchRequest` | Preserved |
+| `BatchJob` | Preserved |
+| `llm_validator` | Preserved |
+| `openai_moderation` | Preserved |
+| `hooks` | Preserved |
+| `v2` | Preserved |
+| `from_anthropic` | Preserved as an optional export |
+| `from_gemini` | Preserved as an optional export |
+| `from_fireworks` | Preserved as an optional export |
+| `from_cerebras` | Preserved as an optional export |
+| `from_groq` | Preserved as an optional export |
+| `from_mistral` | Preserved as an optional export |
+| `from_cohere` | Preserved as an optional export |
+| `from_bedrock` | Preserved as an optional export |
+| `from_writer` | Preserved as an optional export |
+| `from_xai` | Preserved as an optional export |
+| `from_perplexity` | Preserved as an optional export |
+| `from_genai` | Preserved as an optional export |
+
+`instructor.__version__` also remains available. No public export was removed.
+
+## Provider and mode inventory
+
+The table lists canonical modes after normalization. Existing provider-specific
+mode enum values remain accepted as deprecated aliases where declared by the
+provider specification.
+
+| Provider or alias | Factory | Canonical modes | Result |
+| --- | --- | --- | --- |
+| OpenAI | `from_openai` | `TOOLS`, `JSON`, `JSON_SCHEMA`, `MD_JSON`, `PARALLEL_TOOLS`, `RESPONSES_TOOLS` | Preserved |
+| Anyscale | `from_anyscale` | `TOOLS`, `JSON`, `JSON_SCHEMA`, `MD_JSON`, `PARALLEL_TOOLS` | Preserved through OpenAI-compatible handlers |
+| Together | `from_together` | `TOOLS`, `JSON`, `JSON_SCHEMA`, `MD_JSON`, `PARALLEL_TOOLS` | Preserved through OpenAI-compatible handlers |
+| Databricks | `from_databricks` | `TOOLS`, `JSON`, `JSON_SCHEMA`, `MD_JSON`, `PARALLEL_TOOLS` | Preserved through OpenAI-compatible handlers |
+| DeepSeek | `from_deepseek` | `TOOLS`, `JSON`, `JSON_SCHEMA`, `MD_JSON`, `PARALLEL_TOOLS` | Preserved through OpenAI-compatible handlers |
+| OpenRouter | `from_openrouter` | `TOOLS`, `JSON_SCHEMA`, `MD_JSON`, `PARALLEL_TOOLS` | Preserved |
+| Anthropic | `from_anthropic` | `TOOLS`, `JSON`, `JSON_SCHEMA`, `PARALLEL_TOOLS` | Preserved, including beta client routing |
+| Google GenAI (`google/...`) | `from_genai` | `TOOLS`, `JSON` | Preserved |
+| `generative-ai` | `from_provider` alias | Canonicalizes to Google GenAI | Preserved deprecated alias |
+| Gemini | `from_gemini` | `TOOLS`, `MD_JSON` | Preserved deprecated SDK integration |
+| Cohere | `from_cohere` | `TOOLS`, `JSON_SCHEMA`, `MD_JSON` | Preserved, including V1/V2 and split stream methods |
+| Perplexity | `from_perplexity` | `MD_JSON` | Preserved |
+| xAI | `from_xai` | `TOOLS`, `JSON_SCHEMA`, `MD_JSON`, `PARALLEL_TOOLS` | Preserved custom adapter |
+| Groq | `from_groq` | `TOOLS`, `JSON_SCHEMA`, `MD_JSON` | Preserved |
+| Mistral | `from_mistral` | `TOOLS`, `JSON_SCHEMA`, `MD_JSON` | Preserved, including split stream methods |
+| Fireworks | `from_fireworks` | `TOOLS`, `JSON_SCHEMA`, `MD_JSON` | Preserved |
+| Cerebras | `from_cerebras` | `TOOLS`, `JSON_SCHEMA`, `MD_JSON`, `PARALLEL_TOOLS` | Preserved |
+| Writer | `from_writer` | `TOOLS`, `JSON_SCHEMA`, `MD_JSON` | Preserved |
+| Bedrock | `from_bedrock` | `TOOLS`, `MD_JSON` | Preserved, including async wrapping of the sync SDK method |
+| Vertex AI | `from_vertexai` | `TOOLS`, `MD_JSON`, `PARALLEL_TOOLS` | Preserved deprecated provider path |
+| Azure OpenAI | `from_provider` alias | Canonicalizes to OpenAI | Preserved compatibility alias |
+| Ollama | `from_provider` alias | Canonicalizes to OpenAI | Preserved compatibility alias |
+| LiteLLM | `from_litellm` | Callable wrapper modes | Preserved custom adapter |
+
+Unsupported provider/mode combinations continue to raise `ModeError`; they are
+not advertised as capabilities by `ProviderSpec`.
+
+## Workflow parity
+
+| Workflow | Result | Deterministic evidence |
+| --- | --- | --- |
+| Sync structured extraction | Preserved | Shared provider/client, handler, patch, and retry suites |
+| Async structured extraction | Preserved | Shared wrapper selection and async retry suites |
+| Pydantic response validation | Preserved | Shared response parser and retry runtime suites |
+| Full streaming | Preserved | Provider capability runtime contracts |
+| Async streaming | Preserved | Async extractor contract for every advertised stream mode |
+| `Partial[T]` streaming | Preserved | DSL and provider capability suites |
+| `Iterable[T]` responses and streaming | Preserved | DSL, response-list, and provider capability suites |
+| Retries and re-asks | Preserved | Central sync/async retry runtime suites |
+| `completion:kwargs` and `completion:response` hooks | Preserved | Retry runtime suites |
+| `completion:error` and `completion:last_attempt` hooks | Intentionally changed to match the documented contract | Raw and structured failure hook tests |
+| Usage accumulation and reporting | Preserved | Shared retry usage paths and provider usage tests |
+| `Maybe`, citations, schemas, multimodal DSL | Preserved | Public typing and deterministic DSL suites |
+| Automatic provider detection | Preserved | `from_provider` and provider URL detection suites |
+| Provider-specific factory imports | Preserved | Lazy public import and legacy compatibility suites |
+| Documented Mistral async workflow | Preserved and corrected | Uses `async_client=True` explicitly |
+| Documented Bedrock async workflow | Preserved and corrected | Uses `async_client=True` explicitly |
+
+## Intentional changes and removals
+
+| Item | Result | Evidence and migration |
+| --- | --- | --- |
+| Provider-local sync/async validation, patching, stream switching, and wrapper construction | Removed as obsolete duplication | Replaced by `ClientSpec` and `create_instructor()`; public factory signatures are unchanged |
+| Repeated Bedrock, Cerebras, Fireworks, Groq, Mistral, and Writer client suites | Removed as meaningless duplication | Replaced by the manifest-driven shared client contract; provider-specific handler tests remain |
+| Bedrock `_async` documentation | Removed as broken or obsolete | `_async` was not a supported selector; pass `async_client=True` to `from_provider()` or use the async factory overload |
+| Claim that provider-specific helpers were removed | Removed as incorrect documentation | Native-client helpers remain public; prefer `from_provider()` for model-string construction |
+| Vertex AI deterministic test without the optional SDK | Intentionally changed | The test now skips when `vertexai` is unavailable instead of failing during patch setup |
+| Final failure hook behavior | Intentionally changed to restore documented behavior | `completion:error` and `completion:last_attempt` now receive attempt metadata; existing hook signatures remain backward-compatible |
+
+No provider, working mode, DSL type, retry path, stream workflow, hook name, or
+documented supported factory was removed.
+
+## Measurements
+
+Measurements compare the working tree with `0212d8833cba` using the same
+fully populated `.venv`, with proxy variables unset. Generated files and
+dependency locks are excluded. Production LOC counts nonblank, non-comment
+implementation-body lines and excludes overloads and docstrings; test LOC is
+physical file length for the replaced contract slice.
+
+| Slice | Baseline | Current | Reduction |
+| --- | ---: | ---: | ---: |
+| Executable body LOC in the 11 migrated `from_*` implementations | 589 LOC | 150 LOC | 74.5% |
+| Provider client contract tests replaced by `test_client_unified.py` | 869 LOC | 260 LOC | 70.1% |
+
+The selected deterministic parity command is:
+
+```bash
+python -m pytest \
+  tests/v2/test_provider_specs.py \
+  tests/v2/test_client_unified.py \
+  tests/v2/test_auto_client_deterministic.py \
+  tests/providers/test_auto_client.py -q
+```
+
+For the selected parity command, three baseline runs from an isolated archive
+had a 16.68-second median with 513 passing and 46 skipped. Three working-tree
+runs had a 16.28-second median with 101 passing and 27 skipped, a 2.4% runtime
+reduction. The complete deterministic `tests/v2 tests/providers` suite improved
+from a 34.76-second three-run median (1,644 passing, 199 skipped) to a
+32.88-second median (1,279 passing, 170 skipped), a 5.4% reduction. Optional SDK
+imports and pytest startup dominate both measurements, so the 75% timing target
+remains unmet even though repeated test cases and provider implementations were
+removed.
+
+Browser automation verified the rendered `from_provider`, Mistral, Bedrock, and
+provider parity pages on the local MkDocs site. The parity inventory rendered
+all five tables without console errors.

--- a/docs/integrations/bedrock.md
+++ b/docs/integrations/bedrock.md
@@ -21,7 +21,7 @@ pip install "instructor[bedrock]"
 - [from_provider Guide](../concepts/from_provider.md) - Detailed client configuration
 - [Mode Migration Guide](../concepts/mode-migration.md) - Move to core modes
 - [Provider Examples](../index.md#provider-examples) - Quick examples for all providers
-- [AWS Integration Guide](../examples/index.md#aws-integration) - More AWS examples
+- [Examples](../examples/index.md) - More integration examples
 
 # AWS Bedrock
 
@@ -43,11 +43,10 @@ client = instructor.from_provider("bedrock/anthropic.claude-3-5-sonnet-20241022-
 # - Mode selection based on model (Claude models use TOOLS)
 ```
 
-## Deprecation Notice
+## Async Clients
 
-> **Deprecation Notice:**
->
-> The `_async` argument to `instructor.from_bedrock` is deprecated. Please use `async_client=True` for async clients instead. Support for `_async` may be removed in a future release. All new code and examples should use `async_client`.
+Use `async_client=True` with `from_provider` or `from_bedrock`. The obsolete
+`_async` keyword is no longer accepted as an async selector.
 
 ### Environment Configuration
 

--- a/docs/integrations/genai.md
+++ b/docs/integrations/genai.md
@@ -545,13 +545,13 @@ print(response)
 
 ## Streaming Responses
 
-!!! warning "Streaming Limitations"
+!!! note "V2 streaming contract"
 
-    **As of July 11, 2025, Google GenAI does not support streaming with tool/function calling or structured outputs for regular models.** 
-    
-    - `Mode.TOOLS` and `Mode.JSON` do not support streaming with regular models
-    - To use streaming, you must use `Partial[YourModel]` explicitly or switch to other modes like `Mode.JSON`
-    - Alternatively, set `stream=False` to disable streaming
+    The v2 GenAI client advertises public partial and iterable streaming for
+    `Mode.TOOLS` and `Mode.JSON`. This contract covers Instructor's request and
+    parsing path; select a Gemini model that supports the requested operation.
+    The legacy `gemini` and `vertexai` provider families have separate feature
+    contracts and do not currently expose public iterable streaming.
 
 Streaming allows you to process responses incrementally rather than waiting for the complete result. This is extremely useful for making UI changes feel instant and responsive.
 

--- a/docs/integrations/mistral.md
+++ b/docs/integrations/mistral.md
@@ -185,17 +185,12 @@ Instructor now supports streaming capabilities with Mistral! You can use both `c
 ```python
 from pydantic import BaseModel
 import instructor
-from mistralai import Mistral
 from instructor.dsl.partial import Partial
 
 class UserExtract(BaseModel):
     name: str
     age: int
 
-# Initialize with API key
-client = Mistral(api_key=os.environ.get("MISTRAL_API_KEY"))
-
-# Enable instructor patches for Mistral client
 instructor_client = instructor.from_provider("mistral/mistral-small")
 
 # Stream partial responses
@@ -220,16 +215,11 @@ for partial_user in model:
 ```python
 from pydantic import BaseModel
 import instructor
-from mistralai import Mistral
 
 class UserExtract(BaseModel):
     name: str
     age: int
 
-# Initialize with API key
-client = Mistral(api_key=os.environ.get("MISTRAL_API_KEY"))
-
-# Enable instructor patches for Mistral client
 instructor_client = instructor.from_provider("mistral/mistral-small")
 
 # Stream iterable responses
@@ -255,16 +245,16 @@ You can also use async versions of both streaming approaches:
 import asyncio
 from pydantic import BaseModel
 import instructor
-from mistralai import Mistral
 from instructor.dsl.partial import Partial
 
 class UserExtract(BaseModel):
     name: str
     age: int
 
-# Initialize client with async support
-client = Mistral(api_key=os.environ.get("MISTRAL_API_KEY"))
-instructor_client = instructor.from_provider("mistral/mistral-small")
+instructor_client = instructor.from_provider(
+    "mistral/mistral-small",
+    async_client=True,
+)
 
 async def stream_partial():
     model = await instructor_client.create(

--- a/docs/integrations/sambanova.md
+++ b/docs/integrations/sambanova.md
@@ -8,7 +8,7 @@ description: Use Instructor with SambaNova's LLM API for structured outputs.
 - [Getting Started](../getting-started.md) - Quick start guide
 - [from_provider Guide](../concepts/from_provider.md) - Detailed client configuration
 - [Provider Examples](../index.md#provider-examples) - Quick examples for all providers
-- [Enterprise Integration](../examples/index.md#enterprise-integration) - More enterprise examples
+- [Examples](../examples/index.md) - More integration examples
 
 # SambaNova Integration
 

--- a/docs/integrations/vertex.md
+++ b/docs/integrations/vertex.md
@@ -74,7 +74,7 @@ class User(BaseModel):
 
 
 client = instructor.from_provider(
-    "vertex_ai/gemini-1.5-pro-preview-0409",
+    "vertexai/gemini-1.5-pro-preview-0409",
     async_client=True,
     mode=instructor.Mode.TOOLS,
 )
@@ -99,7 +99,10 @@ print(user)  # User(name='Jason', age=25)
 
 ## Streaming Support
 
-Instructor now supports streaming capabilities with Vertex AI! You can use both `create_partial` for incremental model building and `create_iterable` for streaming collections.
+The v2 VertexAI provider exposes partial streaming with `Mode.TOOLS` and
+`Mode.MD_JSON`. It does not currently advertise public `create_iterable()`
+streaming; use partial streaming for incremental results or GenAI when iterable
+streaming is required.
 
 ### Streaming Partial Responses
 
@@ -117,7 +120,7 @@ class UserExtract(BaseModel):
     age: int
 
 client = instructor.from_provider(
-    "vertex_ai/gemini-1.5-pro-preview-0409",
+    "vertexai/gemini-1.5-pro-preview-0409",
     mode=instructor.Mode.TOOLS,
 )
 
@@ -137,43 +140,9 @@ for partial_user in response_stream:
 # Received update: UserExtract(name='Anibal', age=23)
 ```
 
-### Streaming Iterable Collections
+### Async Partial Streaming
 
-```python
-import vertexai  # type: ignore
-from vertexai.generative_models import GenerativeModel  # type: ignore
-import instructor
-from pydantic import BaseModel
-
-vertexai.init()
-
-class UserExtract(BaseModel):
-    name: str
-    age: int
-
-client = instructor.from_provider(
-    "vertex_ai/gemini-1.5-pro-preview-0409",
-    mode=instructor.Mode.TOOLS,
-)
-
-# Stream iterable responses
-response_stream = client.create_iterable(
-    response_model=UserExtract,
-    messages=[
-        {"role": "user", "content": "Make up two people"},
-    ],
-)
-
-for user in response_stream:
-    print(f"Generated user: {user}")
-# Output:
-# Generated user: UserExtract(name='Sarah Johnson', age=32)
-# Generated user: UserExtract(name='David Chen', age=27)
-```
-
-### Async Streaming
-
-You can also use async versions of both streaming approaches:
+The async client exposes the same partial streaming contract:
 
 ```python
 import asyncio
@@ -190,7 +159,7 @@ class UserExtract(BaseModel):
     age: int
 
 client = instructor.from_provider(
-    "vertex_ai/gemini-1.5-pro-preview-0409",
+    "vertexai/gemini-1.5-pro-preview-0409",
     async_client=True,
     mode=instructor.Mode.TOOLS,
 )
@@ -207,20 +176,8 @@ async def stream_partial():
     async for partial_user in response_stream:
         print(f"Received update: {partial_user}")
 
-async def stream_iterable():
-    response_stream = client.create_iterable(
-        response_model=UserExtract,
-        messages=[
-            {"role": "user", "content": "Make up two people"},
-        ],
-    )
-
-    async for user in response_stream:
-        print(f"Generated user: {user}")
-
 # Run async functions
 asyncio.run(stream_partial())
-asyncio.run(stream_iterable())
 ```
 
 ## Related Resources
@@ -284,4 +241,6 @@ export GOOGLE_CLOUD_LOCATION="us-central1"
 
 Instructor maintains compatibility with Vertex AI's latest API versions. Check the [changelog](https://github.com/jxnl/instructor/blob/main/CHANGELOG.md) for updates.
 
-Streaming support has been added for both partial responses and iterable collections, with both synchronous and asynchronous interfaces.
+Partial streaming is available through both synchronous and asynchronous
+interfaces. Public iterable streaming is not yet part of the VertexAI
+capability contract.

--- a/docs/why.md
+++ b/docs/why.md
@@ -234,4 +234,4 @@ Let's be clear - you might not need Instructor if:
 
 For everyone else building production LLM applications, Instructor is the obvious choice.
 
-[Get Started →](index.md#quick-start-extract-structured-data-in-3-lines){ .md-button .md-button--primary }
+[Get Started](index.md#quick-start){ .md-button .md-button--primary }

--- a/examples/v2-model-mode-benchmark/README.md
+++ b/examples/v2-model-mode-benchmark/README.md
@@ -1,0 +1,39 @@
+# V2 model and mode benchmark
+
+This example runs a small live structured-extraction probe across the v2
+provider/mode contract. It ranks completed cells by success rate and median
+request latency, and reports skipped cells when a default model, optional SDK,
+or required API key is unavailable.
+
+The default run enumerates every provider that declares v2 handlers and every
+supported mode in `ProviderSpec`:
+
+```bash
+uv run python examples/v2-model-mode-benchmark/run.py --trials 3
+```
+
+Only set credentials for providers you want to run. Missing credentials produce
+`skipped` rows instead of errors. Common variables include
+`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `COHERE_API_KEY`,
+`XAI_API_KEY`, `MISTRAL_API_KEY`, `FIREWORKS_API_KEY`, `CEREBRAS_API_KEY`,
+and `WRITER_API_KEY`.
+
+Bedrock and Vertex AI can use ambient cloud credential chains rather than a
+single API key. They are skipped by default; include `--allow-cloud-auth` when
+your local cloud credentials and project/region settings are configured.
+
+To compare selected models and modes:
+
+```bash
+uv run python examples/v2-model-mode-benchmark/run.py \
+  --model openai/gpt-4o-mini \
+  --model anthropic/claude-sonnet-4-6 \
+  --mode TOOLS \
+  --mode JSON_SCHEMA \
+  --trials 5 \
+  --markdown-out benchmark-results.md \
+  --json-out benchmark-results.json
+```
+
+This is a smoke benchmark, not a model leaderboard. Replace or expand the
+prompt and response model when measuring an application-specific workload.

--- a/instructor/v2/README.md
+++ b/instructor/v2/README.md
@@ -36,6 +36,29 @@ The v2 architecture uses a hierarchical registry system for managing provider mo
   `instructor/dsl`, and `instructor/validation` are compatibility facades over
   v2-owned implementations.
 
+### Capability Contract
+
+`ProviderSpec.capabilities` is the executable feature contract. It records the
+public streaming modes, typed multimodal input conversion, and explicit or
+implicit parallel tool support for each provider. These fields are intentionally
+narrow: a provider may accept its own SDK media object without advertising
+Instructor typed-media conversion, and an internal streaming parser is not a
+public `create_iterable()` feature until the client exposes that path.
+
+This keeps provider differences visible instead of pretending all SDKs implement
+the same surface. For example:
+
+| Provider | Public partial streams | Public iterable streams | Typed media conversion |
+| --- | --- | --- | --- |
+| OpenAI | `TOOLS`, `JSON`, `JSON_SCHEMA`, `MD_JSON`, `RESPONSES_TOOLS` | `TOOLS`, `RESPONSES_TOOLS` | image, audio, PDF |
+| Anthropic | `TOOLS`, `JSON`, `JSON_SCHEMA` | `TOOLS` | image, PDF |
+| GenAI (`google`) | `TOOLS`, `JSON` | `TOOLS`, `JSON` | image, audio, PDF |
+| Gemini / VertexAI | `TOOLS`, `MD_JSON` | not exposed through the public iterable API | none |
+| xAI | `TOOLS`, `JSON_SCHEMA` | `TOOLS`, `JSON_SCHEMA` | none |
+
+Tests build their conformance parameters from this manifest, so an advertised
+feature must route to a registered provider handler.
+
 ## Core Components
 
 ### Protocols (`instructor/v2/core/protocols.py`)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -249,6 +249,7 @@ nav:
     - Multimodal : 'concepts/multimodal.md'
     - Patching: 'concepts/patching.md'
     - from_provider: 'concepts/from_provider.md'
+    - Provider Architecture and Parity: 'concepts/provider-architecture-parity.md'
     - Migration Guide: 'concepts/migration.md'
     - Mode Migration: 'concepts/mode-migration.md'
     - Hooks: 'concepts/hooks.md'


### PR DESCRIPTION
## Summary

- document the provider-owned client architecture and explicit compatibility decisions
- add the public export, provider, mode, workflow, and removal parity inventory
- correct representative `from_provider`, Mistral, Bedrock, GenAI, and migration examples
- record LOC and test-timing methodology without claiming the unmet timing target

## Stack

- Parent: https://github.com/567-labs/instructor/pull/2355
- This PR contains documentation only and targets the core architecture branch.
- Sibling: shared behavioral contract tests

## Verification

- `mkdocs build --strict`
- Browser automation verified the parity inventory, `from_provider`, Mistral, and Bedrock pages.
- The parity page rendered five tables with no browser console errors.

Supersedes the documentation portion of #2315.
