### PR TITLE
fix(v2): derive Iterable name from union members instead of "Union"

### DIFF
--- a/instructor/v2/dsl/iterable.py
+++ b/instructor/v2/dsl/iterable.py
@@ -267,13 +267,15 @@ def IterableModel(
         task_name = name
     else:
         # Handle `Union[A, B]` / `A | B` task types.
-        # `types.UnionType` does not have `__name__`, so fall back to a stable name.
-        task_name = getattr(subtask_class, "__name__", None)
-        if task_name is None and get_origin(subtask_class) in _UNION_ORIGINS:
+        # Both `typing.Union[A, B]` and PEP 604 `A | B` expose ``__name__ == "Union"``
+        # (and `types.UnionType` normalizes to ``typing.Union`` on modern Python), so we
+        # must detect a union *origin* first and build the name from its members --
+        # otherwise every union collapses to the unhelpful ``IterableUnion``.
+        if get_origin(subtask_class) in _UNION_ORIGINS:
             members = get_args(subtask_class)
             task_name = "Or".join(getattr(m, "__name__", str(m)) for m in members)
-        if task_name is None:
-            task_name = str(subtask_class)
+        else:
+            task_name = getattr(subtask_class, "__name__", None) or str(subtask_class)
 
     name = f"Iterable{task_name}"
 

--- a/tests/dsl/test_simple_types.py
+++ b/tests/dsl/test_simple_types.py
@@ -170,3 +170,43 @@ def test_list_of_model_pipe_union_generates_clean_name():
     assert "|" not in prepared.__name__
     assert "." not in prepared.__name__
     assert prepared.__name__ == "IterableAOrB"
+
+
+def test_list_of_model_typing_union_generates_clean_name():
+    """`List[Union[A, B]]` must derive its Iterable name from the union members.
+
+    Both `typing.Union[A, B]` and PEP 604 `A | B` expose ``__name__ == "Union"``, so a
+    naive ``__name__`` lookup collapses every union to ``IterableUnion``. The name should
+    instead be built from the member names (``IterableAOrB``).
+    """
+
+    class A(BaseModel):
+        x: int
+
+    class B(BaseModel):
+        y: str
+
+    prepared = prepare_response_model(List[Union[A, B]])  # noqa: UP006
+    assert prepared is not None
+    assert prepared.__name__ == "IterableAOrB"
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Union pipe syntax is only available in Python 3.10+",
+)
+def test_list_of_model_three_way_union_generates_clean_name():
+    """A union with more than two members joins every member name with ``Or``."""
+
+    class A(BaseModel):
+        x: int
+
+    class B(BaseModel):
+        y: str
+
+    class C(BaseModel):
+        z: float
+
+    prepared = prepare_response_model(list[A | B | C])
+    assert prepared is not None
+    assert prepared.__name__ == "IterableAOrBOrC"


### PR DESCRIPTION
## What this fixes

When building an `Iterable` response model for a **union** task type, the generated class name collapses to `IterableUnion` for both `typing.Union[A, B]` and PEP 604 `A | B`, instead of a member-derived name like `IterableAOrB`.

## Root cause

In `instructor/v2/dsl/iterable.py`, the naming logic was:

```python
# Handle `Union[A, B]` / `A | B` task types.
# `types.UnionType` does not have `__name__`, so fall back to a stable name.
task_name = getattr(subtask_class, "__name__", None)
if task_name is None and get_origin(subtask_class) in _UNION_ORIGINS:
    members = get_args(subtask_class)
    task_name = "Or".join(getattr(m, "__name__", str(m)) for m in members)
if task_name is None:
    task_name = str(subtask_class)
```

The comment's assumption is incorrect: a union type's `__name__` is `"Union"`, **not** `None`. (And on modern Python, `A | B` / `types.UnionType` normalizes to `typing.Union`, whose `__name__` is also `"Union"`.) So `getattr(..., "__name__", None)` returns `"Union"`, the `if task_name is None` guard is never entered, the member-joining branch is skipped, and every union becomes `IterableUnion`.

This affected both union spellings:

```python
prepare_response_model(list[A | B]).__name__          # -> "IterableUnion"  (want IterableAOrB)
prepare_response_model(List[Union[A, B]]).__name__    # -> "IterableUnion"  (want IterableAOrB)
```

## The fix

Detect a union origin **first**, and only fall back to `__name__`/`str()` for non-union types:

```python
if get_origin(subtask_class) in _UNION_ORIGINS:
    members = get_args(subtask_class)
    task_name = "Or".join(getattr(m, "__name__", str(m)) for m in members)
else:
    task_name = getattr(subtask_class, "__name__", None) or str(subtask_class)
```

Result:

| Input | Before | After |
|---|---|---|
| `list[A \| B]` | `IterableUnion` | `IterableAOrB` |
| `List[Union[A, B]]` | `IterableUnion` | `IterableAOrB` |
| `list[A \| B \| C]` | `IterableUnion` | `IterableAOrBOrC` |
| `list[User]` (non-union) | `IterableUser` | `IterableUser` (unchanged) |

## Tests

The existing `test_list_of_model_pipe_union_generates_clean_name` was **failing on `main`** (it asserts `IterableAOrB` but got `IterableUnion`) — this fix makes it pass. I also added two regression tests for the `typing.Union` form and a three-way union.

```
pytest tests/dsl tests/core -k "not test_patch_completes and not test_apatch_completes"
135 passed, 3 skipped
```

(The two deselected tests instantiate `OpenAI()` and require an API key — unrelated to this change; they fail identically on `main`.)

`ruff check` passes on both changed files. `black` reports one pre-existing reformat elsewhere in `iterable.py` that is present on `main` too and is left untouched.

## Type of change
- [x] Bug fix (non-breaking) — improves generated class names for union iterables; non-union names are unchanged.
