### PR TITLE
fix(openai): derive input_audio format from media type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - **Templating**: Use populated `contents` when `messages` is empty, avoid mutating nested caller input, and preserve uncopyable metadata during template expansion.
 - **Anthropic system messages**: Reject invalid new system-message values even when no existing system message is present.
 - **Python 3.9**: Include the required type-evaluation backport in minimal installs, keep overload metadata available, and avoid runtime evaluation of unsupported union syntax in the core response path and offline tests.
+- **OpenAI**: Send the correct `input_audio.format` for audio content by deriving it from the audio's media type (e.g. mp3) instead of always sending `"wav"`, so non-WAV audio is no longer mislabeled. ([#2415](https://github.com/567-labs/instructor/pull/2415))
 
 ### Tests / CI
 - **Coverage and test quality**: Run the complete offline suite on Python 3.9-3.13, enforce fork-safe statement and branch coverage plus supported-version type checks in pull-request CI, add strict resource and thread warning checks, and provide a manual retry-mutation workflow. Consolidate typed response, stream, and SDK fixtures; remove duplicate tests and unreachable provider paths; and replace coverage-only stubs with meaningful edge-case and transport-backed provider checks.

--- a/instructor/v2/providers/openai/multimodal.py
+++ b/instructor/v2/providers/openai/multimodal.py
@@ -39,7 +39,17 @@ def image_to_openai(image: Any, mode: Mode) -> dict[str, Any]:
 def audio_to_openai(audio: Any, mode: Mode) -> dict[str, Any]:
     if mode in RESPONSES_MODES:
         raise ValueError("OpenAI Responses doesn't support audio")
-    return {"type": "input_audio", "input_audio": {"data": audio.data, "format": "wav"}}
+    # OpenAI Chat Completions `input_audio` only accepts "wav" or "mp3", so pick
+    # the format from the audio's media type instead of assuming WAV; otherwise
+    # an mp3 (media_type "audio/mpeg") is sent mislabeled as "wav".
+    media_type = (getattr(audio, "media_type", "") or "").lower()
+    audio_format = (
+        "mp3" if media_type in {"audio/mp3", "audio/mpeg", "audio/mpga"} else "wav"
+    )
+    return {
+        "type": "input_audio",
+        "input_audio": {"data": audio.data, "format": audio_format},
+    }
 
 
 def pdf_to_openai(pdf: Any, mode: Mode) -> dict[str, Any]:

--- a/tests/v2/test_core_multimodal_runtime.py
+++ b/tests/v2/test_core_multimodal_runtime.py
@@ -218,3 +218,15 @@ def test_audio_from_path_normalizes_windows_wav_and_aac_mime_types(
 
     assert wav_audio.media_type == "audio/wav"
     assert aac_audio.media_type == "audio/aac"
+
+
+def test_audio_to_openai_format_follows_media_type() -> None:
+    from instructor.v2.providers.openai.multimodal import audio_to_openai
+
+    # OpenAI Chat Completions `input_audio` only accepts "wav" or "mp3", so the
+    # format must follow the audio's media type rather than always being "wav".
+    mp3 = Audio(source="clip.mp3", media_type="audio/mpeg", data="ZmFrZQ==")
+    assert audio_to_openai(mp3, Mode.TOOLS)["input_audio"]["format"] == "mp3"
+
+    wav = Audio(source="clip.wav", media_type="audio/wav", data="ZmFrZQ==")
+    assert audio_to_openai(wav, Mode.TOOLS)["input_audio"]["format"] == "wav"


### PR DESCRIPTION
### Problem

`audio_to_openai` always sets `input_audio.format` to `"wav"`, ignoring the audio's `media_type`:

```python
def audio_to_openai(audio: Any, mode: Mode) -> dict[str, Any]:
    if mode in RESPONSES_MODES:
        raise ValueError("OpenAI Responses doesn't support audio")
    return {"type": "input_audio", "input_audio": {"data": audio.data, "format": "wav"}}
```

OpenAI Chat Completions `input_audio.format` only accepts `"wav"` or `"mp3"`. `Audio` accepts many audio MIME types (`VALID_AUDIO_MIME_TYPES`), and `Audio.from_path("clip.mp3")` stores `media_type="audio/mpeg"` (`mimetypes.guess_type` maps `.mp3` to `audio/mpeg`). So an mp3 gets sent labeled `"wav"` and is rejected or mis-decoded. The sibling `image_to_openai` and `pdf_to_openai` already read `media_type`; only the audio handler ignored it.

### Fix

Derive the format from `audio.media_type`: map the mp3 media types (`audio/mp3`, `audio/mpeg`, `audio/mpga`) to `"mp3"`, and default to `"wav"` otherwise (the two formats OpenAI Chat Completions supports; `"wav"` is the safe default and is no worse than today for the rarer types). WAV audio is unchanged.

### Test

`test_audio_to_openai_format_follows_media_type` asserts an `audio/mpeg` input yields `format == "mp3"` and an `audio/wav` input yields `format == "wav"`. It fails on the current code (mp3 comes back as `"wav"`) and passes with this change.
