### PR TITLE
fix(schema): don't mark default_factory fields as required in generate_openai_schema

### DIFF
--- a/instructor/v2/providers/openai/schema.py
+++ b/instructor/v2/providers/openai/schema.py
@@ -23,9 +23,12 @@ def generate_openai_schema(model: type[BaseModel]) -> dict[str, Any]:
             if "description" not in parameters["properties"][name]:
                 parameters["properties"][name]["description"] = description
 
-    parameters["required"] = sorted(
-        k for k, v in parameters["properties"].items() if "default" not in v
-    )
+    # Reuse Pydantic's own required set, which excludes any field that has a
+    # default -- whether that default is a plain value (``default=``) or a
+    # ``default_factory=``. Deriving it from the presence of a ``"default"``
+    # key in each property missed default_factory fields (whose defaults are
+    # never emitted into the JSON schema) and wrongly marked them required.
+    parameters["required"] = sorted(schema.get("required", []))
 
     if "description" not in schema:
         schema["description"] = (

--- a/tests/core/test_schema_utils.py
+++ b/tests/core/test_schema_utils.py
@@ -147,6 +147,23 @@ def test_required_fields_generation():
     assert "email" not in required
 
 
+def test_default_factory_fields_not_required():
+    """Fields with a default_factory have a default and must not be required."""
+
+    class ModelWithFactory(BaseModel):
+        name: str
+        items: list[str] = Field(default_factory=list)
+        tags: dict[str, str] = Field(default_factory=dict)
+
+    schema = generate_openai_schema(ModelWithFactory)
+    required = schema["parameters"]["required"]
+
+    # Only ``name`` has no default; the default_factory fields are optional.
+    assert required == ["name"]
+    # And it should agree with Pydantic's own required set.
+    assert set(required) == set(ModelWithFactory.model_json_schema().get("required", []))
+
+
 def test_field_descriptions():
     """Test that field descriptions are preserved."""
     schema = generate_openai_schema(TestModel)


### PR DESCRIPTION
## Describe your changes

`generate_openai_schema` computed the `required` list itself instead of using the one Pydantic already produces:

```python
parameters["required"] = sorted(
    k for k, v in parameters["properties"].items() if "default" not in v
)
```

Pydantic does not emit a `"default"` key for fields declared with `default_factory=`, so those fields have no `"default"` in their property schema and were incorrectly marked required. Fields with a plain `default=` are excluded correctly, which makes the treatment of `default_factory` inconsistent — a `default_factory` field is optional just like a `default` field.

Concretely:

```python
class M(BaseModel):
    name: str
    items: list[str] = Field(default_factory=list)
    tags: dict[str, str] = Field(default_factory=dict)

generate_openai_schema(M)["parameters"]["required"]
# before: ['items', 'name', 'tags']   (items/tags wrongly required)
# after:  ['name']
M.model_json_schema()["required"]
# ['name']
```

The generated function/tool schema is what tells the model which fields it must produce, so this told the model that fields with defaults were mandatory.

Fix: derive `required` from Pydantic's own `schema["required"]`, which already excludes both `default=` and `default_factory=` fields and uses the same (alias-aware) property keys.

Verified consistent with aliased fields — the required entry uses the alias key, matching `properties`, matching `model_json_schema()`.

Test added to `tests/core/test_schema_utils.py` (`test_default_factory_fields_not_required`). It fails on `main`:

```
assert ['items', 'name', 'tags'] == ['name']
```

and passes with this change. Run:

```
pytest tests/core/test_schema_utils.py -q
```

The existing `test_required_fields_generation` and the rest of `tests/core/test_schema*` / `tests/dsl` still pass.

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.