### PR TITLE
docs(examples): fix dead hooks documentation link in hooks example README

### DIFF
--- a/examples/hooks/README.md
+++ b/examples/hooks/README.md
@@ -58,4 +58,4 @@ At the end, it will print a summary of the statistics collected.
 
 ## Learn More
 
-For more information about hooks in Instructor, see the [hooks documentation](https://instructor-ai.github.io/instructor/concepts/hooks/). 
+For more information about hooks in Instructor, see the [hooks documentation](https://python.useinstructor.com/concepts/hooks/). 


### PR DESCRIPTION
The "Learn More" link in `examples/hooks/README.md` pointed to `https://instructor-ai.github.io/instructor/concepts/hooks/`, which now returns a 404 since the documentation moved to `python.useinstructor.com` (the domain set as `site_url` in `mkdocs.yml` and already used in the main README). This updates the link to `https://python.useinstructor.com/concepts/hooks/`, which resolves correctly. Documentation-only change, single line.