### PR TITLE
perf: defer openai SDK import in v2 core modules

### DIFF
--- a/instructor/v2/core/client.py
+++ b/instructor/v2/core/client.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import openai
-from instructor.v2.core.mode import Mode
-from instructor.v2.core.providers import Provider
-from openai.types.chat import ChatCompletionMessageParam
 from typing import (
+    TYPE_CHECKING,
     TypeVar,
     Callable,
     overload,
@@ -14,6 +11,13 @@ from typing import (
     get_origin,
     get_args,
 )
+
+if TYPE_CHECKING:
+    import openai
+    from openai.types.chat import ChatCompletionMessageParam
+
+from instructor.v2.core.mode import Mode
+from instructor.v2.core.providers import Provider
 from tenacity import (
     AsyncRetrying,
     Retrying,
@@ -412,7 +416,9 @@ class Instructor:
             Mode.RESPONSES_TOOLS,
             Mode.RESPONSES_TOOLS_WITH_INBUILT_TOOLS,
         }:
-            assert isinstance(client, (openai.OpenAI, openai.AsyncOpenAI))
+            import openai as _openai
+
+            assert isinstance(client, (_openai.OpenAI, _openai.AsyncOpenAI))
             self.responses = Response(client=self)
 
     def on(
@@ -758,7 +764,9 @@ class AsyncInstructor(Instructor):
             Mode.RESPONSES_TOOLS,
             Mode.RESPONSES_TOOLS_WITH_INBUILT_TOOLS,
         }:
-            assert isinstance(client, (openai.OpenAI, openai.AsyncOpenAI))
+            import openai as _openai
+
+            assert isinstance(client, (_openai.OpenAI, _openai.AsyncOpenAI))
             self.responses = AsyncResponse(client=self)
 
     async def create(  # type: ignore[override]  # ty: ignore[invalid-method-override]

--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from openai.types.chat import ChatCompletionMessage, ChatCompletionMessageParam
+if TYPE_CHECKING:
+    from openai.types.chat import ChatCompletionMessage, ChatCompletionMessageParam
 
 
 def extract_messages(kwargs: dict[str, Any]) -> Any:

--- a/instructor/v2/core/patch.py
+++ b/instructor/v2/core/patch.py
@@ -11,7 +11,6 @@ from collections.abc import Awaitable
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast, overload
 
-from openai import AsyncOpenAI, OpenAI
 from pydantic import BaseModel
 
 from instructor.v2.core.mode import Mode
@@ -26,6 +25,7 @@ from instructor.v2.core.retry import retry_async_v2, retry_sync_v2
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from openai import AsyncOpenAI, OpenAI
     from tenacity import AsyncRetrying, Retrying
 
 logger = logging.getLogger("instructor.v2")

--- a/instructor/v2/core/usage.py
+++ b/instructor/v2/core/usage.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, TypeVar
 
-from openai.types import CompletionUsage as OpenAIUsage
-
 if TYPE_CHECKING:
     from anthropic.types import Usage as AnthropicUsage
+    from openai.types import CompletionUsage as OpenAIUsage
 
 logger = logging.getLogger("instructor")
 T_Response = TypeVar("T_Response")
@@ -21,8 +20,10 @@ def update_total_usage(
     if response is None:
         return None
 
+    from openai.types import CompletionUsage as _OpenAIUsage
+
     response_usage = getattr(response, "usage", None)
-    if isinstance(response_usage, OpenAIUsage) and isinstance(total_usage, OpenAIUsage):
+    if isinstance(response_usage, _OpenAIUsage) and isinstance(total_usage, _OpenAIUsage):
         total_usage.completion_tokens += response_usage.completion_tokens or 0
         total_usage.prompt_tokens += response_usage.prompt_tokens or 0
         total_usage.total_tokens += response_usage.total_tokens or 0

--- a/scripts/benchmark_import.py
+++ b/scripts/benchmark_import.py
@@ -1,0 +1,114 @@
+"""Benchmark script for instructor import performance.
+
+Measures memory usage and module count at various import stages to identify
+bottlenecks in the import chain. Run with:
+
+    python scripts/benchmark_import.py
+
+Requires: tracemalloc (stdlib), optionally the provider SDKs for full profiling.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def run_import_benchmark(code: str, label: str) -> dict[str, str]:
+    """Run a Python snippet in a subprocess and capture memory/timing stats."""
+    script = textwrap.dedent(f"""
+        import tracemalloc
+        import time
+        import sys
+
+        tracemalloc.start()
+        start = time.time()
+
+        {code}
+
+        elapsed = time.time() - start
+        current, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        mod_count = len(sys.modules)
+        print(f"{{elapsed:.3f}}|{{current}}|{{peak}}|{{mod_count}}")
+    """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    if result.returncode != 0:
+        return {
+            "label": label,
+            "time": "ERROR",
+            "memory_mb": "ERROR",
+            "peak_mb": "ERROR",
+            "modules": "ERROR",
+            "error": result.stderr.strip(),
+        }
+
+    parts = result.stdout.strip().split("|")
+    elapsed, current, peak, mod_count = parts
+
+    return {
+        "label": label,
+        "time": f"{float(elapsed):.3f}s",
+        "memory_mb": f"{int(current) / 1024 / 1024:.1f} MB",
+        "peak_mb": f"{int(peak) / 1024 / 1024:.1f} MB",
+        "modules": mod_count,
+    }
+
+
+def main() -> None:
+    print("=" * 70)
+    print(" INSTRUCTOR IMPORT BENCHMARK")
+    print("=" * 70)
+    print(f" Python: {sys.version.split()[0]}")
+    print(f" Executable: {sys.executable}")
+    print("=" * 70)
+    print()
+
+    benchmarks = [
+        ("import sys", "baseline (sys only)"),
+        ("import instructor", "import instructor"),
+        ("import instructor; _ = instructor.from_provider", "access from_provider"),
+        ("import instructor; _ = instructor.from_openai", "access from_openai"),
+        ("import instructor; _ = instructor.from_anthropic", "access from_anthropic"),
+        ("import instructor; _ = instructor.from_genai", "access from_genai"),
+        ("import instructor; _ = instructor.Mode", "access Mode"),
+        ("import instructor; _ = instructor.Instructor", "access Instructor class"),
+        ("import instructor; _ = instructor.Partial", "access Partial"),
+    ]
+
+    results = []
+    for code, label in benchmarks:
+        result = run_import_benchmark(code, label)
+        results.append(result)
+
+    header = f"{'Benchmark':<30} {'Time':>8} {'Memory':>10} {'Peak':>10} {'Modules':>8}"
+    print(header)
+    print("-" * len(header))
+
+    for r in results:
+        if r.get("error"):
+            print(f"{r['label']:<30} {'ERROR':>8} (missing dependency?)")
+        else:
+            print(
+                f"{r['label']:<30} {r['time']:>8} {r['memory_mb']:>10} "
+                f"{r['peak_mb']:>10} {r['modules']:>8}"
+            )
+
+    print()
+    print("Notes:")
+    print("  - 'import instructor' should be <1MB and <100 modules (lazy loading)")
+    print("  - Provider access loads the SDK on demand (expected ~20-50MB)")
+    print("  - If 'import instructor' alone is >50MB, lazy loading is broken")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_import_lazy_openai.py
+++ b/tests/test_import_lazy_openai.py
@@ -1,0 +1,89 @@
+"""Regression test for issue #2205: import instructor should not eagerly load openai.
+
+Verifies that accessing core instructor symbols (Instructor, from_provider, Mode)
+does not trigger the openai SDK import, which is expensive (~30MB, ~550 modules).
+The openai SDK should only load when a user explicitly creates an OpenAI-based client.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def _check_openai_not_loaded(access_code: str) -> None:
+    """Run a subprocess that accesses an instructor symbol and asserts openai is not loaded."""
+    script = textwrap.dedent(f"""
+        import sys
+        import instructor
+        {access_code}
+        if "openai" in sys.modules:
+            loaded = [m for m in sys.modules if m.startswith("openai")]
+            print(f"FAIL: openai loaded ({{len(loaded)}} modules)")
+            sys.exit(1)
+        else:
+            print("PASS: openai not loaded")
+            sys.exit(0)
+    """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"openai was eagerly loaded after: {access_code}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_bare_import_does_not_load_openai():
+    _check_openai_not_loaded("pass")
+
+
+def test_from_provider_access_does_not_load_openai():
+    _check_openai_not_loaded("_ = instructor.from_provider")
+
+
+def test_instructor_class_access_does_not_load_openai():
+    _check_openai_not_loaded("_ = instructor.Instructor")
+
+
+def test_mode_access_does_not_load_openai():
+    _check_openai_not_loaded("_ = instructor.Mode")
+
+
+def test_partial_access_does_not_load_openai():
+    _check_openai_not_loaded("_ = instructor.Partial")
+
+
+@pytest.mark.parametrize("symbol", [
+    "from_provider",
+    "Instructor",
+    "AsyncInstructor",
+    "Mode",
+    "Partial",
+    "Maybe",
+])
+def test_core_symbols_accessible_without_openai(symbol: str):
+    """Core symbols must remain accessible (no import errors)."""
+    script = textwrap.dedent(f"""
+        import instructor
+        obj = getattr(instructor, "{symbol}")
+        assert obj is not None, f"{{symbol}} resolved to None"
+    """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"Failed to access instructor.{symbol}\n"
+        f"stderr: {result.stderr}"
+    )


### PR DESCRIPTION
Partially addresses #2205.

## Problem

With `openai`, `anthropic`, and `google-genai` installed, accessing `instructor.from_provider` or `instructor.Instructor` eagerly loaded the entire openai SDK (~30MB, 558 modules) even though nothing OpenAI-specific was needed yet. The root cause: several `v2/core/` modules imported `openai` at the module level for type annotations and isinstance checks that only matter at runtime when an OpenAI client is actually in play.

## Fix

Moved openai imports behind `TYPE_CHECKING` in four files:

- **`v2/core/client.py`** - `import openai` + `ChatCompletionMessageParam` (used only in annotations thanks to `from __future__ import annotations`; two isinstance checks now use a local import inside the conditional block that already guards for RESPONSES_TOOLS mode)
- **`v2/core/patch.py`** - `AsyncOpenAI`, `OpenAI` (annotation-only)
- **`v2/core/messages.py`** - `ChatCompletionMessage`, `ChatCompletionMessageParam` (annotation-only)
- **`v2/core/usage.py`** - `CompletionUsage` (moved to local import inside `update_total_usage()` where the isinstance check lives)

## Results

Benchmarked on Python 3.12 with `openai`, `anthropic`, and `google-genai` installed:

| Access pattern | Before | After | Reduction |
|---|---|---|---|
| `instructor.from_provider` | 26.7 MB / 942 modules | 13.0 MB / 304 modules | **51% memory, 68% modules** |
| `instructor.Instructor` | 29.0 MB / 976 modules | 14.8 MB / 338 modules | **49% memory, 65% modules** |
| `import instructor` | 0.6 MB / 78 modules | 0.6 MB / 78 modules | (already lazy) |

Provider-specific access (`from_openai`, `from_anthropic`, etc.) still correctly loads the respective SDK on demand - that's expected and intentional.

## Included

- Benchmark script (`scripts/benchmark_import.py`) for reproducible profiling
- Regression test (`tests/test_import_lazy_openai.py`) verifying openai isn't pulled in by core symbol access

## Scope

This is intentionally a focused fix for the `v2/core/` import chain. The top-level `__init__.py` lazy loading (already on main) handles the outer layer; this PR closes the gap in the inner layer that still triggered openai through `core/__init__.py` → `patch.py` → `messages.py` / `usage.py`.


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.
