### PR TITLE
fix(v2): preserve backticks inside JSON string values during stream extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **v2 streaming**: Preserve backtick characters that appear inside JSON string values during streaming extraction. `extract_json_from_stream` (and its async counterpart) treated any backtick as a potential markdown code-fence delimiter, even while inside a JSON string, silently dropping content such as inline code (`` "use `pip install`" ``) or fenced snippets (`` "```py```" ``) from unfenced streamed responses.
+
+---
+
 ## [1.15.3] - 2026-06-15
 
 ### Fixed

--- a/instructor/v2/core/json.py
+++ b/instructor/v2/core/json.py
@@ -58,7 +58,11 @@ def extract_json_from_stream(chunks: Iterable[str]) -> Generator[str, None, None
 
     for chunk in chunks:
         for char in chunk:
-            if not in_codeblock and char == "`":
+            # Backticks inside a JSON string value are literal content, not
+            # codeblock fences. Treat them as fence candidates only when we are
+            # outside the JSON payload (or between its keys/structure), so code
+            # snippets like ``"```py```"`` survive extraction intact.
+            if not in_codeblock and char == "`" and not (json_started and in_string):
                 codeblock_buffer.append(char)
                 if len(codeblock_buffer) == 3:
                     in_codeblock = True
@@ -146,7 +150,11 @@ async def extract_json_from_stream_async(
 
     async for chunk in chunks:
         for char in chunk:
-            if not in_codeblock and char == "`":
+            # Backticks inside a JSON string value are literal content, not
+            # codeblock fences. Treat them as fence candidates only when we are
+            # outside the JSON payload (or between its keys/structure), so code
+            # snippets like ``"```py```"`` survive extraction intact.
+            if not in_codeblock and char == "`" and not (json_started and in_string):
                 codeblock_buffer.append(char)
                 if len(codeblock_buffer) == 3:
                     in_codeblock = True

--- a/tests/v2/test_json_helpers.py
+++ b/tests/v2/test_json_helpers.py
@@ -75,6 +75,42 @@ def test_extract_json_from_stream_handles_even_backslashes_before_quote() -> Non
     )
 
 
+def test_extract_json_from_stream_preserves_backticks_in_plain_string() -> None:
+    # Backticks inside a string value of unfenced JSON are literal content and
+    # must not be consumed as codeblock-fence candidates.
+    chunks = ['{"md":"use ', "`", "pip install`", ' here"}']
+
+    assert (
+        "".join(extract_json_from_stream(chunks)) == '{"md":"use `pip install` here"}'
+    )
+
+
+def test_extract_json_from_stream_preserves_triple_backticks_in_plain_string() -> None:
+    chunks = ['{"code":"', "```", "py```", '"}']
+
+    assert "".join(extract_json_from_stream(chunks)) == '{"code":"```py```"}'
+
+
+def test_extract_json_from_stream_preserves_backticks_in_fenced_string() -> None:
+    # Backticks within a string value still survive when the JSON itself is
+    # wrapped in a markdown codeblock.
+    chunks = ["```json\n", '{"code":"`inline`"}', "\n```"]
+
+    assert "".join(extract_json_from_stream(chunks)) == '{"code":"`inline`"}'
+
+
+@pytest.mark.asyncio
+async def test_extract_json_from_stream_async_preserves_backticks_in_string() -> None:
+    async def chunks():
+        for chunk in ['{"md":"use ', "`", "pip install`", ' here"}']:
+            yield chunk
+
+    assert (
+        "".join([chunk async for chunk in extract_json_from_stream_async(chunks())])
+        == '{"md":"use `pip install` here"}'
+    )
+
+
 @pytest.mark.asyncio
 async def test_extract_json_from_stream_async_handles_fenced_json() -> None:
     async def chunks():


### PR DESCRIPTION
## Describe your changes

`extract_json_from_stream` and `extract_json_from_stream_async` (`instructor/v2/core/json.py`) treat any backtick as a potential Markdown code-fence delimiter, even while inside a JSON string value. For an unfenced streamed response, backticks inside a string were silently diverted into the code-fence buffer and dropped, corrupting the extracted content while still producing valid-looking JSON:

~~~text
{"md":"use `pip install`"}   ->   {"md":"use pip install"}
{"code":"```py```"}          ->   {"code":"py```"}
~~~

This is common in practice, since models routinely emit code and markdown (with backticks) inside string fields.

The fix only treats a backtick as a code-fence candidate when not inside a JSON string (`not (json_started and in_string)`). Inside a string, backticks are appended as literal content. It is applied identically to the sync and async extractors.

## Issue ticket number and link

None. Bug found while reading the streaming extractor.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.

Added offline unit tests in `tests/v2/test_json_helpers.py` (inline and triple backticks in unfenced streamed JSON, sync and async, plus a non-regression test that backticks survive inside a fenced block). Verified red/green: the new tests fail on `main` and pass with the fix; the existing JSON-extraction suites (95 tests) still pass. `ruff check`, `ruff format --check`, and `ty check` are clean. Added an `[Unreleased]` to `Fixed` entry in `CHANGELOG.md`.
