### PR TITLE
fix: build proper model instances for Optional[BaseModel] fields during partial streaming

### DIFF
--- a/instructor/v2/dsl/partial.py
+++ b/instructor/v2/dsl/partial.py
@@ -44,6 +44,27 @@ UNION_ORIGINS = (Union, UNION_TYPE) if UNION_TYPE is not None else (Union,)
 _processing_models: set[type] = set()
 
 
+def _unwrap_optional_base_model(annotation: Any) -> type[BaseModel] | None:
+    """Return the BaseModel subclass for a type annotation, unwrapping Optional[T].
+
+    Handles:
+    - Direct BaseModel subclass  →  returns it as-is
+    - ``Optional[T]`` / ``Union[T, None]`` where T is a BaseModel  →  returns T
+    - Arbitrary ``Union`` with multiple non-None args  →  returns None (ambiguous)
+    - Any other annotation  →  returns None
+    """
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+    origin = get_origin(annotation)
+    if origin in UNION_ORIGINS:
+        non_none_args = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if len(non_none_args) == 1:
+            arg = non_none_args[0]
+            if isinstance(arg, type) and issubclass(arg, BaseModel):
+                return arg
+    return None
+
+
 class MakeFieldsOptional:
     pass
 
@@ -150,15 +171,15 @@ def _build_partial_object(
         field_type = field_info.annotation if field_info else None
 
         if field_complete and field_type is not None:
-            if isinstance(field_type, type) and issubclass(field_type, BaseModel):
-                result[field_name] = field_type.model_validate(field_value, **kwargs)
+            _base_model = _unwrap_optional_base_model(field_type)
+            if _base_model is not None:
+                result[field_name] = _base_model.model_validate(field_value, **kwargs)
                 continue
 
         if isinstance(field_value, dict):
-            nested_model = None
-            if field_type is not None and isinstance(field_type, type):
-                if issubclass(field_type, BaseModel):
-                    nested_model = field_type
+            nested_model = (
+                _unwrap_optional_base_model(field_type) if field_type is not None else None
+            )
 
             if nested_model:
                 result[field_name] = _build_partial_object(
@@ -214,10 +235,10 @@ def _build_partial_list(
         item_path = f"{path}[{i}]"
         item_complete = tracker.is_path_complete(item_path)
 
-        if item_complete and item_type and isinstance(item_type, type):
-            if issubclass(item_type, BaseModel) and isinstance(item, dict):
-                result.append(item_type.model_validate(item, **kwargs))
-                continue
+        _item_model = _unwrap_optional_base_model(item_type) if item_type else None
+        if item_complete and _item_model is not None and isinstance(item, dict):
+            result.append(_item_model.model_validate(item, **kwargs))
+            continue
 
         result.append(item)
 

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -1197,3 +1197,86 @@ class TestRecursiveModels:
         assert result.content[0].text == "Introduction paragraph"
         assert result.content[1].title == "Section 1.1"
         assert result.content[1].content[1].title == "Subsection 1.1.1"
+
+
+class TestOptionalNestedBaseModelDuringPartialStreaming:
+    """Regression tests for Optional[BaseModel] field handling during partial streaming.
+
+    When the root JSON is incomplete (stream still in flight), _build_partial_object()
+    is called instead of model_validate().  Fields annotated as ``Optional[NestedModel]``
+    (equivalently ``Union[NestedModel, None]``) used to be stored as raw ``dict`` objects
+    because the guard ``isinstance(field_type, type)`` returns False for generic aliases
+    like ``Optional[NestedModel]``.
+
+    The fix adds ``_unwrap_optional_base_model()`` which unwraps the Optional wrapper, so
+    callers get proper model instances with attribute access instead of plain dicts.
+    """
+
+    def test_optional_nested_basemodel_is_model_instance_during_incomplete_stream(self):
+        """Optional[NestedModel] fields must yield NestedModel instances, not raw dicts."""
+
+        class Inner(BaseModel):
+            value: int
+
+        class Outer(BaseModel):
+            name: str
+            inner: Optional[Inner] = None
+
+        partial = Partial[Outer]
+
+        # Incomplete JSON — root closing brace is missing, so _build_partial_object runs
+        chunks = ['{"name": "alice", "inner": {"value": 42}']
+
+        results = list(_partial_api(partial).model_from_chunks(chunks))
+        assert len(results) == 1
+        obj = results[0]
+
+        # Before the fix: obj.inner was a plain dict {"value": 42}
+        assert isinstance(obj.inner, Inner), (
+            f"Expected Inner instance, got {type(obj.inner)}: {obj.inner!r}"
+        )
+        assert obj.inner.value == 42
+
+    def test_optional_nested_basemodel_attribute_access_does_not_raise(self):
+        """Attribute access on an Optional[BaseModel] field must not raise AttributeError."""
+
+        class Address(BaseModel):
+            city: str
+            zip_code: str
+
+        class Person(BaseModel):
+            name: str
+            address: Optional[Address] = None
+
+        partial = Partial[Person]
+
+        # Root still open — simulates mid-stream state
+        chunks = ['{"name": "bob", "address": {"city": "NYC", "zip_code": "10001"}']
+
+        results = list(_partial_api(partial).model_from_chunks(chunks))
+        obj = results[-1]
+
+        # Would raise AttributeError on a raw dict before the fix
+        assert obj.address.city == "NYC"
+        assert obj.address.zip_code == "10001"
+
+    def test_optional_nested_basemodel_absent_field_stays_none(self):
+        """When the Optional[BaseModel] field is absent, its default (None) must not change."""
+
+        class Inner(BaseModel):
+            value: int
+
+        class Outer(BaseModel):
+            name: str
+            inner: Optional[Inner] = None
+
+        partial = Partial[Outer]
+
+        # inner field completely absent; root also incomplete
+        chunks = ['{"name": "carol"']
+
+        results = list(_partial_api(partial).model_from_chunks(chunks))
+        obj = results[-1]
+
+        # Must remain None — not an empty Inner() instance
+        assert obj.inner is None


### PR DESCRIPTION
## Problem

When streaming a `Partial[Model]` and the root JSON is still open (i.e. the
LLM hasn't closed the outer `}`), `_build_partial_object()` is called for
every chunk.  Fields annotated as `Optional[NestedModel]` (equivalently
`Union[NestedModel, None]`) were silently stored as raw `dict` objects instead
of `NestedModel` instances, because the guard used was:

```python
isinstance(field_type, type) and issubclass(field_type, BaseModel)
```

`Optional[NestedModel]` is a generic alias (`typing.Union[NestedModel, None]`),
not a `type`, so `isinstance` returns `False` and the dict falls through
unprocessed.  The symptom is an `AttributeError` when user code accesses
`chunk.inner.some_field` mid-stream.

This asymmetry is clearly a bug: a field typed `inner: Inner` correctly yields
a partial `Inner` instance during incomplete streaming, while `inner:
Optional[Inner]` yields a raw `dict`.

## Fix

Add a helper `_unwrap_optional_base_model(annotation)` that:

- Returns the class directly for a plain `BaseModel` subclass annotation.
- Unwraps `Optional[T]` / `Union[T, None]` (exactly **one** non-`None` arg
  that is a `BaseModel` subclass) and returns `T`.
- Returns `None` for all other annotations, including multi-member `Union`s
  (to avoid ambiguity about which branch to validate against).

Replace the three affected `isinstance(field_type, type)` guards in
`_build_partial_object` (complete-field path and dict-recurse path) and
`_build_partial_list` with this helper.

The **missing-fields** branch in `_build_partial_object` is intentionally left
unchanged: an absent `Optional[Inner]` field should remain `None` (its
default), not become an empty `Inner()` instance.

## Tests

Three new regression tests in `TestOptionalNestedBaseModelDuringPartialStreaming`:

1. `Optional[Inner]` present during an incomplete-root stream yields an `Inner`
   instance, not a `dict`.
2. Attribute access on that instance works without raising `AttributeError`.
3. When the `Optional[Inner]` field is absent altogether, the value remains
   `None` (default-contract preserved).

All 49 unit tests pass (`46` pre-existing + `3` new), `2` skipped
(require `OPENAI_API_KEY`).