### PR TITLE
fix(v2): treat list[A | B] PEP 604 unions as iterable of models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Response models**: `list[A | B]` written with PEP 604 union syntax is now treated as an iterable of models, identical to `list[Union[A, B]]`. Previously the `|` form was misrouted to the simple-type wrapper (root property `content`) instead of an iterable (root property `tasks`), silently changing the JSON schema sent to the model and breaking multi-item extraction. Pipe-union iterables also get a clean generated name (e.g. `IterableAOrB`) instead of leaking a module-qualified `str(types.UnionType)`.
+
+---
+
 ## [1.15.3] - 2026-06-15
 
 ### Fixed

--- a/instructor/v2/core/response_model.py
+++ b/instructor/v2/core/response_model.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import sys
 from collections.abc import Iterable
 from typing import Any, Callable, TypeVar, Union, cast, get_args, get_origin
 
@@ -11,6 +12,16 @@ from pydantic import BaseModel, create_model
 T = TypeVar("T")
 
 _create_dynamic_model = cast(Callable[..., type[BaseModel]], create_model)
+
+# PEP 604 unions (``A | B``) report ``types.UnionType`` as their origin, whereas the
+# legacy ``Union[A, B]`` form reports ``typing.Union``. Both must be recognized so that
+# ``list[A | B]`` is treated as an iterable of models, matching ``list[Union[A, B]]``.
+if sys.version_info >= (3, 10):
+    from types import UnionType
+
+    _UNION_ORIGINS: tuple[Any, ...] = (Union, UnionType)
+else:  # pragma: no cover - Python 3.9 has no runtime ``X | Y`` union syntax
+    _UNION_ORIGINS = (Union,)
 
 
 def is_typed_dict(cls: Any) -> bool:
@@ -41,7 +52,7 @@ def prepare_response_model(response_model: type[T] | None) -> type[T] | None:
         def _is_model_type(candidate: Any) -> bool:
             if inspect.isclass(candidate) and issubclass(candidate, BaseModel):
                 return True
