### PR TITLE
fix(dsl): classify list[BaseModel] as non-simple type

### DIFF
--- a/instructor/v2/dsl/simple_type.py
+++ b/instructor/v2/dsl/simple_type.py
@@ -108,6 +108,15 @@ def is_simple_type(
                 ):
                     return True
 
+                # Check if inner type is a BaseModel - if so, not a simple type.
+                # This must run before the broad pipe-syntax check below, since
+                # every class exposes ``__or__`` on Python 3.10+.
+                try:
+                    if isclass(inner_arg) and issubclass(inner_arg, BaseModel):
+                        return False
+                except TypeError:
+                    pass
+
                 # Check for Python 3.10+ pipe syntax
                 if hasattr(inner_arg, "__or__"):
                     return True
@@ -115,13 +124,6 @@ def is_simple_type(
                 # For simple list with basic types, also return True
                 if inner_arg in {str, int, float, bool}:
                     return True
-
-                # Check if inner type is a BaseModel - if so, not a simple type
-                try:
-                    if isclass(inner_arg) and issubclass(inner_arg, BaseModel):
-                        return False
-                except TypeError:
-                    pass
 
             # If no args or unknown pattern, treat as simple list
             return len(args) == 0

--- a/tests/dsl/test_simple_types.py
+++ b/tests/dsl/test_simple_types.py
@@ -76,6 +76,26 @@ def test_iterable_not_simple():
     assert not is_simple_type(new_type), f"Failed for type: {new_type}"
 
 
+def test_list_of_base_model_not_simple():
+    """list[BaseModel] must NOT be treated as a simple type.
+
+    It should be routed through IterableModel, not wrapped in a scalar
+    ModelAdapter. Regression test: a too-broad ``hasattr(inner, "__or__")``
+    check (true for every class on Python 3.10+) used to short-circuit and
+    return True before the BaseModel guard could run.
+    """
+
+    class Item(BaseModel):
+        value: int
+
+    assert not is_simple_type(list[Item]), (
+        "list[BaseModel] should not be a simple type"
+    )
+    assert not is_simple_type(List[Item]), (  # noqa: UP006
+        "List[BaseModel] should not be a simple type"
+    )
+
+
 @pytest.mark.skipif(
     sys.version_info < (3, 10),
     reason="Union pipe syntax is only available in Python 3.10+",


### PR DESCRIPTION
## Bug

`instructor.utils.is_simple_type` (defined in `instructor/v2/dsl/simple_type.py`) misclassifies `list[SomeBaseModel]` as a *simple* type, returning `True` when it should return `False`.

Inside the `origin is list` branch the function checks `hasattr(inner_arg, "__or__")` as a heuristic for "PEP 604 pipe-union syntax". The problem is that on Python 3.10+ **every** class exposes `__or__` (that's what makes `int | str` work), so the check is true for any inner type — including a `BaseModel` subclass. Because it runs before the `issubclass(inner_arg, BaseModel) -> return False` guard, that guard is dead code and `list[User]` is reported as simple.

```python
from pydantic import BaseModel
from instructor.utils import is_simple_type

class User(BaseModel):
    name: str

is_simple_type(list[User])   # -> True  (should be False)
```

## Fix

Move the existing `BaseModel` guard ahead of the pipe-syntax check so a list of pydantic models is correctly classified as non-simple. No other cases change:

- `list[int]`, `list[str]`, `list[int | str]`, `List[Union[int, str]]` still return `True`
- `list[SomeEnum]` still returns `True`
- `list[User]` / `List[User]` now return `False`

`prepare_response_model` already routed `list[User]` through `IterableModel` via a secondary guard, so runtime routing is unchanged; this fixes the public `is_simple_type` helper itself and makes the previously-dead `BaseModel` branch reachable.

## Verification

Added `test_list_of_base_model_not_simple` to `tests/dsl/test_simple_types.py`.

```
$ pytest tests/dsl/test_simple_types.py -q
...............                                                          [100%]
15 passed
```

Before the fix the new test fails with `AssertionError: list[BaseModel] should not be a simple type`. The rest of `tests/dsl/test_simple_types.py` (including the existing `list[int | str]` / `List[Union[int, str]]` cases) continues to pass.

> Drafted with AI assistance; I reviewed the change and verified it locally with the command above.
