### PR TITLE
fix(v2): stop OpenAI-compat handlers from mutating caller's messages list

### DIFF
--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -19,6 +19,25 @@ def extract_messages(kwargs: dict[str, Any]) -> Any:
     return []
 
 
+def copy_messages_for_mutation(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return a copy of `messages` that is safe to mutate in place.
+
+    Handlers that inject a system/instruction message do so by mutating a
+    `messages` list and its dict elements directly (`.insert()`, `.append()`,
+    `message["content"] += ...`). Since `kwargs.copy()` is shallow, `messages`
+    is otherwise the exact list (and dict) objects the caller passed in, so
+    those in-place edits would corrupt the caller's own conversation state.
+    """
+    copied = [dict(message) for message in messages]
+    for message in copied:
+        content = message.get("content")
+        if isinstance(content, list):
+            message["content"] = [
+                dict(item) if isinstance(item, dict) else item for item in content
+            ]
+    return copied
+
+
 def dump_message(message: ChatCompletionMessage) -> ChatCompletionMessageParam:
     ret: ChatCompletionMessageParam = {
         "role": message.role,

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -607,6 +607,7 @@ class OpenAIToolsHandler(OpenAIHandlerBase):
     ) -> tuple[Any, dict[str, Any]]:
         """Prepare request with tool definitions."""
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
 
         if response_model is None:
             return None, new_kwargs
@@ -732,6 +733,7 @@ class OpenAIJSONSchemaHandler(OpenAIHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         schema = response_model.model_json_schema()
         new_kwargs["response_format"] = {
             "type": "json_schema",
@@ -995,6 +997,7 @@ class OpenAIParallelToolsHandler(OpenAIHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         if new_kwargs.get("stream", False):
             raise ConfigurationError(
                 "stream=True is not supported when using PARALLEL_TOOLS mode"
@@ -1074,6 +1077,7 @@ class OpenAIResponsesToolsHandler(OpenAIHandlerBase):
         self._register_streaming_from_kwargs(response_model, kwargs)
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
 
         # Handle max_tokens to max_output_tokens conversion
         if new_kwargs.get("max_tokens") is not None:

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -41,7 +41,11 @@ from instructor.v2.core.json import (
     extract_json_from_stream,
     extract_json_from_stream_async,
 )
-from instructor.v2.core.messages import dump_message, merge_consecutive_messages
+from instructor.v2.core.messages import (
+    copy_messages_for_mutation,
+    dump_message,
+    merge_consecutive_messages,
+)
 from instructor.v2.providers.openai.schema import generate_openai_schema
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.core.handler import ModeHandler
@@ -819,7 +823,7 @@ class OpenAIJSONHandler(OpenAIHandlerBase):
             Make sure to return an instance of the JSON, not the schema itself
             """
         )
-        messages = new_kwargs.get("messages", [])
+        messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
         if messages and messages[0]["role"] != "system":
             messages.insert(
                 0,
@@ -909,7 +913,7 @@ class OpenAIMDJSONHandler(OpenAIHandlerBase):
         )
 
         # Add system message with schema
