### PR TITLE
docs(google): fix incorrect mode enums and outdated limitations in Google provider docs

### DIFF
--- a/docs/concepts/patching.md
+++ b/docs/concepts/patching.md
@@ -37,7 +37,7 @@ Different providers support different modes for structured extraction. Instructo
 
 Uses the provider's function/tool calling API. This is the default for OpenAI.
 
-Supported by: OpenAI, Anthropic (ANTHROPIC_TOOLS), Google (GENAI_TOOLS), Ollama (for supported models)
+Supported by: OpenAI, Anthropic, Google, Ollama (for supported models)
 
 ### JSON Mode
 
@@ -136,14 +136,14 @@ The patched client's `create()` method:
 
 ### Anthropic
 
-- Default mode: `ANTHROPIC_TOOLS` (tool use)
+- Default mode: `Mode.TOOLS` (tool use)
 - Uses Claude's native tool calling API
 
 ### Google Gemini
 
-- Default mode: `GENAI_TOOLS` (function calling)
+- Default mode: `Mode.TOOLS` (function calling)
 - Requires `jsonref` package for tool calling
-- Some limitations with strict validation and enums
+- Union types (except `Optional`) are not supported
 
 ### Ollama (Local Models)
 

--- a/docs/integrations/genai.md
+++ b/docs/integrations/genai.md
@@ -31,7 +31,7 @@ We currently have two modes for Gemini
 
 !!! note "Backwards Compatibility"
 
-    The provider-specific modes (`Mode.TOOLS`, `Mode.JSON`, `Mode.JSON`) are still supported but emit deprecation warnings and map to the generic modes (`Mode.TOOLS`, `Mode.JSON`).
+    The legacy provider-specific modes (`Mode.GENAI_TOOLS`, `Mode.GENAI_JSON`, `Mode.GENAI_STRUCTURED_OUTPUTS`) are still supported but emit deprecation warnings and automatically map to the generic modes (`Mode.TOOLS`, `Mode.JSON`).
 
 ## Installation
 
@@ -41,9 +41,9 @@ pip install "instructor[google-genai]"
 
 ## Basic Usage
 
-!!! warning "Unions and Optionals"
+!!! warning "Union Types"
 
-    Gemini doesn't have support for Union and Optional types in the structured outputs and tool calling integrations. We currently throw an error when we detect these in your response model.
+    Gemini does not support Union types (except for `Optional`) in structured outputs and tool calling. Use separate response models or `Literal` types instead. `Optional` fields (i.e., `X | None`) work correctly.
 
 Getting started with Instructor and the genai SDK is straightforward. Just create a Pydantic model defining your output structure, patch the genai client, and make your request with a response_model parameter:
 
@@ -547,11 +547,11 @@ print(response)
 
 !!! warning "Streaming Limitations"
 
-    **As of July 11, 2025, Google GenAI does not support streaming with tool/function calling or structured outputs for regular models.** 
+    Google GenAI does not support streaming with tool/function calling (`Mode.TOOLS`) for regular models. To use streaming with Gemini:
     
-    - `Mode.TOOLS` and `Mode.JSON` do not support streaming with regular models
-    - To use streaming, you must use `Partial[YourModel]` explicitly or switch to other modes like `Mode.JSON`
-    - Alternatively, set `stream=False` to disable streaming
+    - Use `Mode.JSON` which supports streaming via `create_partial` and `create_iterable`
+    - Or use `Partial[YourModel]` explicitly with `Mode.JSON`
+    - Alternatively, set `stream=False` to disable streaming when using `Mode.TOOLS`
 
 Streaming allows you to process responses incrementally rather than waiting for the complete result. This is extremely useful for making UI changes feel instant and responsive.
 

