### PR TITLE
fix(v2): stop Mistral/Cohere/Writer/xAI/OpenRouter from mutating caller's messages

### DIFF
--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -19,6 +19,25 @@ def extract_messages(kwargs: dict[str, Any]) -> Any:
     return []
 
 
+def copy_messages_for_mutation(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return a copy of `messages` that is safe to mutate in place.
+
+    Handlers that inject a system/instruction message do so by mutating a
+    `messages` list and its dict elements directly (`.insert()`, `.append()`,
+    `message["content"] += ...`). Since `kwargs.copy()` is shallow, `messages`
+    is otherwise the exact list (and dict) objects the caller passed in, so
+    those in-place edits would corrupt the caller's own conversation state.
+    """
+    copied = [dict(message) for message in messages]
+    for message in copied:
+        content = message.get("content")
+        if isinstance(content, list):
+            message["content"] = [
+                dict(item) if isinstance(item, dict) else item for item in content
+            ]
+    return copied
+
+
 def dump_message(message: ChatCompletionMessage) -> ChatCompletionMessageParam:
     ret: ChatCompletionMessageParam = {
         "role": message.role,

--- a/instructor/v2/providers/cohere/handlers.py
+++ b/instructor/v2/providers/cohere/handlers.py
@@ -21,6 +21,7 @@ from instructor.v2.core.errors import ConfigurationError, ResponseParsingError
 from instructor.v2.core.json import extract_json_from_codeblock
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.core.handler import ModeHandler
+from instructor.v2.core.messages import copy_messages_for_mutation
 from instructor.v2.dsl.iterable import IterableBase
 from instructor.v2.dsl.partial import PartialBase
 
@@ -70,6 +71,8 @@ def _convert_messages_to_cohere_v2(kwargs: dict[str, Any]) -> dict[str, Any]:
     """Clean up kwargs for Cohere V2 format (OpenAI-compatible)."""
     new_kwargs = kwargs.copy()
     new_kwargs.pop("_cohere_client_version", None)
+    if "messages" in new_kwargs:
+        new_kwargs["messages"] = copy_messages_for_mutation(new_kwargs["messages"])
 
     # Rename model_name to model if needed
     if "model_name" in new_kwargs and "model" not in new_kwargs:

--- a/instructor/v2/providers/mistral/handlers.py
+++ b/instructor/v2/providers/mistral/handlers.py
@@ -43,7 +43,11 @@ from instructor.v2.core.json import (
     extract_json_from_stream_async,
 )
 from instructor.v2.providers.openai.schema import generate_openai_schema
-from instructor.v2.core.messages import dump_message, merge_consecutive_messages
+from instructor.v2.core.messages import (
+    copy_messages_for_mutation,
+    dump_message,
+    merge_consecutive_messages,
+)
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.core.handler import ModeHandler
 
@@ -252,6 +256,7 @@ class MistralToolsHandler(MistralHandlerBase):
     ) -> tuple[type[BaseModel] | None, dict[str, Any]]:
         """Prepare request with tool definitions."""
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
 
         if response_model is None:
             return None, new_kwargs
@@ -394,6 +399,7 @@ class MistralJSONSchemaHandler(MistralHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
 
         # Use Mistral's helper to create response format
         from mistralai.extra import response_format_from_pydantic_model
@@ -500,7 +506,7 @@ class MistralMDJSONHandler(MistralHandlerBase):
         )
 
         # Add system message with schema
-        messages = new_kwargs.get("messages", [])
+        messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
         if messages and messages[0]["role"] != "system":
             messages.insert(
                 0,

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -607,6 +607,7 @@ class OpenAIToolsHandler(OpenAIHandlerBase):
     ) -> tuple[Any, dict[str, Any]]:
         """Prepare request with tool definitions."""
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
 
         if response_model is None:
             return None, new_kwargs
@@ -732,6 +733,7 @@ class OpenAIJSONSchemaHandler(OpenAIHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         schema = response_model.model_json_schema()
         new_kwargs["response_format"] = {
             "type": "json_schema",
@@ -995,6 +997,7 @@ class OpenAIParallelToolsHandler(OpenAIHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         if new_kwargs.get("stream", False):
             raise ConfigurationError(
                 "stream=True is not supported when using PARALLEL_TOOLS mode"
@@ -1074,6 +1077,7 @@ class OpenAIResponsesToolsHandler(OpenAIHandlerBase):
         self._register_streaming_from_kwargs(response_model, kwargs)
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
 
         # Handle max_tokens to max_output_tokens conversion
         if new_kwargs.get("max_tokens") is not None:

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -41,7 +41,11 @@ from instructor.v2.core.json import (
     extract_json_from_stream,
     extract_json_from_stream_async,
 )
-from instructor.v2.core.messages import dump_message, merge_consecutive_messages
+from instructor.v2.core.messages import (
+    copy_messages_for_mutation,
+    dump_message,
+    merge_consecutive_messages,
+)
 from instructor.v2.providers.openai.schema import generate_openai_schema
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.core.handler import ModeHandler
@@ -819,7 +823,7 @@ class OpenAIJSONHandler(OpenAIHandlerBase):
             Make sure to return an instance of the JSON, not the schema itself
             """
         )
