### PR TITLE
fix(bedrock): route top_k via additionalModelRequestFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **Bedrock**: Route `top_k`/`topK` through `additionalModelRequestFields` instead of leaving it as a top-level Converse kwarg. AWS `InferenceConfiguration` only supports `maxTokens`/`stopSequences`/`temperature`/`topP`, so a leftover `top_k` reached `client.converse(top_k=...)` and boto3 raised `ParamValidationError: Unknown parameter "top_k"`.
 - **v2 cleanup**: Consolidate small provider/runtime fixes for Gemini JSON prompts, Cohere templating, JSON array extraction, iterable streaming, missing `jsonref` dependency guidance, retry semantics and hook metadata, and multimodal autodetection.
 
 ### Tests / CI

--- a/instructor/v2/providers/bedrock/handlers.py
+++ b/instructor/v2/providers/bedrock/handlers.py
@@ -275,6 +275,28 @@ def _prepare_bedrock_converse_kwargs_internal(
     elif "stopSequences" in call_kwargs:
         inference_config_params["stopSequences"] = call_kwargs.pop("stopSequences")
 
+    # top_k is not part of the Bedrock InferenceConfiguration base set
+    # (maxTokens/stopSequences/temperature/topP). Model-specific parameters
+    # like top_k must be routed through additionalModelRequestFields, otherwise
+    # the leftover kwarg reaches client.converse() and boto3 raises
+    # ParamValidationError: Unknown parameter "top_k".
+    additional_model_request_fields = {}
+    if "top_k" in call_kwargs:
+        additional_model_request_fields["top_k"] = call_kwargs.pop("top_k")
+    elif "topK" in call_kwargs:
+        additional_model_request_fields["top_k"] = call_kwargs.pop("topK")
+
+    if additional_model_request_fields:
+        if "additionalModelRequestFields" in call_kwargs:
+            existing_additional_fields = call_kwargs["additionalModelRequestFields"]
+            for key, value in additional_model_request_fields.items():
+                if key not in existing_additional_fields:
+                    existing_additional_fields[key] = value
+        else:
+            call_kwargs["additionalModelRequestFields"] = (
+                additional_model_request_fields
+            )
+
     if inference_config_params:
         if "inferenceConfig" in call_kwargs:
             existing_inference_config = call_kwargs["inferenceConfig"]

--- a/tests/llm/test_bedrock/test_prepare_kwargs.py
+++ b/tests/llm/test_bedrock/test_prepare_kwargs.py
@@ -61,3 +61,54 @@ def test_prepare_bedrock_kwargs_openai_image_url_rejects_http():
     }
     with pytest.raises(ValueError, match="Unsupported image_url scheme for Bedrock"):
         _prepare_bedrock_converse_kwargs_internal(call_kwargs)
+
+
+def test_prepare_bedrock_kwargs_routes_top_k_to_additional_fields():
+    """top_k is model-specific and must go to additionalModelRequestFields.
+
+    AWS InferenceConfiguration only supports maxTokens/stopSequences/
+    temperature/topP. A leftover top_k would otherwise reach
+    client.converse(top_k=...) and boto3 raises ParamValidationError.
+    """
+    call_kwargs = {
+        "model": "anthropic.claude-3-5-sonnet",
+        "temperature": 0.3,
+        "top_k": 200,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+    out = _prepare_bedrock_converse_kwargs_internal(call_kwargs)
+
+    assert out["additionalModelRequestFields"] == {"top_k": 200}
+    assert "top_k" not in out
+    assert "top_k" not in out["inferenceConfig"]
+    assert "topK" not in out["inferenceConfig"]
+
+
+def test_prepare_bedrock_kwargs_top_k_camel_case():
+    """topK (camelCase) is also routed to additionalModelRequestFields."""
+    call_kwargs = {
+        "model": "anthropic.claude-3-5-sonnet",
+        "topK": 100,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+    out = _prepare_bedrock_converse_kwargs_internal(call_kwargs)
+
+    assert out["additionalModelRequestFields"] == {"top_k": 100}
+    assert "topK" not in out
+
+
+def test_prepare_bedrock_kwargs_top_k_preserves_user_additional_fields():
+    """A user-provided additionalModelRequestFields must not be clobbered."""
+    call_kwargs = {
+        "model": "anthropic.claude-3-5-sonnet",
+        "top_k": 200,
+        "additionalModelRequestFields": {"anthropic_beta": ["foo"]},
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+    out = _prepare_bedrock_converse_kwargs_internal(call_kwargs)
+
+    assert out["additionalModelRequestFields"]["anthropic_beta"] == ["foo"]
+    assert out["additionalModelRequestFields"]["top_k"] == 200


### PR DESCRIPTION
Thanks for instructor!

Fixes #2368

## Summary

The v2 Bedrock handler dropped `top_k`: it mapped `temperature`/`max_tokens`/`top_p`/`stop` into `inferenceConfig` but left `top_k` in the kwargs, where it fell through to `client.converse(top_k=...)` → boto3 `ParamValidationError: Unknown parameter "top_k"`. AWS `InferenceConfiguration` supports only `maxTokens`/`stopSequences`/`temperature`/`topP`; model-specific params like Anthropic `top_k` must go via `additionalModelRequestFields`. This routes `top_k`/`topK` there.

| Item | Before | After |
|---|---|---|
| `top_k=200` to Bedrock Converse | ❌ `ParamValidationError: Unknown parameter "top_k"` | ✅ `additionalModelRequestFields={"top_k": 200}` |
| `topK=100` (camelCase) | ❌ same failure | ✅ normalized to `{"top_k": 100}` |
| User-supplied `additionalModelRequestFields` | n/a | ✅ preserved (not clobbered) |
| `temperature`/`max_tokens`/`top_p`/`stop` → `inferenceConfig` | ✅ | ✅ unchanged |
| Public API / function signature | — | ✅ unchanged |

## Why this shape

Mirrors the existing "set key only if absent" merge already used for `inferenceConfig` — fills the one sampling param the handler was missing.

## Tests

3 new network-free tests in `tests/llm/test_bedrock/test_prepare_kwargs.py`. Reverting the source fix (keeping tests) → 3 fail with `KeyError: 'additionalModelRequestFields'` (the leftover `top_k` would hit `converse`); restored → bedrock suite 28 passed. `ruff` / `ty` clean.

---

_This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, the AWS-docs rationale, and the test results before submission._