-        messages = new_kwargs.get("messages", [])
+        messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
         if messages and messages[0]["role"] != "system":
             messages.insert(
                 0,

--- a/tests/v2/test_messages_not_mutated.py
+++ b/tests/v2/test_messages_not_mutated.py
@@ -1,9 +1,20 @@
 """Regression tests for the messages= aliasing bug (see GitHub issue #2417).
 
 `client.create()` must treat `messages=` as a read-only input. Internally,
-`prepare_request` must never hand back the caller's own list object (or leave
-the caller's message dicts open to in-place mutation during a reask), because
-`handle_reask` appends retry artifacts onto whatever list it is given.
+`prepare_request` must never hand back the caller's own list object, or
+leave the caller's message dicts open to in-place mutation, because both
+`prepare_request` itself (JSON/MD_JSON's system-message injection) and
+`handle_reask` (the retry path) mutate whatever `messages` list/dicts they
+are handed.
+
+Note on the aliasing check: comparing `new_kwargs["messages"] is not
+caller_messages` alone is not sufficient -- `OpenAIJSONHandler` and
+`OpenAIMDJSONHandler` mutate the *input* list/dicts in place before
+rebuilding `messages` into a genuinely new list via
+`merge_consecutive_messages()`, so an identity check on the final result
+would pass even though the caller's original objects were already
+corrupted. These tests instead snapshot `caller_messages` with `deepcopy`
+before the call and assert it is unchanged afterward.
 
 The provider lists below are imported directly from the shared OpenAI-compat
 handler module so this test stays in sync with the source registrations
@@ -12,6 +23,7 @@ rather than duplicating them.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any, Iterable
 
 import pytest
@@ -46,6 +58,8 @@ FIXED_PAIRS: list[tuple[Provider, Mode]] = [
     *((provider, Mode.TOOLS) for provider in OPENAI_COMPAT_PROVIDERS),
     *((provider, Mode.JSON_SCHEMA) for provider in OPENAI_JSON_SCHEMA_PROVIDERS),
     *((provider, Mode.PARALLEL_TOOLS) for provider in OPENAI_PARALLEL_TOOL_PROVIDERS),
+    *((provider, Mode.JSON) for provider in OPENAI_COMPAT_PROVIDERS),
+    *((provider, Mode.MD_JSON) for provider in OPENAI_COMPAT_PROVIDERS),
     (Provider.OPENAI, Mode.RESPONSES_TOOLS),
 ]
 
@@ -71,6 +85,7 @@ def test_prepare_request_does_not_alias_caller_messages(
     provider: Provider, mode: Mode
 ) -> None:
     caller_messages = [{"role": "user", "content": "hi"}]
+    original_snapshot = deepcopy(caller_messages)
     kwargs: dict[str, Any] = {"model": "test", "messages": caller_messages}
     response_model = Iterable[Answer] if mode is Mode.PARALLEL_TOOLS else Answer
 
@@ -80,7 +95,10 @@ def test_prepare_request_does_not_alias_caller_messages(
     )
 
     assert new_kwargs["messages"] is not caller_messages
-    assert caller_messages == [{"role": "user", "content": "hi"}]
+    # Deep-content check, not just identity: a handler can rebuild
+    # `new_kwargs["messages"]` into a fresh list while still having mutated
+    # the caller's original list/dicts in place before doing so.
+    assert caller_messages == original_snapshot
 
 
 @pytest.mark.parametrize(

--- a/tests/v2/test_messages_not_mutated.py
+++ b/tests/v2/test_messages_not_mutated.py
@@ -1,0 +1,161 @@
+"""Regression tests for the messages= aliasing bug (see GitHub issue #2417).
+
+`client.create()` must treat `messages=` as a read-only input. Internally,
+`prepare_request` must never hand back the caller's own list object (or leave
+the caller's message dicts open to in-place mutation during a reask), because
+`handle_reask` appends retry artifacts onto whatever list it is given.
+
+The provider lists below are imported directly from the shared OpenAI-compat
+handler module so this test stays in sync with the source registrations
+rather than duplicating them.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+from openai.types.completion_usage import CompletionUsage
+from pydantic import BaseModel
+
+from instructor.v2.core.mode import Mode
+from instructor.v2.core.providers import Provider
+from instructor.v2.core.registry import mode_registry
+from instructor.v2.core.retry import retry_sync_v2
+from instructor.v2.providers.openai.handlers import (
+    OPENAI_COMPAT_PROVIDERS,
+    OPENAI_JSON_SCHEMA_PROVIDERS,
+    OPENAI_PARALLEL_TOOL_PROVIDERS,
+)
+
+
+class Answer(BaseModel):
+    name: str
+    age: int
+
+
+# (provider, mode) pairs whose shared OpenAI-compat handler classes were
+# patched to stop aliasing `messages`.
+FIXED_PAIRS: list[tuple[Provider, Mode]] = [
+    *((provider, Mode.TOOLS) for provider in OPENAI_COMPAT_PROVIDERS),
+    *((provider, Mode.JSON_SCHEMA) for provider in OPENAI_JSON_SCHEMA_PROVIDERS),
+    *((provider, Mode.PARALLEL_TOOLS) for provider in OPENAI_PARALLEL_TOOL_PROVIDERS),
+    (Provider.OPENAI, Mode.RESPONSES_TOOLS),
+]
+
+# Independently-implemented handlers that reproduce the same anti-pattern in
+# their own provider-specific code and are not touched by this fix. Tracked
+# here so a future fix flips these from xfail to passing instead of the
+# regression silently going unnoticed.
+KNOWN_STILL_BROKEN_PAIRS: list[tuple[Provider, Mode]] = [
+    (Provider.MISTRAL, Mode.TOOLS),
+    (Provider.COHERE, Mode.JSON_SCHEMA),
+    (Provider.WRITER, Mode.TOOLS),
+    (Provider.XAI, Mode.TOOLS),
+    (Provider.OPENROUTER, Mode.JSON_SCHEMA),
+]
+
+
+@pytest.mark.parametrize(
+    ("provider", "mode"),
+    FIXED_PAIRS,
+    ids=[f"{provider.value}-{mode.value}" for provider, mode in FIXED_PAIRS],
+)
+def test_prepare_request_does_not_alias_caller_messages(
+    provider: Provider, mode: Mode
+) -> None:
+    caller_messages = [{"role": "user", "content": "hi"}]
+    kwargs: dict[str, Any] = {"model": "test", "messages": caller_messages}
+    response_model = Iterable[Answer] if mode is Mode.PARALLEL_TOOLS else Answer
+
+    handlers = mode_registry.get_handlers(provider, mode)
+    _, new_kwargs = handlers.request_handler(
+        response_model=response_model, kwargs=kwargs
+    )
+
+    assert new_kwargs["messages"] is not caller_messages
+    assert caller_messages == [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.parametrize(
+    ("provider", "mode"),
+    KNOWN_STILL_BROKEN_PAIRS,
+    ids=[f"{provider.value}-{mode.value}" for provider, mode in KNOWN_STILL_BROKEN_PAIRS],
+)
+@pytest.mark.xfail(
+    reason="Independently-implemented handler still aliases messages; "
+    "tracked in issue #2417 (Category 2/3), not yet fixed.",
+    strict=True,
+)
+def test_known_still_broken_pairs_are_fixed(provider: Provider, mode: Mode) -> None:
+    caller_messages = [{"role": "user", "content": "hi"}]
+    kwargs: dict[str, Any] = {"model": "test", "messages": caller_messages}
+
+    handlers = mode_registry.get_handlers(provider, mode)
+    _, new_kwargs = handlers.request_handler(response_model=Answer, kwargs=kwargs)
+
+    assert new_kwargs["messages"] is not caller_messages
+
+
+def _make_tool_call_response(arguments: str, call_id: str) -> ChatCompletion:
+    tool_call = ChatCompletionMessageToolCall(
+        id=call_id,
+        type="function",
+        function=Function(name="Answer", arguments=arguments),
+    )
+    message = ChatCompletionMessage(
+        role="assistant", content=None, tool_calls=[tool_call]
+    )
+    choice = Choice(index=0, message=message, finish_reason="tool_calls", logprobs=None)
+    return ChatCompletion(
+        id="chatcmpl-test",
+        choices=[choice],
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        usage=CompletionUsage(completion_tokens=5, prompt_tokens=10, total_tokens=15),
+    )
+
+
+def test_client_create_does_not_mutate_caller_messages_after_reask() -> None:
+    """End-to-end: a validation failure followed by a successful retry must
+    leave the caller's original `messages` list completely untouched."""
+    call_count = {"n": 0}
+
+    def fake_openai_create(*_args: Any, **_kwargs: Any) -> ChatCompletion:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _make_tool_call_response('{"name": "Ada"}', "call_1")
+        return _make_tool_call_response('{"name": "Ada", "age": 37}', "call_2")
+
+    caller_messages = [{"role": "user", "content": "Ada is 37 years old"}]
+
+    handlers = mode_registry.get_handlers(Provider.OPENAI, Mode.TOOLS)
+    response_model, new_kwargs = handlers.request_handler(
+        response_model=Answer,
+        kwargs={"model": "gpt-4o-mini", "messages": caller_messages},
+    )
+
+    result = retry_sync_v2(
+        func=fake_openai_create,
+        response_model=response_model,
+        provider=Provider.OPENAI,
+        mode=Mode.TOOLS,
+        context=None,
+        max_retries=2,
+        args=(),
+        kwargs=new_kwargs,
+        strict=True,
+        hooks=None,
+    )
+
+    assert isinstance(result, Answer)
+    assert result.name == "Ada"
+    assert result.age == 37
+    assert caller_messages == [{"role": "user", "content": "Ada is 37 years old"}]


### PR DESCRIPTION
## Summary
- Fixes #2417: `client.create()` was mutating the caller's own `messages` list (and, in some cases, the message dicts inside it) in place, on the OpenAI-compat handlers.
- Two related root causes, both from the same `kwargs.copy()`-is-shallow mistake:
  1. **Reask-time list aliasing** (`Mode.TOOLS`, `Mode.JSON_SCHEMA`, `Mode.PARALLEL_TOOLS`, `Mode.RESPONSES_TOOLS`): `prepare_request` never rebound `new_kwargs["messages"]` to a new list, so `handle_reask` appended retry artifacts directly onto the caller's original list object.
  2. **First-call dict/list mutation** (`Mode.JSON`, `Mode.MD_JSON`): `prepare_request` injects a system/instruction message by mutating the `messages` list and its dict elements directly (`.insert()`, `.append()`, `message["content"] += ...`) *before* rebuilding into a fresh list via `merge_consecutive_messages()`. This one is worse — it corrupts the caller's state on every call, not just ones that hit a validation reask. (I initially and incorrectly marked these two modes "unaffected" in the issue; see the correction there and in this PR's comments.)
- Fix:
  - For (1): rebind `messages` to a fresh list right after the shallow copy, in `OpenAIToolsHandler`, `OpenAIJSONSchemaHandler`, `OpenAIParallelToolsHandler`, and `OpenAIResponsesToolsHandler`.
  - For (2): added `copy_messages_for_mutation()` (`instructor/v2/core/messages.py`), which copies the list and any dict elements (plus their `content` list items) before the in-place edits run. Used by `OpenAIJSONHandler` and `OpenAIMDJSONHandler`.
- Because all six of these handler classes are registered for multiple providers at once (`OPENAI_COMPAT_PROVIDERS` / `OPENAI_JSON_SCHEMA_PROVIDERS` / `OPENAI_PARALLEL_TOOL_PROVIDERS`), this fixes Anyscale, Together, Databricks, Deepseek, OpenRouter, Groq, Fireworks, and Cerebras too — 9 providers total from one focused diff.

## Scope note
The same anti-pattern is independently reproduced in provider-specific handlers that don't share these classes: Mistral (`Mode.TOOLS`, plus a first-call `Mode.MD_JSON` dict-mutation case matching (2) above), Cohere (`Mode.JSON_SCHEMA`, plus a first-call `Mode.MD_JSON` case), Writer (`Mode.TOOLS`), xAI (`Mode.TOOLS`), and OpenRouter's own `Mode.JSON_SCHEMA` override. Documented in #2417, intentionally left out of this PR to keep the diff reviewable — happy to follow up, or fold them in here, whichever's preferred.

## Test plan
- [x] `tests/v2/test_messages_not_mutated.py`:
  - Parametrized test over every `(provider, mode)` pair fixed by this PR (now including `Mode.JSON`/`Mode.MD_JSON`), snapshotting the caller's `messages` with `deepcopy` before the call and asserting it's byte-for-byte unchanged after — an identity-only check on the returned list is not sufficient for case (2) above, since the input can be mutated before being rebuilt into a new list.
  - An end-to-end test replaying a real validation-failure-then-success cycle through `retry_sync_v2`, asserting the caller's original list is unchanged afterward.
  - `xfail(strict=True)` cases documenting the still-broken Mistral/Cohere/Writer/xAI/OpenRouter pairs.
- [x] `pytest tests/v2/` — 1549 passed, 179 skipped (missing optional provider SDKs), 5 xfailed, 0 failed.
- [x] `pytest tests/` (excluding `tests/v2` and `tests/llm/test_vertexai`) — same 85 pre-existing failures as unpatched `main` (verified via `git stash`; all need live API credentials or are docs-snippet tests, unrelated to this change).