-        messages = new_kwargs.get("messages", [])
+        messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
         if messages and messages[0]["role"] != "system":
             messages.insert(
                 0,
@@ -909,7 +913,7 @@ class OpenAIMDJSONHandler(OpenAIHandlerBase):
         )
 
         # Add system message with schema
-        messages = new_kwargs.get("messages", [])
+        messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
         if messages and messages[0]["role"] != "system":
             messages.insert(
                 0,

--- a/instructor/v2/providers/openrouter/handlers.py
+++ b/instructor/v2/providers/openrouter/handlers.py
@@ -33,6 +33,7 @@ class OpenRouterJSONSchemaHandler(OpenAIJSONSchemaHandler):
         if response_model is None:
             return None, kwargs
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         return handle_openrouter_structured_outputs(response_model, new_kwargs)
 
     def handle_reask(

--- a/instructor/v2/providers/writer/handlers.py
+++ b/instructor/v2/providers/writer/handlers.py
@@ -20,7 +20,11 @@ from instructor.v2.core.providers import Provider
 from instructor.v2.core.errors import IncompleteOutputException
 from instructor.v2.core.json import extract_json_from_codeblock
 from instructor.v2.providers.openai.schema import generate_openai_schema
-from instructor.v2.core.messages import dump_message, merge_consecutive_messages
+from instructor.v2.core.messages import (
+    copy_messages_for_mutation,
+    dump_message,
+    merge_consecutive_messages,
+)
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.providers.openai.handlers import OpenAIHandlerBase
 
@@ -142,6 +146,7 @@ class WriterToolsHandler(WriterHandlerBase):
         self._register_streaming_from_kwargs(response_model, kwargs)
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         schema = generate_openai_schema(response_model)
 
         new_kwargs["tools"] = [{"type": "function", "function": schema}]
@@ -228,7 +233,7 @@ class WriterMDJSONHandler(WriterHandlerBase):
         )
 
         # Add system message with schema
-        messages = new_kwargs.get("messages", [])
+        messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
         if messages and messages[0]["role"] != "system":
             messages.insert(
                 0,
@@ -309,6 +314,7 @@ class WriterJSONSchemaHandler(WriterHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         self._register_streaming_from_kwargs(response_model, new_kwargs)
         return handle_writer_json(response_model, new_kwargs)
 

--- a/instructor/v2/providers/xai/handlers.py
+++ b/instructor/v2/providers/xai/handlers.py
@@ -52,6 +52,7 @@ from instructor.v2.core.json import (
 )
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.core.handler import ModeHandler
+from instructor.v2.core.messages import copy_messages_for_mutation
 
 
 def _convert_messages(messages: list[dict[str, Any]]) -> list[Any]:
@@ -398,6 +399,7 @@ class XAIToolsHandler(XAIHandlerBase):
     ) -> tuple[type[BaseModel] | None, dict[str, Any]]:
         """Prepare request with tool definitions for xAI."""
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
 
         if response_model is None:
             return None, new_kwargs
@@ -522,6 +524,7 @@ class XAIParallelToolsHandler(XAIHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         if new_kwargs.get("stream", False):
             from instructor.v2.core.errors import ConfigurationError
 
@@ -593,6 +596,7 @@ class XAIJSONSchemaHandler(XAIHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         schema = response_model.model_json_schema()
 
         # Store schema info for xAI SDK's parse() method
@@ -705,7 +709,7 @@ class XAIMDJSONHandler(XAIHandlerBase):
         )
 
         # Add system message with schema
-        messages = new_kwargs.get("messages", [])
+        messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
         if messages and messages[0]["role"] != "system":
             messages.insert(
                 0,

--- a/tests/v2/test_messages_not_mutated.py
+++ b/tests/v2/test_messages_not_mutated.py
@@ -1,9 +1,20 @@
 """Regression tests for the messages= aliasing bug (see GitHub issue #2417).
 
 `client.create()` must treat `messages=` as a read-only input. Internally,
-`prepare_request` must never hand back the caller's own list object (or leave
-the caller's message dicts open to in-place mutation during a reask), because
-`handle_reask` appends retry artifacts onto whatever list it is given.
+`prepare_request` must never hand back the caller's own list object, or
+leave the caller's message dicts open to in-place mutation, because both
+`prepare_request` itself (JSON/MD_JSON's system-message injection) and
+`handle_reask` (the retry path) mutate whatever `messages` list/dicts they
+are handed.
+
+Note on the aliasing check: comparing `new_kwargs["messages"] is not
+caller_messages` alone is not sufficient -- `OpenAIJSONHandler` and
+`OpenAIMDJSONHandler` mutate the *input* list/dicts in place before
+rebuilding `messages` into a genuinely new list via
+`merge_consecutive_messages()`, so an identity check on the final result
+would pass even though the caller's original objects were already
+corrupted. These tests instead snapshot `caller_messages` with `deepcopy`
+before the call and assert it is unchanged afterward.
 
 The provider lists below are imported directly from the shared OpenAI-compat
 handler module so this test stays in sync with the source registrations
@@ -12,6 +23,7 @@ rather than duplicating them.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any, Iterable
 
 import pytest
@@ -46,6 +58,8 @@ FIXED_PAIRS: list[tuple[Provider, Mode]] = [
     *((provider, Mode.TOOLS) for provider in OPENAI_COMPAT_PROVIDERS),
     *((provider, Mode.JSON_SCHEMA) for provider in OPENAI_JSON_SCHEMA_PROVIDERS),
     *((provider, Mode.PARALLEL_TOOLS) for provider in OPENAI_PARALLEL_TOOL_PROVIDERS),
+    *((provider, Mode.JSON) for provider in OPENAI_COMPAT_PROVIDERS),
+    *((provider, Mode.MD_JSON) for provider in OPENAI_COMPAT_PROVIDERS),
     (Provider.OPENAI, Mode.RESPONSES_TOOLS),
 ]
 
@@ -71,6 +85,7 @@ def test_prepare_request_does_not_alias_caller_messages(
     provider: Provider, mode: Mode
 ) -> None:
     caller_messages = [{"role": "user", "content": "hi"}]
+    original_snapshot = deepcopy(caller_messages)
     kwargs: dict[str, Any] = {"model": "test", "messages": caller_messages}
     response_model = Iterable[Answer] if mode is Mode.PARALLEL_TOOLS else Answer
 
@@ -80,7 +95,10 @@ def test_prepare_request_does_not_alias_caller_messages(
     )
 
     assert new_kwargs["messages"] is not caller_messages
-    assert caller_messages == [{"role": "user", "content": "hi"}]
+    # Deep-content check, not just identity: a handler can rebuild
+    # `new_kwargs["messages"]` into a fresh list while still having mutated
+    # the caller's original list/dicts in place before doing so.
+    assert caller_messages == original_snapshot
 
 
 @pytest.mark.parametrize(

--- a/tests/v2/test_messages_not_mutated.py
+++ b/tests/v2/test_messages_not_mutated.py
@@ -1,0 +1,161 @@
+"""Regression tests for the messages= aliasing bug (see GitHub issue #2417).
+
+`client.create()` must treat `messages=` as a read-only input. Internally,
+`prepare_request` must never hand back the caller's own list object (or leave
+the caller's message dicts open to in-place mutation during a reask), because
+`handle_reask` appends retry artifacts onto whatever list it is given.
+
+The provider lists below are imported directly from the shared OpenAI-compat
+handler module so this test stays in sync with the source registrations
+rather than duplicating them.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+from openai.types.completion_usage import CompletionUsage
+from pydantic import BaseModel
+
+from instructor.v2.core.mode import Mode
+from instructor.v2.core.providers import Provider
+from instructor.v2.core.registry import mode_registry
+from instructor.v2.core.retry import retry_sync_v2
+from instructor.v2.providers.openai.handlers import (
+    OPENAI_COMPAT_PROVIDERS,
+    OPENAI_JSON_SCHEMA_PROVIDERS,
+    OPENAI_PARALLEL_TOOL_PROVIDERS,
+)
+
+
+class Answer(BaseModel):
+    name: str
+    age: int
+
+
+# (provider, mode) pairs whose shared OpenAI-compat handler classes were
+# patched to stop aliasing `messages`.
+FIXED_PAIRS: list[tuple[Provider, Mode]] = [
+    *((provider, Mode.TOOLS) for provider in OPENAI_COMPAT_PROVIDERS),
+    *((provider, Mode.JSON_SCHEMA) for provider in OPENAI_JSON_SCHEMA_PROVIDERS),
+    *((provider, Mode.PARALLEL_TOOLS) for provider in OPENAI_PARALLEL_TOOL_PROVIDERS),
+    (Provider.OPENAI, Mode.RESPONSES_TOOLS),
+]
+
+# Independently-implemented handlers that reproduce the same anti-pattern in
+# their own provider-specific code and are not touched by this fix. Tracked
+# here so a future fix flips these from xfail to passing instead of the
+# regression silently going unnoticed.
+KNOWN_STILL_BROKEN_PAIRS: list[tuple[Provider, Mode]] = [
+    (Provider.MISTRAL, Mode.TOOLS),
+    (Provider.COHERE, Mode.JSON_SCHEMA),
+    (Provider.WRITER, Mode.TOOLS),
+    (Provider.XAI, Mode.TOOLS),
+    (Provider.OPENROUTER, Mode.JSON_SCHEMA),
+]
+
+
+@pytest.mark.parametrize(
+    ("provider", "mode"),
+    FIXED_PAIRS,
+    ids=[f"{provider.value}-{mode.value}" for provider, mode in FIXED_PAIRS],
+)
+def test_prepare_request_does_not_alias_caller_messages(
+    provider: Provider, mode: Mode
+) -> None:
+    caller_messages = [{"role": "user", "content": "hi"}]
+    kwargs: dict[str, Any] = {"model": "test", "messages": caller_messages}
+    response_model = Iterable[Answer] if mode is Mode.PARALLEL_TOOLS else Answer
+
+    handlers = mode_registry.get_handlers(provider, mode)
+    _, new_kwargs = handlers.request_handler(
+        response_model=response_model, kwargs=kwargs
+    )
+
+    assert new_kwargs["messages"] is not caller_messages
+    assert caller_messages == [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.parametrize(
+    ("provider", "mode"),
+    KNOWN_STILL_BROKEN_PAIRS,
+    ids=[f"{provider.value}-{mode.value}" for provider, mode in KNOWN_STILL_BROKEN_PAIRS],
+)
+@pytest.mark.xfail(
+    reason="Independently-implemented handler still aliases messages; "
+    "tracked in issue #2417 (Category 2/3), not yet fixed.",
+    strict=True,
+)
+def test_known_still_broken_pairs_are_fixed(provider: Provider, mode: Mode) -> None:
+    caller_messages = [{"role": "user", "content": "hi"}]
+    kwargs: dict[str, Any] = {"model": "test", "messages": caller_messages}
+
+    handlers = mode_registry.get_handlers(provider, mode)
+    _, new_kwargs = handlers.request_handler(response_model=Answer, kwargs=kwargs)
+
+    assert new_kwargs["messages"] is not caller_messages
+
+
+def _make_tool_call_response(arguments: str, call_id: str) -> ChatCompletion:
+    tool_call = ChatCompletionMessageToolCall(
+        id=call_id,
+        type="function",
+        function=Function(name="Answer", arguments=arguments),
+    )
+    message = ChatCompletionMessage(
+        role="assistant", content=None, tool_calls=[tool_call]
+    )
+    choice = Choice(index=0, message=message, finish_reason="tool_calls", logprobs=None)
+    return ChatCompletion(
+        id="chatcmpl-test",
+        choices=[choice],
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        usage=CompletionUsage(completion_tokens=5, prompt_tokens=10, total_tokens=15),
+    )
+
+
+def test_client_create_does_not_mutate_caller_messages_after_reask() -> None:
+    """End-to-end: a validation failure followed by a successful retry must
+    leave the caller's original `messages` list completely untouched."""
+    call_count = {"n": 0}
+
+    def fake_openai_create(*_args: Any, **_kwargs: Any) -> ChatCompletion:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _make_tool_call_response('{"name": "Ada"}', "call_1")
+        return _make_tool_call_response('{"name": "Ada", "age": 37}', "call_2")
+
+    caller_messages = [{"role": "user", "content": "Ada is 37 years old"}]
+
+    handlers = mode_registry.get_handlers(Provider.OPENAI, Mode.TOOLS)
+    response_model, new_kwargs = handlers.request_handler(
+        response_model=Answer,
+        kwargs={"model": "gpt-4o-mini", "messages": caller_messages},
+    )
+
+    result = retry_sync_v2(
+        func=fake_openai_create,
+        response_model=response_model,
+        provider=Provider.OPENAI,
+        mode=Mode.TOOLS,
+        context=None,
+        max_retries=2,
+        args=(),
+        kwargs=new_kwargs,
+        strict=True,
+        hooks=None,
+    )
+
+    assert isinstance(result, Answer)
+    assert result.name == "Ada"
+    assert result.age == 37
+    assert caller_messages == [{"role": "user", "content": "Ada is 37 years old"}]

--- a/tests/v2/test_messages_not_mutated.py
+++ b/tests/v2/test_messages_not_mutated.py
@@ -19,6 +19,11 @@ before the call and assert it is unchanged afterward.
 The provider lists below are imported directly from the shared OpenAI-compat
 handler module so this test stays in sync with the source registrations
 rather than duplicating them.
+
+Independently-implemented handlers (Mistral, Cohere, Writer, xAI, OpenRouter)
+reproduce the same anti-pattern in their own provider-specific code and were
+previously tracked here as known-broken `xfail` cases. They are now fixed too
+and folded into `FIXED_PAIRS` below.
 """
 
 from __future__ import annotations
@@ -52,8 +57,10 @@ class Answer(BaseModel):
     age: int
 
 
-# (provider, mode) pairs whose shared OpenAI-compat handler classes were
-# patched to stop aliasing `messages`.
+# (provider, mode) pairs whose handlers were patched to stop aliasing
+# `messages`. Covers both the shared OpenAI-compat handler classes and the
+# independently-implemented provider-specific handlers (Mistral, Cohere,
+# Writer, xAI, OpenRouter) that reproduced the same anti-pattern separately.
 FIXED_PAIRS: list[tuple[Provider, Mode]] = [
     *((provider, Mode.TOOLS) for provider in OPENAI_COMPAT_PROVIDERS),
     *((provider, Mode.JSON_SCHEMA) for provider in OPENAI_JSON_SCHEMA_PROVIDERS),
@@ -61,17 +68,18 @@ FIXED_PAIRS: list[tuple[Provider, Mode]] = [
     *((provider, Mode.JSON) for provider in OPENAI_COMPAT_PROVIDERS),
     *((provider, Mode.MD_JSON) for provider in OPENAI_COMPAT_PROVIDERS),
     (Provider.OPENAI, Mode.RESPONSES_TOOLS),
-]
-
-# Independently-implemented handlers that reproduce the same anti-pattern in
-# their own provider-specific code and are not touched by this fix. Tracked
-# here so a future fix flips these from xfail to passing instead of the
-# regression silently going unnoticed.
-KNOWN_STILL_BROKEN_PAIRS: list[tuple[Provider, Mode]] = [
     (Provider.MISTRAL, Mode.TOOLS),
+    (Provider.MISTRAL, Mode.JSON_SCHEMA),
+    (Provider.MISTRAL, Mode.MD_JSON),
     (Provider.COHERE, Mode.JSON_SCHEMA),
+    (Provider.COHERE, Mode.MD_JSON),
     (Provider.WRITER, Mode.TOOLS),
+    (Provider.WRITER, Mode.JSON_SCHEMA),
+    (Provider.WRITER, Mode.MD_JSON),
     (Provider.XAI, Mode.TOOLS),
+    (Provider.XAI, Mode.PARALLEL_TOOLS),
+    (Provider.XAI, Mode.JSON_SCHEMA),
+    (Provider.XAI, Mode.MD_JSON),
     (Provider.OPENROUTER, Mode.JSON_SCHEMA),
 ]
 
@@ -99,26 +107,6 @@ def test_prepare_request_does_not_alias_caller_messages(
     # `new_kwargs["messages"]` into a fresh list while still having mutated
     # the caller's original list/dicts in place before doing so.
     assert caller_messages == original_snapshot
-
-
-@pytest.mark.parametrize(
-    ("provider", "mode"),
-    KNOWN_STILL_BROKEN_PAIRS,
-    ids=[f"{provider.value}-{mode.value}" for provider, mode in KNOWN_STILL_BROKEN_PAIRS],
-)
-@pytest.mark.xfail(
-    reason="Independently-implemented handler still aliases messages; "
-    "tracked in issue #2417 (Category 2/3), not yet fixed.",
-    strict=True,
-)
-def test_known_still_broken_pairs_are_fixed(provider: Provider, mode: Mode) -> None:
-    caller_messages = [{"role": "user", "content": "hi"}]
-    kwargs: dict[str, Any] = {"model": "test", "messages": caller_messages}
-
-    handlers = mode_registry.get_handlers(provider, mode)
-    _, new_kwargs = handlers.request_handler(response_model=Answer, kwargs=kwargs)
-
-    assert new_kwargs["messages"] is not caller_messages
 
 
 def _make_tool_call_response(arguments: str, call_id: str) -> ChatCompletion:
@@ -177,3 +165,62 @@ def test_client_create_does_not_mutate_caller_messages_after_reask() -> None:
     assert result.name == "Ada"
     assert result.age == 37
     assert caller_messages == [{"role": "user", "content": "Ada is 37 years old"}]
+
+
+REASK_MUTATION_PAIRS: list[tuple[Provider, Mode]] = [
+    (Provider.MISTRAL, Mode.TOOLS),
+    (Provider.MISTRAL, Mode.JSON_SCHEMA),
+    (Provider.COHERE, Mode.JSON_SCHEMA),
+    (Provider.WRITER, Mode.TOOLS),
+    (Provider.WRITER, Mode.JSON_SCHEMA),
+    (Provider.XAI, Mode.TOOLS),
+    (Provider.XAI, Mode.PARALLEL_TOOLS),
+    (Provider.XAI, Mode.JSON_SCHEMA),
+    (Provider.OPENROUTER, Mode.JSON_SCHEMA),
+]
+
+
+@pytest.mark.parametrize(
+    ("provider", "mode"),
+    REASK_MUTATION_PAIRS,
+    ids=[f"{provider.value}-{mode.value}" for provider, mode in REASK_MUTATION_PAIRS],
+)
+def test_reask_does_not_mutate_caller_messages(provider: Provider, mode: Mode) -> None:
+    """Simulates the actual retry path (prepare_request -> handle_reask) for
+    provider-specific handlers, since `prepare_request` alone never touches
+    `messages` for these modes -- the append only happens once a reask
+    actually runs, which a prepare_request-only check would miss."""
+    tool_call = ChatCompletionMessageToolCall(
+        id="call_1", type="function", function=Function(name="Answer", arguments='{"name": "Ada"}')
+    )
+    response = ChatCompletion(
+        id="chatcmpl-test",
+        choices=[
+            Choice(
+                index=0,
+                message=ChatCompletionMessage(
+                    role="assistant", content="stub", tool_calls=[tool_call]
+                ),
+                finish_reason="tool_calls",
+                logprobs=None,
+            )
+        ],
+        created=0,
+        model="m",
+        object="chat.completion",
+        usage=CompletionUsage(completion_tokens=1, prompt_tokens=1, total_tokens=2),
+    )
+    exception = ValueError("1 validation error for Answer\nage\n  Field required")
+
+    caller_messages = [{"role": "user", "content": "hi"}]
+    original_snapshot = deepcopy(caller_messages)
+    response_model = Iterable[Answer] if mode is Mode.PARALLEL_TOOLS else Answer
+
+    handlers = mode_registry.get_handlers(provider, mode)
+    _, new_kwargs = handlers.request_handler(
+        response_model=response_model,
+        kwargs={"model": "test", "messages": caller_messages},
+    )
+    handlers.reask_handler(new_kwargs, response, exception)
+
+    assert caller_messages == original_snapshot


### PR DESCRIPTION
## Stacked on #2418

This branch is built on top of #2418 (`fix/messages-aliasing-openai-handlers`) so it can reuse `copy_messages_for_mutation()` introduced there. Until #2418 merges, this diff will show both PRs' commits; GitHub will automatically narrow it down to just the new commit once #2418 merges into `main`. The only new commit here is `7ca74b0e`.

## Summary
Follow-up to #2417 / #2418: the same "shallow `kwargs.copy()`, `messages` never rebound/copied" bug, independently reproduced in five providers' own handler code (not the shared OpenAI-compat classes fixed in #2418):

**Reask-time list aliasing** (`prepare_request` never rebinds `messages`, so `handle_reask` appends retry artifacts onto the caller's original list):
- Mistral: `Mode.TOOLS`, `Mode.JSON_SCHEMA`
- Cohere: `Mode.JSON_SCHEMA` — fixed centrally in `_convert_messages_to_cohere_v2`, which also covers `Mode.TOOLS` (already had its own explicit fix) and `Mode.MD_JSON` since all three funnel through the same conversion function
- Writer: `Mode.TOOLS`, `Mode.JSON_SCHEMA`
- xAI: `Mode.TOOLS`, `Mode.PARALLEL_TOOLS`, `Mode.JSON_SCHEMA`
- OpenRouter: `Mode.JSON_SCHEMA` (its own `prepare_request` override)

**First-call dict/list mutation** (worse — corrupts caller state on every call, not just reasks; same category as OpenAI's `Mode.JSON`/`Mode.MD_JSON` fixed in #2418):
- Mistral: `Mode.MD_JSON`
- Cohere: `Mode.MD_JSON` (covered by the same central conversion fix above)
- Writer: `Mode.MD_JSON`
- xAI: `Mode.MD_JSON`

13 `(provider, mode)` pairs fixed in total — these were tracked as `xfail(strict=True)` known-broken cases in #2418's test file; this PR fixes them and removes the `xfail` list.

## Verification
Before writing the fix, empirically confirmed each of the 13 pairs actually mutates the caller's original `messages` on unpatched code:
- For the first-call category: called `prepare_request` alone and confirmed the caller's list/dict changed.
- For the reask-time category: `prepare_request` alone does *not* mutate anything for these modes (that's the bug — it silently hands back an aliased reference), so verifying required simulating the real retry path: `prepare_request` followed by `handle_reask` with a realistic mock response + validation error, confirming the caller's list gained the reask's appended messages.

After the fix, re-ran the exact same 13 checks and confirmed the caller's `messages` is untouched in every case, using both an identity check (`new_kwargs["messages"] is not caller_messages`) and a `deepcopy` snapshot content comparison (identity alone doesn't catch the first-call dict-mutation cases, per the correction in #2417).

## Test plan
- [x] `tests/v2/test_messages_not_mutated.py`: all 13 pairs folded into `FIXED_PAIRS`; new `test_reask_does_not_mutate_caller_messages` drives the full `prepare_request` → `handle_reask` cycle for the 9 reask-time pairs (a prepare_request-only check would miss this class of bug, since the mutation only happens once a reask actually runs).
- [x] `pytest tests/v2/` — 1571 passed, 179 skipped (missing optional provider SDKs), 0 failed, 0 xfailed.
- [x] `pytest tests/` (excluding `tests/v2` and `tests/llm/test_vertexai`) — same 85 pre-existing failures as unpatched `main` (verified via `git stash`; all need live API credentials or are docs-snippet tests, unrelated to this change).
