### PR TITLE
fix(json stream): emit all objects in a chunk, not just the first

### DIFF
--- a/instructor/v2/core/json.py
+++ b/instructor/v2/core/json.py
@@ -117,7 +117,7 @@ def extract_json_from_stream(chunks: Iterable[str]) -> Generator[str, None, None
                             yield from buffer
                             buffer = []
                             json_started = False
-                            break
+                            continue
 
                 buffer.append(char)
                 continue
@@ -207,7 +207,7 @@ async def extract_json_from_stream_async(
                                 yield buffered_char
                             buffer = []
                             json_started = False
-                            break
+                            continue
 
                 buffer.append(char)
                 continue

--- a/tests/v2/test_json_helpers.py
+++ b/tests/v2/test_json_helpers.py
@@ -89,6 +89,17 @@ def test_extract_json_from_stream_preserves_triple_backticks_in_plain_string() -
     assert "".join(extract_json_from_stream(chunks)) == '{"code":"```py```"}'
 
 
+def test_extract_json_from_stream_yields_all_objects_in_one_chunk() -> None:
+    # A complete object must not swallow a second object sharing its chunk.
+    chunks = ['{"a":1}{"b":2}']
+    assert "".join(extract_json_from_stream(chunks)) == '{"a":1}{"b":2}'
+
+
+def test_extract_json_from_stream_yields_all_objects_in_fenced_chunk() -> None:
+    chunks = ['```json\n{"a":1}{"b":2}\n```']
+    assert "".join(extract_json_from_stream(chunks)) == '{"a":1}{"b":2}'
+
+
 def test_extract_json_from_stream_preserves_backticks_in_fenced_string() -> None:
     chunks = ["```json\n", '{"code":"`inline`"}', "\n```"]
 


### PR DESCRIPTION
## Summary
- `extract_json_from_stream` / `extract_json_from_stream_async` built a JSON char buffer and `break` the inner per-char loop once a complete object's closing delimiter was hit. The `break` abandoned the rest of the chunk, so any JSON object following in the same chunk was silently dropped (e.g. `{"a":1}{"b":2}` yielded only `{"a":1}`).
- Changed `break` to `continue` so remaining chars are still scanned, matching the plain object-start path.

## Test plan
- Added `test_extract_json_from_stream_yields_all_objects_in_one_chunk` and `..._in_fenced_chunk` to `tests/v2/test_json_helpers.py`.
- Fail-before/pass-after verified locally (18 passed); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>