### PR TITLE
fix(v2): consolidate import and responses fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [1.15.5] - 2026-06-28
+
+### Fixed
+- **v2 imports**: Defer OpenAI SDK imports from core v2 modules until an OpenAI-specific path actually needs them, reducing import side effects for non-OpenAI usage. ([#2390](https://github.com/567-labs/instructor/pull/2390))
+- **v2 response models**: Treat `list[A | B]` PEP 604 unions of Pydantic models as iterable response models, matching `list[Union[A, B]]` schema behavior. ([#2377](https://github.com/567-labs/instructor/pull/2377))
+- **OpenAI Responses API**: Align `RESPONSES_TOOLS` `text.format` with the forced tool schema and add targeted retry guidance when tool calls return empty `{}` arguments. ([#2300](https://github.com/567-labs/instructor/issues/2300), [#2304](https://github.com/567-labs/instructor/pull/2304))
+
+---
+
 ## [1.15.4] - 2026-06-27
 
 ### Fixed

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -66,7 +66,7 @@ if TYPE_CHECKING:
         openai_moderation as openai_moderation,
     )
 
-__version__ = "1.15.4"
+__version__ = "1.15.5"
 
 __all__ = [
     "Instructor",

--- a/instructor/v2/core/client.py
+++ b/instructor/v2/core/client.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import openai
-from instructor.v2.core.mode import Mode
-from instructor.v2.core.providers import Provider
-from openai.types.chat import ChatCompletionMessageParam
 from typing import (
+    TYPE_CHECKING,
     TypeVar,
     Callable,
     overload,
@@ -14,6 +11,13 @@ from typing import (
     get_origin,
     get_args,
 )
+
+if TYPE_CHECKING:
+    import openai
+    from openai.types.chat import ChatCompletionMessageParam
+
+from instructor.v2.core.mode import Mode
+from instructor.v2.core.providers import Provider
 from tenacity import (
     AsyncRetrying,
     Retrying,
@@ -412,7 +416,9 @@ class Instructor:
             Mode.RESPONSES_TOOLS,
             Mode.RESPONSES_TOOLS_WITH_INBUILT_TOOLS,
         }:
-            assert isinstance(client, (openai.OpenAI, openai.AsyncOpenAI))
+            import openai as _openai
+
+            assert isinstance(client, (_openai.OpenAI, _openai.AsyncOpenAI))
             self.responses = Response(client=self)
 
     def on(
@@ -758,7 +764,9 @@ class AsyncInstructor(Instructor):
             Mode.RESPONSES_TOOLS,
             Mode.RESPONSES_TOOLS_WITH_INBUILT_TOOLS,
         }:
-            assert isinstance(client, (openai.OpenAI, openai.AsyncOpenAI))
+            import openai as _openai
+
+            assert isinstance(client, (_openai.OpenAI, _openai.AsyncOpenAI))
             self.responses = AsyncResponse(client=self)
 
     async def create(  # type: ignore[override]  # ty: ignore[invalid-method-override]

--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from openai.types.chat import ChatCompletionMessage, ChatCompletionMessageParam
+if TYPE_CHECKING:
+    from openai.types.chat import ChatCompletionMessage, ChatCompletionMessageParam
 
 
 def extract_messages(kwargs: dict[str, Any]) -> Any:

--- a/instructor/v2/core/patch.py
+++ b/instructor/v2/core/patch.py
@@ -11,7 +11,6 @@ from collections.abc import Awaitable
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast, overload
 
-from openai import AsyncOpenAI, OpenAI
 from pydantic import BaseModel
 
 from instructor.v2.core.mode import Mode
@@ -27,6 +26,7 @@ from instructor.v2.core.retry import retry_async_v2, retry_sync_v2
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from openai import AsyncOpenAI, OpenAI
     from tenacity import AsyncRetrying, Retrying
 
 logger = logging.getLogger("instructor.v2")

--- a/instructor/v2/core/response_model.py
+++ b/instructor/v2/core/response_model.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import sys
 from collections.abc import Iterable
 from typing import Any, Callable, TypeVar, Union, cast, get_args, get_origin
 
@@ -11,6 +12,13 @@ from pydantic import BaseModel, create_model
 T = TypeVar("T")
 
 _create_dynamic_model = cast(Callable[..., type[BaseModel]], create_model)
+
+if sys.version_info >= (3, 10):
+    from types import UnionType
+
+    _UNION_ORIGINS: tuple[Any, ...] = (Union, UnionType)
+else:  # pragma: no cover - Python 3.9 has no runtime ``X | Y`` syntax
+    _UNION_ORIGINS = (Union,)
 
 
 def is_typed_dict(cls: Any) -> bool:
@@ -41,7 +49,7 @@ def prepare_response_model(response_model: type[T] | None) -> type[T] | None:
         def _is_model_type(candidate: Any) -> bool:
             if inspect.isclass(candidate) and issubclass(candidate, BaseModel):
                 return True
-            return get_origin(candidate) is Union and all(
+            return get_origin(candidate) in _UNION_ORIGINS and all(
                 inspect.isclass(member) and issubclass(member, BaseModel)
                 for member in get_args(candidate)
             )

--- a/instructor/v2/core/usage.py
+++ b/instructor/v2/core/usage.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, TypeVar
 
-from openai.types import CompletionUsage as OpenAIUsage
-
 if TYPE_CHECKING:
     from anthropic.types import Usage as AnthropicUsage
+    from openai.types import CompletionUsage as OpenAIUsage
 
 logger = logging.getLogger("instructor")
 T_Response = TypeVar("T_Response")
@@ -21,8 +20,12 @@ def update_total_usage(
     if response is None:
         return None
 
+    from openai.types import CompletionUsage as _OpenAIUsage
+
     response_usage = getattr(response, "usage", None)
-    if isinstance(response_usage, OpenAIUsage) and isinstance(total_usage, OpenAIUsage):
+    if isinstance(response_usage, _OpenAIUsage) and isinstance(
+        total_usage, _OpenAIUsage
+    ):
         total_usage.completion_tokens += response_usage.completion_tokens or 0
         total_usage.prompt_tokens += response_usage.prompt_tokens or 0
         total_usage.total_tokens += response_usage.total_tokens or 0

--- a/instructor/v2/dsl/iterable.py
+++ b/instructor/v2/dsl/iterable.py
@@ -11,8 +11,16 @@ from typing import (
     TYPE_CHECKING,
 )
 import json
+import sys
 
 from pydantic import BaseModel, Field, create_model
+
+if sys.version_info >= (3, 10):
+    from types import UnionType
+
+    _UNION_ORIGINS: tuple[Any, ...] = (Union, UnionType)
+else:  # pragma: no cover - Python 3.9 has no runtime ``X | Y`` syntax
+    _UNION_ORIGINS = (Union,)
 
 if TYPE_CHECKING:
     pass
@@ -261,7 +269,7 @@ def IterableModel(
         # Handle `Union[A, B]` / `A | B` task types.
         # `types.UnionType` does not have `__name__`, so fall back to a stable name.
         task_name = getattr(subtask_class, "__name__", None)
-        if task_name is None and get_origin(subtask_class) is Union:
+        if task_name is None and get_origin(subtask_class) in _UNION_ORIGINS:
             members = get_args(subtask_class)
             task_name = "Or".join(getattr(m, "__name__", str(m)) for m in members)
         if task_name is None:

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import logging
 from collections.abc import (
     AsyncGenerator,
     AsyncIterator,
@@ -44,6 +45,8 @@ from instructor.v2.core.messages import dump_message, merge_consecutive_messages
 from instructor.v2.providers.openai.schema import generate_openai_schema
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.core.handler import ModeHandler
+
+logger = logging.getLogger("instructor")
 
 
 OPENAI_COMPAT_PROVIDERS = [
@@ -116,6 +119,37 @@ def _format_responses_tool_call_details(tool_call: Any) -> str:
     return f" (tool call {', '.join(details)})"
 
 
+def _ensure_text_format_config(
+    new_kwargs: dict[str, Any],
+    response_model: type[Any],
+    parameters_schema: dict[str, Any],
+) -> None:
+    """Align Responses API text.format with the forced tool schema."""
+    desired_format = {
+        "type": "json_schema",
+        "name": response_model.__name__,
+        "strict": True,
+        "schema": parameters_schema,
+    }
+
+    existing_text = new_kwargs.get("text")
+    if isinstance(existing_text, dict):
+        existing_format = existing_text.get("format")
+        if existing_format == desired_format:
+            return
+        if isinstance(existing_format, dict):
+            logger.debug(
+                "Overriding user-provided text.format with tool schema "
+                "to prevent competing Responses output paths."
+            )
+        updated_text = existing_text.copy()
+        updated_text["format"] = desired_format
+        new_kwargs["text"] = updated_text
+        return
+
+    new_kwargs["text"] = {"format": desired_format}
+
+
 def reask_tools(
     kwargs: dict[str, Any],
     response: Any,
@@ -176,13 +210,32 @@ def reask_responses_tools(
     reask_messages = []
     for tool_call in _filter_responses_tool_calls(response.output):
         details = _format_responses_tool_call_details(tool_call)
+        args = getattr(tool_call, "arguments", "")
+        is_empty_args = not args or (
+            isinstance(args, str) and args.strip() in {"", "{}"}
+        )
+        if is_empty_args:
+            reask_messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        f"Validation Error found:\n{exception}\n"
+                        "The function was called with empty arguments '{}'. "
+                        "You MUST populate ALL required fields in the function "
+                        "call according to the schema. Do not return empty "
+                        f"arguments.{details}"
+                    ),
+                }
+            )
+            continue
+
         reask_messages.append(
             {
                 "role": "user",
                 "content": (
                     f"Validation Error found:\n{exception}\n"
                     "Recall the function correctly, fix the errors with "
-                    f"{tool_call.arguments}{details}"
+                    f"{args}{details}"
                 ),
             }
         )
@@ -1059,6 +1112,11 @@ class OpenAIResponsesToolsHandler(OpenAIHandlerBase):
             "type": "function",
             "name": schema["function"]["name"],
         }
+        _ensure_text_format_config(
+            new_kwargs,
+            prepared_model,
+            tool_definition["parameters"],
+        )
 
         return prepared_model, new_kwargs
 
@@ -1100,6 +1158,15 @@ class OpenAIResponsesToolsHandler(OpenAIHandlerBase):
                 item_type = getattr(item, "type", None)
                 if item_type in {"function_call", "tool_call"}:
                     args = getattr(item, "arguments", None)
+                    if not args or (
+                        isinstance(args, str) and args.strip() in {"", "{}"}
+                    ):
+                        logger.warning(
+                            "RESPONSES_TOOLS: tool '%s' returned empty arguments. "
+                            "This can indicate a text.format/tool_choice conflict "
+                            "or insufficient reasoning budget.",
+                            getattr(item, "name", "unknown"),
+                        )
                     if args:
                         parsed = response_model.model_validate_json(
                             args,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "requests<3.0.0,>=2.32.3",
 ]
 name = "instructor"
-version = "1.15.4"
+version = "1.15.5"
 description = "structured outputs for llm"
 readme = "README.md"
 

--- a/scripts/benchmark_import.py
+++ b/scripts/benchmark_import.py
@@ -1,0 +1,107 @@
+"""Benchmark instructor import costs.
+
+Run with:
+
+    python scripts/benchmark_import.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def run_import_benchmark(code: str, label: str) -> dict[str, str]:
+    """Run a Python snippet in a subprocess and capture import stats."""
+    script = textwrap.dedent(
+        f"""
+        import sys
+        import time
+        import tracemalloc
+
+        tracemalloc.start()
+        start = time.time()
+
+        {code}
+
+        elapsed = time.time() - start
+        current, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        print(f"{{elapsed:.3f}}|{{current}}|{{peak}}|{{len(sys.modules)}}")
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if result.returncode != 0:
+        return {
+            "label": label,
+            "time": "ERROR",
+            "memory_mb": "ERROR",
+            "peak_mb": "ERROR",
+            "modules": "ERROR",
+            "error": result.stderr.strip(),
+        }
+
+    elapsed, current, peak, mod_count = result.stdout.strip().split("|")
+    return {
+        "label": label,
+        "time": f"{float(elapsed):.3f}s",
+        "memory_mb": f"{int(current) / 1024 / 1024:.1f} MB",
+        "peak_mb": f"{int(peak) / 1024 / 1024:.1f} MB",
+        "modules": mod_count,
+    }
+
+
+def main() -> None:
+    print("=" * 70)
+    print(" INSTRUCTOR IMPORT BENCHMARK")
+    print("=" * 70)
+    print(f" Python: {sys.version.split()[0]}")
+    print(f" Executable: {sys.executable}")
+    print("=" * 70)
+    print()
+
+    benchmarks = [
+        ("import sys", "baseline (sys only)"),
+        ("import instructor", "import instructor"),
+        ("import instructor; _ = instructor.from_provider", "access from_provider"),
+        ("import instructor; _ = instructor.from_openai", "access from_openai"),
+        ("import instructor; _ = instructor.from_anthropic", "access from_anthropic"),
+        ("import instructor; _ = instructor.from_genai", "access from_genai"),
+        ("import instructor; _ = instructor.Mode", "access Mode"),
+        ("import instructor; _ = instructor.Instructor", "access Instructor class"),
+        ("import instructor; _ = instructor.Partial", "access Partial"),
+    ]
+
+    results = [run_import_benchmark(code, label) for code, label in benchmarks]
+
+    header = f"{'Benchmark':<30} {'Time':>8} {'Memory':>10} {'Peak':>10} {'Modules':>8}"
+    print(header)
+    print("-" * len(header))
+
+    for result in results:
+        if result.get("error"):
+            print(f"{result['label']:<30} {'ERROR':>8} (missing dependency?)")
+        else:
+            print(
+                f"{result['label']:<30} {result['time']:>8} "
+                f"{result['memory_mb']:>10} {result['peak_mb']:>10} "
+                f"{result['modules']:>8}"
+            )
+
+    print()
+    print("Notes:")
+    print("  - 'import instructor' should stay small because of lazy loading.")
+    print("  - Provider access loads each SDK on demand.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/dsl/test_simple_types.py
+++ b/tests/dsl/test_simple_types.py
@@ -1,7 +1,7 @@
 import sys
 from collections.abc import Iterable
 from enum import Enum
-from typing import Annotated, Literal, Union, List, get_origin, get_args  # noqa: UP035
+from typing import Annotated, Literal, Union, List, cast, get_origin, get_args  # noqa: UP035
 
 import pytest
 from pydantic import BaseModel, Field
@@ -125,3 +125,48 @@ def test_prepare_response_model_with_list_union():
     assert prepared_model is not None, (
         "prepare_response_model should not return None for list[int | str]"
     )
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Union pipe syntax is only available in Python 3.10+",
+)
+def test_list_of_model_pipe_union_is_treated_as_iterable():
+    from instructor.v2.dsl.iterable import IterableBase
+
+    class A(BaseModel):
+        x: int
+
+    class B(BaseModel):
+        y: str
+
+    pipe = prepare_response_model(list[A | B])
+    typing_union = prepare_response_model(List[Union[A, B]])  # noqa: UP006
+
+    assert isinstance(typing_union, type) and issubclass(typing_union, IterableBase)
+    assert isinstance(pipe, type) and issubclass(pipe, IterableBase)
+
+    pipe_model = cast(type[BaseModel], pipe)
+    pipe_schema = pipe_model.model_json_schema()
+    assert "tasks" in pipe_schema["properties"]
+    assert "content" not in pipe_schema["properties"]
+    assert set(pipe_schema.get("$defs", {})) == {"A", "B"}
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Union pipe syntax is only available in Python 3.10+",
+)
+def test_list_of_model_pipe_union_generates_clean_name():
+    class A(BaseModel):
+        x: int
+
+    class B(BaseModel):
+        y: str
+
+    prepared = prepare_response_model(list[A | B])
+    assert prepared is not None
+
+    assert "|" not in prepared.__name__
+    assert "." not in prepared.__name__
+    assert prepared.__name__ == "IterableAOrB"

--- a/tests/test_import_lazy_openai.py
+++ b/tests/test_import_lazy_openai.py
@@ -1,0 +1,92 @@
+"""Regression tests for avoiding eager OpenAI SDK imports."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def _check_openai_not_loaded(access_code: str) -> None:
+    script = textwrap.dedent(
+        f"""
+        import sys
+        import instructor
+
+        {access_code}
+
+        loaded = [module for module in sys.modules if module.startswith("openai")]
+        if loaded:
+            print(f"FAIL: openai loaded ({{len(loaded)}} modules)")
+            sys.exit(1)
+        print("PASS: openai not loaded")
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"openai was eagerly loaded after: {access_code}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_bare_import_does_not_load_openai():
+    _check_openai_not_loaded("pass")
+
+
+def test_from_provider_access_does_not_load_openai():
+    _check_openai_not_loaded("_ = instructor.from_provider")
+
+
+def test_instructor_class_access_does_not_load_openai():
+    _check_openai_not_loaded("_ = instructor.Instructor")
+
+
+def test_mode_access_does_not_load_openai():
+    _check_openai_not_loaded("_ = instructor.Mode")
+
+
+def test_partial_access_does_not_load_openai():
+    _check_openai_not_loaded("_ = instructor.Partial")
+
+
+@pytest.mark.parametrize(
+    "symbol",
+    [
+        "from_provider",
+        "Instructor",
+        "AsyncInstructor",
+        "Mode",
+        "Partial",
+        "Maybe",
+    ],
+)
+def test_core_symbols_accessible_without_openai(symbol: str):
+    script = textwrap.dedent(
+        f"""
+        import instructor
+
+        obj = getattr(instructor, "{symbol}")
+        assert obj is not None
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"Failed to access instructor.{symbol}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/tests/test_openai_responses_tools.py
+++ b/tests/test_openai_responses_tools.py
@@ -1,10 +1,17 @@
+from unittest.mock import MagicMock
+
 from pydantic import BaseModel
 
 from openai import pydantic_function_tool
 
 from instructor.v2.providers.openai.handlers import (
     OpenAIResponsesToolsHandler,
+    reask_responses_tools,
 )
+
+
+def _tool_parameters_schema(model: type[BaseModel]) -> dict:
+    return pydantic_function_tool(model)["function"]["parameters"]
 
 
 class ResponseToolModel(BaseModel):
@@ -13,18 +20,147 @@ class ResponseToolModel(BaseModel):
     name: str
 
 
+class AlternateModel(BaseModel):
+    title: str
+    count: int
+
+
 def test_responses_tools_preserves_function_description() -> None:
     expected_description = pydantic_function_tool(ResponseToolModel)["function"][
         "description"
     ]
 
-    _, responses_tools_kwargs = OpenAIResponsesToolsHandler().prepare_request(
-        ResponseToolModel, {}
-    )
-    _, inbuilt_tools_kwargs = OpenAIResponsesToolsHandler().prepare_request(
-        ResponseToolModel, {}
+    _, kwargs = OpenAIResponsesToolsHandler().prepare_request(ResponseToolModel, {})
+
+    assert kwargs["tools"][0]["description"] == expected_description
+
+
+def test_responses_tools_sets_text_format() -> None:
+    _, kwargs = OpenAIResponsesToolsHandler().prepare_request(ResponseToolModel, {})
+
+    fmt = kwargs["text"]["format"]
+    assert fmt["type"] == "json_schema"
+    assert fmt["name"] == "ResponseToolModel"
+    assert fmt["strict"] is True
+    assert fmt["schema"] == _tool_parameters_schema(ResponseToolModel)
+    assert fmt["schema"].get("additionalProperties") is False
+
+
+def test_responses_tools_overrides_conflicting_text_format() -> None:
+    conflicting_text = {
+        "format": {
+            "type": "json_schema",
+            "name": "AlternateModel",
+            "strict": True,
+            "schema": AlternateModel.model_json_schema(),
+        },
+        "verbosity": "low",
+    }
+
+    _, kwargs = OpenAIResponsesToolsHandler().prepare_request(
+        ResponseToolModel,
+        {"text": conflicting_text},
     )
 
-    assert responses_tools_kwargs["tools"][0]["description"] == expected_description
-    assert inbuilt_tools_kwargs["tools"][0]["description"] == expected_description
-    assert responses_tools_kwargs["tools"][0] == inbuilt_tools_kwargs["tools"][0]
+    fmt = kwargs["text"]["format"]
+    assert fmt["name"] == "ResponseToolModel"
+    assert fmt["schema"] == _tool_parameters_schema(ResponseToolModel)
+    assert kwargs["text"]["verbosity"] == "low"
+    assert kwargs["text"] is not conflicting_text
+
+
+def test_responses_tools_preserves_matching_text_format() -> None:
+    matching_text = {
+        "format": {
+            "type": "json_schema",
+            "name": "ResponseToolModel",
+            "strict": True,
+            "schema": _tool_parameters_schema(ResponseToolModel),
+        }
+    }
+
+    _, kwargs = OpenAIResponsesToolsHandler().prepare_request(
+        ResponseToolModel,
+        {"text": matching_text},
+    )
+
+    assert kwargs["text"] is matching_text
+
+
+def test_responses_tools_none_model_no_text() -> None:
+    _, kwargs = OpenAIResponsesToolsHandler().prepare_request(None, {})
+
+    assert "text" not in kwargs
+
+
+def _make_mock_response(arguments: str | None) -> MagicMock:
+    tool_call = MagicMock()
+    tool_call.type = "function_call"
+    tool_call.arguments = arguments
+    tool_call.name = "ResponseToolModel"
+    tool_call.id = "call_123"
+
+    response = MagicMock()
+    response.output = [tool_call]
+    return response
+
+
+def test_reask_responses_tools_empty_args_message() -> None:
+    response = _make_mock_response("{}")
+    error = ValueError(
+        "1 validation error for ResponseToolModel\nname\n  Field required"
+    )
+
+    result = reask_responses_tools({"messages": []}, response, error)
+
+    msg = result["messages"][0]["content"]
+    assert "empty arguments" in msg
+    assert "MUST populate ALL required fields" in msg
+    assert "fix the errors with" not in msg
+
+
+def test_reask_responses_tools_nonempty_args_message() -> None:
+    response = _make_mock_response('{"name": 123}')
+    error = ValueError(
+        "1 validation error for ResponseToolModel\nname\n  Input should be a valid string"
+    )
+
+    result = reask_responses_tools({"messages": []}, response, error)
+
+    msg = result["messages"][0]["content"]
+    assert "fix the errors with" in msg
+    assert '{"name": 123}' in msg
+
+
+def test_reask_responses_tools_none_arguments() -> None:
+    response = _make_mock_response(None)
+
+    result = reask_responses_tools({"messages": []}, response, ValueError("required"))
+
+    msg = result["messages"][0]["content"]
+    assert "MUST populate ALL required fields" in msg
+
+
+def test_responses_tools_overrides_text_type_format() -> None:
+    _, kwargs = OpenAIResponsesToolsHandler().prepare_request(
+        ResponseToolModel,
+        {"text": {"format": {"type": "text"}}},
+    )
+
+    assert kwargs["text"]["format"]["type"] == "json_schema"
+    assert kwargs["text"]["format"]["name"] == "ResponseToolModel"
+
+
+def test_parse_response_warns_on_empty_args(caplog) -> None:
+    import logging
+
+    response = _make_mock_response("{}")
+    response.choices = []
+
+    with caplog.at_level(logging.WARNING, logger="instructor"):
+        try:
+            OpenAIResponsesToolsHandler().parse_response(response, ResponseToolModel)
+        except Exception:
+            pass
+
+    assert any("empty arguments" in record.message for record in caplog.records)

--- a/uv.lock
+++ b/uv.lock
@@ -1760,7 +1760,7 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.15.4"
+version = "1.15.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- consolidate the focused lazy OpenAI import work from #2390 by moving OpenAI-only imports out of v2 core import paths and adding subprocess regression tests
- fix `list[A | B]` PEP 604 unions of Pydantic models so they prepare as iterable response models, matching `list[Union[A, B]]`
- harden `RESPONSES_TOOLS` by aligning `text.format` with the forced tool schema and adding targeted retry guidance/warnings for empty `{}` tool arguments
- prepare the next patch release as `1.15.5` with changelog, package metadata, and lockfile updates

## Supersedes / Links
- Supersedes #2390
- Supersedes #2377
- Supersedes #2304
- Closes #2300

## Validation
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/test_import_lazy_openai.py tests/dsl/test_simple_types.py tests/test_openai_responses_tools.py -q`
  - `38 passed`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check instructor/__init__.py instructor/v2/core/client.py instructor/v2/core/messages.py instructor/v2/core/patch.py instructor/v2/core/response_model.py instructor/v2/core/usage.py instructor/v2/dsl/iterable.py instructor/v2/providers/openai/handlers.py tests/dsl/test_simple_types.py tests/test_openai_responses_tools.py tests/test_import_lazy_openai.py scripts/benchmark_import.py`
  - `All checks passed!`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run ty check instructor/__init__.py instructor/v2/core/client.py instructor/v2/core/messages.py instructor/v2/core/patch.py instructor/v2/core/response_model.py instructor/v2/core/usage.py instructor/v2/dsl/iterable.py instructor/v2/providers/openai/handlers.py tests/dsl/test_simple_types.py tests/test_openai_responses_tools.py tests/test_import_lazy_openai.py scripts/benchmark_import.py`
  - `All checks passed!`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv lock --check`
  - `Resolved 248 packages`
- pre-commit during commit:
  - Ruff lint and format passed
  - uv.lock check passed
  - dependency install verification passed
  - requirements export passed
  - ty check passed

## Notes
- I preserved existing `text` options when overriding only conflicting `text.format`.
- `uv.lock` diff is intentionally limited to the editable package version bump.
- This PR does not merge, tag, publish, deploy, or post release/tweet copy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch core response-model preparation and OpenAI Responses request shaping, which can alter structured-output behavior for union iterables and conflicting `text.format` configs; import deferral is lower risk but affects load order for edge imports.
> 
> **Overview**
> **Release 1.15.5** bundles three runtime fixes plus metadata and regression coverage.
> 
> **Lazy OpenAI imports in v2 core** — `openai` types and clients move behind `TYPE_CHECKING` or local imports in modules such as `client`, `messages`, `patch`, and `usage`, so importing `instructor` or touching common symbols no longer loads the OpenAI SDK until a Responses-tools client path needs it. Subprocess tests and `scripts/benchmark_import.py` document and guard this behavior.
> 
> **Iterable response models** — `prepare_response_model` and `IterableModel` now recognize PEP 604 unions (`A | B`) alongside `Union[A, B]`, so `list[A | B]` prepares as an iterable schema (e.g. `IterableAOrB`) instead of misrouting through simple-type adapters.
> 
> **OpenAI `RESPONSES_TOOLS`** — request prep sets or overrides `text.format` to match the forced function tool JSON schema (keeping other `text` keys when present), logs a warning on empty `{}` tool arguments, and sends clearer reask prompts when arguments are empty versus partially wrong.
> 
> Version bumps land in `__init__.py`, `pyproject.toml`, `uv.lock`, and `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4682a989d01d44621b80a606d7c725fce1148616. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->