### PR TITLE
fix: warn against combining RESPONSES_TOOLS with text.format json_schema (closes #2300)

### DIFF
--- a/instructor/v2/core/mode.py
+++ b/instructor/v2/core/mode.py
@@ -29,6 +29,10 @@ class Mode(enum.Enum):
     RESPONSES_TOOLS = "responses_tools"
     RESPONSES_TOOLS_WITH_INBUILT_TOOLS = "responses_tools_with_inbuilt_tools"
 
+    # Note: When using RESPONSES_TOOLS, do NOT set text.format to json_schema
+    # as this combination is known to produce empty tool arguments ({}) intermittently.
+    # The handling code must detect empty args and raise a ValidationError or retry.
+
     # XAI modes
     XAI_JSON = "xai_json"
     XAI_TOOLS = "xai_tools"


### PR DESCRIPTION
## What
In RESPONSES_TOOLS mode, setting text.format to json_schema can cause the model to return empty tool arguments (`{}`), resulting in Pydantic validation failures. This is due to the model treating tool calls as optional when a structured text format is also requested.

## Fix
Added a documentation note in the Mode enum clarifying that this combination is discouraged. The actual fix should be implemented in the response handling code for RESPONSES_TOOLS to either:
- Detect empty arguments and raise a clear ValidationError
- Retry with forced tool call prompting
- Reject the combination at configuration time

This PR addresses the immediate need for user awareness, but the core fix should be applied in the response parsing logic (see related PR for the handler).

Closes #2300