### PR TITLE
fix(gemini): fold generation_config into config when response_model=None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **Gemini/GenAI**: Fold `generation_config` (and `safety_settings`/`thinking_config`) into `config` when `response_model=None`, so plain-text calls no longer raise `generate_content() got an unexpected keyword argument 'generation_config'` ([#2366](https://github.com/567-labs/instructor/issues/2366)).
 - **v2 cleanup**: Consolidate small provider/runtime fixes for Gemini JSON prompts, Cohere templating, JSON array extraction, iterable streaming, missing `jsonref` dependency guidance, retry semantics and hook metadata, and multimodal autodetection.
 
 ### Tests / CI

--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -458,14 +458,23 @@ def handle_genai_message_conversion(
         new_kwargs["contents"], autodetect_images
     )
 
+    base_config: dict[str, Any] = {}
     if "system" not in new_kwargs:
         system_message = extract_genai_system_message(messages)
         if system_message:
-            new_kwargs["config"] = types.GenerateContentConfig(
-                system_instruction=system_message
-            )
+            base_config["system_instruction"] = system_message
+
+    # Fold `generation_config`, `safety_settings` and `thinking_config` into `config` the same
+    # way the structured-output path does. Otherwise these would be passed as raw keyword
+    # arguments to `generate_content`, which raises e.g. "got an unexpected keyword argument
+    # 'generation_config'" when `response_model=None` (see #2366).
+    generation_config = update_genai_kwargs(new_kwargs, base_config)
+    new_kwargs["config"] = types.GenerateContentConfig(**generation_config)
 
     new_kwargs.pop("messages", None)
+    new_kwargs.pop("generation_config", None)
+    new_kwargs.pop("safety_settings", None)
+    new_kwargs.pop("thinking_config", None)
 
     return new_kwargs
 

--- a/tests/v2/test_gemini_utils_deterministic.py
+++ b/tests/v2/test_gemini_utils_deterministic.py
@@ -262,6 +262,32 @@ def test_handle_genai_message_conversion_extracts_system_and_contents(
     assert "messages" not in result
 
 
+def test_handle_genai_message_conversion_folds_generation_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression test for #2366: when response_model is None, generation_config must be folded
+    # into `config` instead of leaking as a raw keyword argument to generate_content.
+    _install_fake_genai_types(monkeypatch)
+    monkeypatch.setattr(
+        utils, "convert_to_genai_messages", lambda _messages: ["converted"]
+    )
+    monkeypatch.setattr(
+        "instructor.v2.core.multimodal.extract_genai_multimodal_content",
+        lambda contents, _autodetect_images: contents,
+    )
+
+    result = utils.handle_genai_message_conversion(
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "generation_config": {"temperature": 0.7, "max_tokens": 128},
+        }
+    )
+
+    assert "generation_config" not in result
+    assert result["config"].kwargs["temperature"] == 0.7
+    assert result["config"].kwargs["max_output_tokens"] == 128
+
+
 def test_handle_vertexai_wrappers_use_provider_helpers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #2366.

When using a GenAI / Gemini provider with `response_model=None` (plain text generation), passing a `generation_config` dict raised:

```
AsyncModels.generate_content() got an unexpected keyword argument 'generation_config'
```

The `response_model=None` path goes through `handle_genai_message_conversion`, which converted messages to `contents` but never processed `generation_config`. The raw dict therefore reached `generate_content` as an unexpected keyword argument. The structured-output path (`response_model != None`) already folds these into a `config` object via `update_genai_kwargs`.

## Fix

`handle_genai_message_conversion` now runs `update_genai_kwargs` and folds `generation_config` (and, consistently, `safety_settings` and `thinking_config`, which had the same latent leak) into the `config` object, then removes the raw keys. This makes the `response_model=None` path consistent with the structured-output path. The shared helper is used by both the structured-output and tools None-paths, so both are fixed.

## Test

Added `test_handle_genai_message_conversion_folds_generation_config` in `tests/v2/test_gemini_utils_deterministic.py` (deterministic, no live API, uses the existing fake `google.genai.types`). It asserts `generation_config` is removed and its values are mapped into `config` (`temperature`, `max_tokens` -> `max_output_tokens`). The test fails on `main` and passes with this change. All 18 tests in that file pass; `ruff check`/`ruff format` clean.

---
*Disclosure: prepared with AI assistance; reviewed by me and I can explain every line.*