### PR TITLE
fix(cli): use uploaded file ID for validation_file in create_from_file

### DIFF
--- a/instructor/cli/jobs.py
+++ b/instructor/cli/jobs.py
@@ -206,7 +206,7 @@ def create_from_file(
     if hyperparameters_dict:
         additional_params["hyperparameters"] = hyperparameters_dict
     if validation_file:
-        additional_params["validation_file"] = validation_file
+        additional_params["validation_file"] = validation_file_id
     if model_suffix:
         additional_params["suffix"] = model_suffix
 


### PR DESCRIPTION
`create_from_file` uploads the validation file and stores its id in `validation_file_id`, but then passes the raw local path string (`validation_file`) to `client.fine_tuning.jobs.create(validation_file=...)`, which expects an uploaded-file id rather than a path. As a result the `--validation-file` option currently fails.

This matches the sibling `create_from_id` command, which already passes `validation_file_id`, and the success log line that reports the job was created "with validation_file ID: {validation_file_id}".

One-line fix: pass `validation_file_id` instead of the path string.