-            return get_origin(candidate) is Union and all(
+            return get_origin(candidate) in _UNION_ORIGINS and all(
                 inspect.isclass(member) and issubclass(member, BaseModel)
                 for member in get_args(candidate)
             )

--- a/instructor/v2/dsl/iterable.py
+++ b/instructor/v2/dsl/iterable.py
@@ -11,8 +11,20 @@ from typing import (
     TYPE_CHECKING,
 )
 import json
+import sys
 
 from pydantic import BaseModel, Field, create_model
+
+# PEP 604 unions (``A | B``) report ``types.UnionType`` as their origin; the legacy
+# ``Union[A, B]`` form reports ``typing.Union``. Recognize both when deriving the
+# iterable's task name so ``list[A | B]`` yields a clean name instead of leaking a
+# module-qualified ``str(UnionType)`` such as ``Iterablemymodule.A | mymodule.B``.
+if sys.version_info >= (3, 10):
+    from types import UnionType
+
+    _UNION_ORIGINS: tuple[Any, ...] = (Union, UnionType)
+else:  # pragma: no cover - Python 3.9 has no runtime ``X | Y`` union syntax
+    _UNION_ORIGINS = (Union,)
 
 if TYPE_CHECKING:
     pass
@@ -261,7 +273,7 @@ def IterableModel(
         # Handle `Union[A, B]` / `A | B` task types.
         # `types.UnionType` does not have `__name__`, so fall back to a stable name.
         task_name = getattr(subtask_class, "__name__", None)
-        if task_name is None and get_origin(subtask_class) is Union:
+        if task_name is None and get_origin(subtask_class) in _UNION_ORIGINS:
             members = get_args(subtask_class)
             task_name = "Or".join(getattr(m, "__name__", str(m)) for m in members)
         if task_name is None:

--- a/tests/dsl/test_simple_types.py
+++ b/tests/dsl/test_simple_types.py
@@ -115,3 +115,61 @@ def test_prepare_response_model_with_list_union():
     assert prepared_model is not None, (
         "prepare_response_model should not return None for list[int | str]"
     )
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Union pipe syntax is only available in Python 3.10+",
+)
+def test_list_of_model_pipe_union_is_treated_as_iterable():
+    """``list[A | B]`` must be treated as an iterable of models, exactly like
+    ``list[Union[A, B]]`` (regression for PEP 604 union response models).
+
+    Before the fix the PEP 604 form fell through to the simple-type ``ModelAdapter``
+    wrapper (root property ``content``) instead of an ``IterableModel`` (root property
+    ``tasks``), silently changing the schema sent to the model.
+    """
+    from instructor.v2.dsl.iterable import IterableBase
+
+    class A(BaseModel):
+        x: int
+
+    class B(BaseModel):
+        y: str
+
+    pipe = prepare_response_model(list[A | B])
+    typing_union = prepare_response_model(List[Union[A, B]])  # noqa: UP006
+
+    # The legacy ``Union`` form is wrapped as an iterable of models...
+    assert isinstance(typing_union, type) and issubclass(typing_union, IterableBase)
+    # ...and the PEP 604 ``A | B`` form must behave identically.
+    assert isinstance(pipe, type) and issubclass(pipe, IterableBase), (
+        "list[A | B] should be an iterable of models like list[Union[A, B]]"
+    )
+
+    pipe_schema = pipe.model_json_schema()
+    assert "tasks" in pipe_schema["properties"]
+    assert "content" not in pipe_schema["properties"]
+    # the iterable element still references both union members
+    assert set(pipe_schema.get("$defs", {})) == {"A", "B"}
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Union pipe syntax is only available in Python 3.10+",
+)
+def test_list_of_model_pipe_union_generates_clean_name():
+    """The generated iterable class name for ``list[A | B]`` must not leak a
+    module-qualified ``str(types.UnionType)`` such as ``Iterablemod.A | mod.B``."""
+
+    class A(BaseModel):
+        x: int
+
+    class B(BaseModel):
+        y: str
+
+    prepared = prepare_response_model(list[A | B])
+
+    assert "|" not in prepared.__name__
+    assert "." not in prepared.__name__
+    assert prepared.__name__ == "IterableAOrB"


### PR DESCRIPTION
## Problem

`list[A | B]` (PEP 604 union syntax) is the idiomatic modern way to ask for "a list of A-or-B" and should behave identically to `list[Union[A, B]]`. It didn't:

| `response_model` | prepared as | schema root |
| --- | --- | --- |
| `list[Union[A, B]]` | `IterableModel` ✅ | `tasks` (array) |
| `Iterable[A \| B]` | `IterableModel` ✅ | `tasks` (array) |
| `list[A \| B]` | simple-type wrapper ❌ | `content` (single object) |

`A | B` reports `types.UnionType` as its origin (not `typing.Union`), so `prepare_response_model._is_model_type` didn't recognize it as a union of models and `list[A | B]` fell through to the simple-type `ModelAdapter`. This silently changes the JSON schema sent to the model and breaks multi-item extraction — no error, just wrong results.

## Reproduction

```python
from typing import Union
from pydantic import BaseModel
from instructor.v2.core.response_model import prepare_response_model

class A(BaseModel): x: int
class B(BaseModel): y: str

prepare_response_model(list[A | B]).model_json_schema()        # before: root "content" (wrong)
prepare_response_model(list[Union[A, B]]).model_json_schema()  # root "tasks" (correct)
```

## Fix

Recognize `types.UnionType` alongside `typing.Union` (Python 3.10+), following the existing convention in `dsl/parallel.py`:

1. `prepare_response_model._is_model_type` — routes `list[A | B]` to `IterableModel`.
2. `IterableModel` task-name derivation — gives pipe unions a clean name (`IterableAOrB`) instead of leaking `Iterable<module>.A | <module>.B` into the schema title.

Extends the PEP 604 support added for `Partial` in #2200 to list/iterable response models.

## Tests

Two regression tests in `tests/dsl/test_simple_types.py` (skipped < 3.10), verified red-green. Mixed unions (`list[A | int]`) stay consistent with `list[Union[A, int]]` (both simple).