--- a/docs/integrations/google.md
+++ b/docs/integrations/google.md
@@ -321,13 +321,12 @@ for user in users:
     #> name='Mike' age=28
 ```
 
-## Known Limitations (as of Nov 12, 2024)
+## Known Limitations
 
 Google Gemini has the following known limitations when used with Instructor:
 
-1. **Union Types**: Gemini does not support Union types (except for Optional). Use separate response models or Literal types instead.
-2. **Enum Types**: Gemini returns string values instead of properly typed Enum instances. You may need to manually convert strings to enums after extraction.
-3. **Union Streaming**: Streaming is not supported for Union types with Iterable.
+1. **Union Types**: Gemini does not support Union types (except for `Optional`). Use separate response models or `Literal` types instead.
+2. **Union Streaming**: Streaming is not supported for Union types with Iterable.
 
 These limitations are specific to Google Gemini and do not affect other providers like OpenAI or Anthropic. Tests automatically skip these features for Google to prevent failures.
 
@@ -340,7 +339,7 @@ We provide several modes to make it easy to work with the different response mod
 
 !!! note "Backwards Compatibility"
 
-    Legacy provider-specific modes (for example `Mode.TOOLS`, `Mode.JSON`, `Mode.JSON`, `Mode.TOOLS`) are deprecated. They emit warnings and map to the generic modes.
+    Legacy provider-specific modes (such as `Mode.GENAI_TOOLS`, `Mode.GENAI_JSON`, `Mode.GENAI_STRUCTURED_OUTPUTS`) are deprecated. They emit warnings and automatically map to the generic modes (`Mode.TOOLS`, `Mode.JSON`).
 
 !!! info "Mode Selection"
     When using `from_provider`, the appropriate mode is automatically selected based on the provider and model capabilities.
@@ -349,9 +348,9 @@ We provide several modes to make it easy to work with the different response mod
 
 Google offers several Gemini models:
 
-- Gemini Flash (General purpose)
-- Gemini Pro (Multimodal)
-- Gemini Flash-8b (Coming soon)
+- Gemini Flash (General purpose, fast inference)
+- Gemini Pro (Advanced reasoning, multimodal)
+- Gemini Flash-8b (Lightweight, cost-effective)
 
 ## Using Gemini's Multimodal Capabilities
 
@@ -410,7 +409,9 @@ import vertexai
 from vertexai.generative_models import GenerativeModel
 
 vertexai.init(project="your-project", location="us-central1")
-client = instructor.from_provider("google/gemini-2.5-flash", vertexai=True),
+client = instructor.from_provider(
+    "google/gemini-2.5-flash",
+    vertexai=True,
     mode=instructor.Mode.TOOLS,
 )
 ```

--- a/docs/integrations/vertex.md
+++ b/docs/integrations/vertex.md
@@ -242,7 +242,9 @@ from vertexai.generative_models import GenerativeModel
 
 vertexai.init(project="your-project", location="us-central1")
 
-client = instructor.from_provider("google/gemini-2.5-flash", vertexai=True),
+client = instructor.from_provider(
+    "google/gemini-2.5-flash",
+    vertexai=True,
     mode=instructor.Mode.TOOLS,
 )
 ```


### PR DESCRIPTION
## Summary

I ran into the same confusion described in #2289 while setting up Instructor with Google GenAI. The docs had several issues that made it genuinely hard to figure out which modes to use. Here's what I fixed:

**Mode enum confusion** - The backwards-compatibility notes in both `genai.md` and `google.md` listed `Mode.TOOLS` and `Mode.JSON` as *both* the deprecated modes *and* the recommended replacements, which makes no sense. The actual deprecated modes are `Mode.GENAI_TOOLS`, `Mode.GENAI_JSON`, and `Mode.GENAI_STRUCTURED_OUTPUTS`. Fixed to match what the code actually does.

**Optional types work fine** - `genai.md` warned that "Gemini doesn't have support for Union and Optional types", but Optional (`X | None`) works correctly. Only true Union types (e.g., `str | int`) are unsupported.

**Streaming warning contradicted itself** - It said `Mode.JSON` doesn't support streaming, then in the same section showed working streaming examples with `Mode.JSON`. Clarified that `Mode.TOOLS` doesn't stream, but `Mode.JSON` does.

**Other fixes:**
- Removed outdated Enum limitation (enums work fine, `verify_no_unions` is a no-op)
- Fixed a Python syntax error in the Vertex AI migration example (misplaced parenthesis)
- Removed "Coming soon" for Gemini Flash-8b which has been available for over a year
- Updated `patching.md` to use generic `Mode.TOOLS` instead of deprecated provider-specific mode names

## Verification

Cross-referenced all changes against the v2 source:
- `instructor/v2/providers/genai/handlers.py` - registers `Mode.TOOLS` and `Mode.JSON`
- `instructor/v2/core/mode.py` - `DEPRECATED_TO_CORE` map confirms `GENAI_TOOLS → TOOLS`, etc.
- `instructor/v2/providers/gemini/utils.py` - `verify_no_unions()` always returns `True`

Partially addresses #2289


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.
