### PR TITLE
fix: restore Python 3.9 import compatibility in four v2 modules (PEP 604 in runtime annotations)

### DIFF
--- a/instructor/v2/core/decorators.py
+++ b/instructor/v2/core/decorators.py
@@ -1,5 +1,7 @@
 """Decorator utilities for v2 mode registration."""
 
+from __future__ import annotations
+
 from collections.abc import Iterable
 
 from instructor.v2.core.mode import Mode

--- a/instructor/v2/core/handler.py
+++ b/instructor/v2/core/handler.py
@@ -3,6 +3,8 @@
 Provides the common interface and default implementations for mode handlers.
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Any
 

--- a/instructor/v2/core/protocols.py
+++ b/instructor/v2/core/protocols.py
@@ -4,6 +4,8 @@ Defines the interfaces that all mode handlers must implement for type safety
 and consistency across providers.
 """
 
+from __future__ import annotations
+
 from collections.abc import AsyncGenerator, Generator, Iterable
 from typing import Any, Protocol, TypeVar
 

--- a/instructor/v2/dsl/iterable.py
+++ b/instructor/v2/dsl/iterable.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 from collections.abc import AsyncGenerator, Callable, Generator, Iterable
 from typing import (
     Any,
     ClassVar,
-    Optional,
     cast,
     get_origin,
     get_args,
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
 
 
 class IterableBase:
-    task_type: ClassVar[Optional[type[BaseModel]]] = None
+    task_type: ClassVar[type[BaseModel] | None] = None
 
     @classmethod
     def from_streaming_response(
@@ -171,7 +172,7 @@ class IterableBase:
             yield chunk
 
     @staticmethod
-    def get_object(s: str, stack: int) -> tuple[Optional[str], str]:
+    def get_object(s: str, stack: int) -> tuple[str | None, str]:
         start_index = s.find("{")
         in_string = False
         escape_next = False
@@ -198,8 +199,8 @@ class IterableBase:
 
 def IterableModel(
     subtask_class: type[BaseModel],
-    name: Optional[str] = None,
-    description: Optional[str] = None,
+    name: str | None = None,
+    description: str | None = None,
 ) -> type[BaseModel]:
     # Import at runtime to avoid circular import
     from instructor.v2.core.function_calls import ResponseSchema


### PR DESCRIPTION
## Summary

`pyproject.toml` declares `requires-python = "<4.0,>=3.9"`, but four `instructor/v2` modules use PEP 604 union syntax (`X | Y`) in **runtime-evaluated** annotations *without* `from __future__ import annotations`. On Python 3.9, function/class annotations are evaluated at definition time, so importing these modules raises `TypeError` and the package is unusable on 3.9 once these code paths are touched.

Affected files:
- `instructor/v2/core/decorators.py` — `register_mode_handler(provider: Provider | Iterable[Provider], ...)` (module-level function)
- `instructor/v2/core/handler.py` — `prepare_request(..., response_model: type[BaseModel] | None, ...)`
- `instructor/v2/core/protocols.py` — same `type[T] | None` annotations in `Protocol` methods
- `instructor/v2/dsl/iterable.py` — `task_parser: Callable[...] | None = None`

## Reproduction (Python 3.9)

```python
>>> from enum import Enum
>>> from collections.abc import Iterable
>>> class Provider(Enum): OPENAI = "openai"
>>> def register_mode_handler(provider: Provider | Iterable[Provider], mode: int): ...
Traceback (most recent call last):
TypeError: unsupported operand type(s) for |: 'EnumMeta' and 'types.GenericAlias'
```

The same failure occurs when importing each of the four modules on CPython 3.9.

## Why CI did not catch it

- The pytest matrix runs on Python **3.11 only**, where `X | Y` is valid at runtime.
- `ruff` / `ty` are static checks; they treat PEP 604 in annotations as valid types and do not flag the runtime evaluation that breaks 3.9.

## Fix

Add `from __future__ import annotations` (PEP 563) to the four modules so annotations are not evaluated at runtime. This is exactly the pattern already used elsewhere in v2 (e.g. `instructor/v2/core/multimodal.py` and `instructor/v2/__init__.py`).

`iterable.py` additionally had `Optional[...]` annotations that `ruff` (UP007/UP045) flags once the future import is present; those are converted to `X | None` (safe under deferred annotations) so `ruff check` and `ruff format --check` stay green.

## Verification

- `python3.9 -m compileall` on all four files: OK
- Reproduced the `TypeError` on 3.9 before the change; gone after adding the future import
- `ruff check` and `ruff format --check` (v0.9.9, repo `.ruff.toml`, `target-version = py39`): all pass on the four files