### PR TITLE
fix(openai): stop mutating caller's messages list in place (issue #2417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **v2 OpenAI handlers**: Stop mutating the caller's `messages` list in place. `prepare_request` for `TOOLS`, `JSON_SCHEMA`, `PARALLEL_TOOLS`, and `RESPONSES_TOOLS` now copies the `messages` list, so validation retries (reask) no longer graft synthetic messages onto the caller's own conversation state. ([#2417](https://github.com/567-labs/instructor/issues/2417))
+
+---
+
 ## [1.15.5] - 2026-06-28
 
 ### Fixed

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -607,6 +607,9 @@ class OpenAIToolsHandler(OpenAIHandlerBase):
     ) -> tuple[Any, dict[str, Any]]:
         """Prepare request with tool definitions."""
         new_kwargs = kwargs.copy()
+        # Copy the caller's messages list so validation retries (reask) cannot
+        # mutate the caller's own list in place. See issue #2417.
+        new_kwargs["messages"] = list(new_kwargs.get("messages", []))
 
         if response_model is None:
             return None, new_kwargs
@@ -732,6 +735,10 @@ class OpenAIJSONSchemaHandler(OpenAIHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        # Copy the caller's messages list so validation retries (reask) cannot
+        # mutate the caller's own list in place. See issue #2417.
+        new_kwargs["messages"] = list(new_kwargs.get("messages", []))
+
         schema = response_model.model_json_schema()
         new_kwargs["response_format"] = {
             "type": "json_schema",
@@ -995,6 +1002,10 @@ class OpenAIParallelToolsHandler(OpenAIHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        # Copy the caller's messages list so validation retries (reask) cannot
+        # mutate the caller's own list in place. See issue #2417.
+        new_kwargs["messages"] = list(new_kwargs.get("messages", []))
+
         if new_kwargs.get("stream", False):
             raise ConfigurationError(
                 "stream=True is not supported when using PARALLEL_TOOLS mode"
@@ -1074,6 +1085,9 @@ class OpenAIResponsesToolsHandler(OpenAIHandlerBase):
         self._register_streaming_from_kwargs(response_model, kwargs)
 
         new_kwargs = kwargs.copy()
+        # Copy the caller's messages list so validation retries (reask) cannot
+        # mutate the caller's own list in place. See issue #2417.
+        new_kwargs["messages"] = list(new_kwargs.get("messages", []))
 
         # Handle max_tokens to max_output_tokens conversion
         if new_kwargs.get("max_tokens") is not None:

--- a/tests/v2/test_issue_2417.py
+++ b/tests/v2/test_issue_2417.py
@@ -1,0 +1,166 @@
+"""Regression tests for issue #2417.
+
+``client.create()`` (and the underlying v2 handlers) must treat the caller's
+``messages`` list as a read-only input. Before the fix, the shared OpenAI
+handlers only performed a shallow ``kwargs.copy()`` in ``prepare_request``, so
+the ``messages`` value was still the caller's own list. When a validation
+failure triggered the reask/retry path, synthetic messages were appended to
+that list in place -- corrupting the caller's conversation state even on a
+successful call.
+
+See https://github.com/567-labs/instructor/issues/2417 (Category 1).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from openai.types.chat import (
+    ChatCompletion,
+    ChatCompletionMessage,
+    ChatCompletionMessageToolCall,
+)
+from openai.types.chat.chat_completion_message_tool_call import Function
+from pydantic import BaseModel, ValidationError
+from tenacity import Retrying, retry_if_exception_type, stop_after_attempt
+
+from instructor import Mode, Provider
+from instructor.v2.core.retry import retry_sync_v2
+from instructor.v2.core.registry import mode_registry
+
+OPENAI_COMPAT_PROVIDERS = (
+    Provider.ANYSCALE,
+    Provider.TOGETHER,
+    Provider.DATABRICKS,
+    Provider.DEEPSEEK,
+    Provider.OPENROUTER,
+    Provider.GROQ,
+    Provider.FIREWORKS,
+    Provider.CEREBRAS,
+)
+
+
+class Answer(BaseModel):
+    answer: float
+
+
+def _tool_call_response(arguments: str) -> ChatCompletion:
+    message = ChatCompletionMessage(
+        role="assistant",
+        content=None,
+        tool_calls=[
+            ChatCompletionMessageToolCall(
+                id="call_0",
+                type="function",
+                function=Function(name="Answer", arguments=arguments),
+            )
+        ],
+    )
+    choice = {"index": 0, "message": message, "finish_reason": "stop"}
+    return ChatCompletion(
+        id="cmpl-issue-2417",
+        choices=[choice],  # type: ignore[arg-type]
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion",
+    )
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [Mode.TOOLS, Mode.JSON_SCHEMA, Mode.PARALLEL_TOOLS, Mode.RESPONSES_TOOLS],
+)
+def test_openai_prepare_request_does_not_alias_caller_messages(mode: Mode) -> None:
+    caller_messages = [{"role": "user", "content": "What is 2+2?"}]
+    original = [dict(m) for m in caller_messages]
+
+    # PARALLEL_TOOLS requires an Iterable-wrapped response model.
+    response_model: Any = Iterable[Answer] if mode is Mode.PARALLEL_TOOLS else Answer
+
+    _, out = mode_registry.get_handlers(Provider.OPENAI, mode).request_handler(
+        response_model, {"messages": caller_messages}
+    )
+
+    # A new list object must be used for the outgoing request.
+    assert out["messages"] is not caller_messages
+    # The caller's list (and its contents) must be completely untouched.
+    assert caller_messages == original
+
+
+@pytest.mark.parametrize("provider", OPENAI_COMPAT_PROVIDERS)
+def test_compat_providers_reuse_fixed_openai_tools_handler(provider: Provider) -> None:
+    # The TOOLS handler is a single shared class registered for every OpenAI
+    # compatible provider, so the Category 1 fix covers them all at once.
+    caller_messages = [{"role": "user", "content": "What is 2+2?"}]
+    original = [dict(m) for m in caller_messages]
+
+    _, out = mode_registry.get_handlers(provider, Mode.TOOLS).request_handler(
+        Answer, {"messages": caller_messages}
+    )
+
+    assert out["messages"] is not caller_messages
+    assert caller_messages == original
+
+
+def test_reask_does_not_mutate_caller_messages(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end reproduction of issue #2417 through ``retry_sync_v2``.
+
+    A validation failure on the first attempt forces a reask; the synthetic
+    messages added by the reask path must land on a *copy* of the caller's
+    list, leaving the original untouched.
+    """
+    monkeypatch.setattr(
+        "instructor.v2.core.retry.RegistryValidationMixin.validate_mode_registration",
+        lambda _provider, _mode: None,
+    )
+    monkeypatch.setattr(
+        "instructor.v2.core.retry._initialize_usage",
+        lambda _provider: SimpleNamespace(
+            completion_tokens=0, prompt_tokens=0, total_tokens=0
+        ),
+    )
+    monkeypatch.setattr(
+        "instructor.v2.core.retry.update_total_usage",
+        lambda _response, total_usage: total_usage,
+    )
+
+    caller_messages = [{"role": "user", "content": "What is 2+2?"}]
+    attempts: list[int] = []
+
+    def fake_func(*_args: Any, **_kwargs: Any) -> ChatCompletion:
+        attempts.append(1)
+        # First attempt: invalid tool-call payload -> validation error -> reask.
+        # Second attempt: valid payload -> parsed successfully.
+        if len(attempts) == 1:
+            return _tool_call_response('{"answer": "not-a-number"}')
+        return _tool_call_response('{"answer": 4}')
+
+    # Run prepare_request exactly as the patched client does, so the caller's
+    # messages list is the one we want to prove stays untouched.
+    handlers = mode_registry.get_handlers(Provider.OPENAI, Mode.TOOLS)
+    _, prepared = handlers.request_handler(Answer, {"messages": caller_messages})
+
+    result = retry_sync_v2(
+        func=fake_func,
+        response_model=Answer,
+        provider=Provider.OPENAI,
+        mode=Mode.TOOLS,
+        context=None,
+        max_retries=Retrying(
+            stop=stop_after_attempt(2),
+            retry=retry_if_exception_type(ValidationError),
+            reraise=True,
+        ),
+        args=(),
+        kwargs=prepared,
+        strict=True,
+        hooks=None,
+    )
+
+    assert isinstance(result, Answer)
+    assert result.answer == 4.0
+    # The caller's list must be unchanged by the reask/retry path.
+    assert caller_messages == [{"role": "user", "content": "What is 2+2?"}]


### PR DESCRIPTION
## Summary

Fixes #2417 (Category 1). The shared OpenAI v2 handlers only performed a shallow `kwargs.copy()` in `prepare_request`, so the caller's `messages` list (and the message dicts inside it) stayed aliased. When a validation failure triggered the reask/retry path, synthetic messages were appended **onto the caller's own list** — corrupting conversation state even though the call eventually succeeded and `messages=` looks like a read-only input.

This PR copies the `messages` list in `prepare_request` for the four affected OpenAI modes:
- `Mode.TOOLS` (shared by OpenAI + 8 OpenAI-compatible providers)
- `Mode.JSON_SCHEMA` (shared by OpenAI + 7 providers)
- `Mode.PARALLEL_TOOLS` (shared by OpenAI + 6 providers)
- `Mode.RESPONSES_TOOLS` (OpenAI)

Because `retry_sync_v2` / `retry_async_v2` receive the prepared `new_kwargs` (which now carry the copied list) and the reask handlers append onto that copy, the caller's list is never mutated. As noted in the issue, the JSON/MD_JSON OpenAI handlers already rebuild the list and are unaffected.

## Why this is safe

- Shallow copy of the list is exactly what the issue author recommends and matches the pattern already used correctly inside `CohereToolsHandler`.
- Reask handlers only append **new** message dicts; they never mutate existing message dicts in these four modes, so a list-level copy fully closes the gap.
- The early-return paths (`response_model is None`) do not mutate and are unchanged.

## Test plan

Added `tests/v2/test_issue_2417.py`:
- `test_openai_prepare_request_does_not_alias_caller_messages` — for each of the 4 OpenAI modes, asserts the prepared request uses a different list object and that the caller's list is byte-for-byte unchanged.
- `test_compat_providers_reuse_fixed_openai_tools_handler` — confirms every OpenAI-compatible provider sharing the `TOOLS` handler gets the fix.
- `test_reask_does_not_mutate_caller_messages` — full end-to-end reproduction through `retry_sync_v2` + the real handlers: a validation failure forces a reask, and the caller's `messages` list remains `[{"role": "user", "content": "What is 2+2?"}]`.

All 13 new tests pass; existing `test_openai_compat_handlers`, `test_retry_runtime`, `test_registry`, and `test_handler_registration_unified` suites still pass.

## CHANGELOG

Added an `[Unreleased] > Fixed` entry referencing #2417.

📌 Note: as suggested in the issue, I've scoped this to Category 1 (the shared OpenAI handlers). The Category 2/3 fixes for Mistral/OpenRouter/Cohere/xAI/Writer can follow in separate PRs.