### PR TITLE
fix(v2): avoid Python 3.9 runtime TypeError from PEP 604 unions in cast() calls

### DIFF
--- a/instructor/v2/auto_client.py
+++ b/instructor/v2/auto_client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import importlib
-from typing import Any, Callable, Literal, Union, cast, overload
+from typing import Any, Callable, Literal, Optional, Union, cast, overload
 from instructor.v2.core.client import AsyncInstructor, Instructor
 from instructor import __version__
 from instructor.v2.core.mode import Mode
@@ -194,14 +194,14 @@ def _build_openai(
     try:
         # Extract base_url and other OpenAI client parameters from kwargs
         base_url = kwargs.pop("base_url", None)
-        organization = cast(str | None, kwargs.pop("organization", None))
+        organization = cast(Optional[str], kwargs.pop("organization", None))
 
         timeout_raw = kwargs.pop("timeout", not_given)
         timeout: float | Timeout | None | NotGiven
         timeout = (
             not_given
             if timeout_raw is not_given
-            else cast(float | Timeout | None, timeout_raw)
+            else cast(Optional[Union[float, Timeout]], timeout_raw)
         )
 
         max_retries_raw = kwargs.pop("max_retries", None)
@@ -212,10 +212,10 @@ def _build_openai(
         )
 
         default_headers = cast(
-            Mapping[str, str] | None, kwargs.pop("default_headers", None)
+            Optional[Mapping[str, str]], kwargs.pop("default_headers", None)
         )
         default_query = cast(
-            Mapping[str, object] | None, kwargs.pop("default_query", None)
+            Optional[Mapping[str, object]], kwargs.pop("default_query", None)
         )
         http_client_raw = kwargs.pop("http_client", None)
         strict_response_validation = bool(
@@ -223,7 +223,7 @@ def _build_openai(
         )
 
         if async_client:
-            http_client = cast(httpx.AsyncClient | None, http_client_raw)
+            http_client = cast(Optional[httpx.AsyncClient], http_client_raw)
             client = openai.AsyncOpenAI(
                 api_key=api_key,
                 base_url=base_url,
@@ -236,7 +236,7 @@ def _build_openai(
                 _strict_response_validation=strict_response_validation,
             )
         else:
-            http_client = cast(httpx.Client | None, http_client_raw)
+            http_client = cast(Optional[httpx.Client], http_client_raw)
             client = openai.OpenAI(
                 api_key=api_key,
                 base_url=base_url,


### PR DESCRIPTION
## Problem

`instructor/v2/auto_client.py` passes PEP 604 union syntax (`X | None`) as the **first argument** to `typing.cast()` inside `_build_openai()`:

- `cast(str | None, ...)` (organization)
- `cast(float | Timeout | None, ...)` (timeout)
- `cast(Mapping[str, str] | None, ...)` (default_headers)
- `cast(Mapping[str, object] | None, ...)` (default_query)
- `cast(httpx.AsyncClient | None, ...)` / `cast(httpx.Client | None, ...)` (http_client)

Unlike annotations, the first argument of `cast()` is **evaluated at runtime**. `from __future__ import annotations` (present at the top of the file) only defers *annotation* evaluation; it does not affect a normal call argument. On Python 3.9, evaluating `X | None` raises:

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

The project supports Python 3.9 (`requires-python = "<4.0,>=3.9"`), so any 3.9 user calling `instructor.from_provider("openai/...")` crashes here. CI only runs on 3.11+, so it isn't caught.

Minimal reproduction on Python 3.9:

```python
>>> from typing import cast
>>> cast(str | None, "x")
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

## Fix

Replace the runtime PEP 604 unions **inside `cast()`** with `typing.Optional` / `typing.Union`, which evaluate fine on 3.9. Annotations elsewhere are left untouched (they're safe under `from __future__ import annotations`). `cast(int, ...)` and `cast(Any, ...)` are already 3.9-safe and unchanged.

## Verification

- `ruff check` with the repo `.ruff.toml` (target `py39`, `select = ["UP", ...]`): **passes** — `Optional[...]`/`Union[...]` inside `cast()` are not re-flagged by pyupgrade.
- `ruff format --check`: already formatted.
- `python3.9 -m py_compile`: passes.
- Reproduced the original `TypeError` on 3.9 and confirmed the `Optional` form runs cleanly.

Distinct from #2371 (which fixed *import-time* annotation evaluation in v2 modules); this fixes *call-time* `cast()` evaluation in the OpenAI provider builder.