### PR TITLE
fix(v2): don't mistake a literal '[' inside a preceding string field for the tasks array start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **v2 iterable streaming**: `Iterable[Model]` / `IterableModel` streaming (`tasks_from_chunks` / `tasks_from_chunks_async`, used by every provider's streaming path) no longer mistakes a literal `[` inside a string value emitted before the `tasks` array (e.g. a free-text field) for the start of the array. Previously this silently dropped every streamed task with no error.
+
+---
+
 ## [1.15.5] - 2026-06-28
 
 ### Fixed

--- a/instructor/v2/dsl/iterable.py
+++ b/instructor/v2/dsl/iterable.py
@@ -102,9 +102,10 @@ class IterableBase:
         for chunk in json_chunks:
             potential_object += chunk
             if not started:
-                if "[" in chunk:
+                bracket_index = cls._find_unquoted_char(potential_object, "[")
+                if bracket_index != -1:
                     started = True
-                    potential_object = chunk[chunk.find("[") + 1 :]
+                    potential_object = potential_object[bracket_index + 1 :]
 
             while True:
                 task_json, potential_object = cls.get_object(potential_object, 0)
@@ -124,9 +125,10 @@ class IterableBase:
         async for chunk in json_chunks:
             potential_object += chunk
             if not started:
-                if "[" in chunk:
+                bracket_index = cls._find_unquoted_char(potential_object, "[")
+                if bracket_index != -1:
                     started = True
-                    potential_object = chunk[chunk.find("[") + 1 :]
+                    potential_object = potential_object[bracket_index + 1 :]
 
             while True:
                 task_json, potential_object = cls.get_object(potential_object, 0)
@@ -178,6 +180,34 @@ class IterableBase:
             raise ValueError("stream_extractor is required for streaming responses")
         async for chunk in stream_extractor(completion):
             yield chunk
+
+    @staticmethod
+    def _find_unquoted_char(s: str, target: str) -> int:
+        """Find the index of the first occurrence of `target` that is not
+        inside a JSON string literal.
+
+        Used to detect the start of the streamed tasks array ("[") without
+        being fooled by the same character appearing inside a string value
+        emitted earlier in the object (e.g. a free-text field containing a
+        literal "[" before the "tasks" array has actually started).
+        """
+        in_string = False
+        escape_next = False
+        for i, c in enumerate(s):
+            if escape_next:
+                escape_next = False
+            elif c == "\\" and in_string:
+                escape_next = True
+                continue
+            elif c == '"':
+                in_string = not in_string
+
+            if in_string:
+                continue
+
+            if c == target:
+                return i
+        return -1
 
     @staticmethod
     def get_object(s: str, stack: int) -> tuple[str | None, str]:

--- a/tests/v2/test_iterable_streaming.py
+++ b/tests/v2/test_iterable_streaming.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import pytest
 from pydantic import BaseModel
 
 from instructor.v2.dsl.iterable import IterableBase, IterableModel
@@ -10,6 +11,11 @@ from instructor.v2.dsl.iterable import IterableBase, IterableModel
 class User(BaseModel):
     name: str
     bio: str
+
+
+class Task(BaseModel):
+    name: str
+    priority: int
 
 
 def test_iterable_get_object_ignores_braces_inside_strings() -> None:
@@ -53,4 +59,54 @@ def test_iterable_tasks_from_chunks_handles_braces_inside_strings() -> None:
     assert users == [
         User(name="Alice", bio="happy :}"),
         User(name="Bob", bio="plain"),
+    ]
+
+
+def test_iterable_tasks_from_chunks_ignores_bracket_inside_preceding_string() -> None:
+    """A literal "[" inside a string field emitted before the tasks array must
+    not be mistaken for the start of the array.
+
+    `tasks_from_chunks` decides the array has started with a naive
+    `"[" in chunk` check. If any field preceding "tasks" in the response JSON
+    contains a literal "[" in a string value (e.g. a free-text "note" field),
+    that in-string bracket falsely triggers array-start detection, the buffer
+    gets sliced from the wrong offset, and the real tasks are silently lost.
+    """
+    chunks = [
+        '{"note": "check [priority] items first", ',
+        '"tasks": [',
+        '{"name": "alpha", "priority": 1}',
+        ', {"name": "beta", "priority": 2}',
+        "]}",
+    ]
+
+    iterable_model = cast(Any, IterableModel(Task))
+    tasks = list(iterable_model.tasks_from_chunks(chunks))
+
+    assert tasks == [
+        Task(name="alpha", priority=1),
+        Task(name="beta", priority=2),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_iterable_tasks_from_chunks_async_ignores_bracket_inside_preceding_string() -> (
+    None
+):
+    async def _achunks():
+        for chunk in [
+            '{"note": "check [priority] items first", ',
+            '"tasks": [',
+            '{"name": "alpha", "priority": 1}',
+            ', {"name": "beta", "priority": 2}',
+            "]}",
+        ]:
+            yield chunk
+
+    iterable_model = cast(Any, IterableModel(Task))
+    tasks = [task async for task in iterable_model.tasks_from_chunks_async(_achunks())]
+
+    assert tasks == [
+        Task(name="alpha", priority=1),
+        Task(name="beta", priority=2),
     ]


### PR DESCRIPTION
## Describe your changes

`IterableBase.tasks_from_chunks` / `tasks_from_chunks_async` (`instructor/v2/dsl/iterable.py`), the
streaming path every provider's `Iterable[Model]` extraction goes through, detects the start of the
streamed `tasks` array with a naive `"[" in chunk` check on each individual chunk. If a field
preceding `tasks` in the response JSON contains a literal `[` inside a string value — for example a
free-text `note` field like `"check [priority] items first"` — that in-string bracket falsely
triggers array-start detection. The buffer gets sliced from the wrong offset, and every task
streamed after that point is silently dropped: the function returns an empty list, with no
exception anywhere.

```python
chunks = [
    '{"note": "check [priority] items first", ',
    '"tasks": [',
    '{"name": "alpha", "priority": 1}',
    ', {"name": "beta", "priority": 2}',
    "]}",
]
list(IterableModel(Task).tasks_from_chunks(chunks))
# []  <- both tasks vanished, no error
```

The fix adds `_find_unquoted_char`, a small string-aware scanner (tracks `in_string`/escape state,
the same pattern `get_object` a few lines below already uses for brace-matching) and uses it in
both `tasks_from_chunks` and `tasks_from_chunks_async` to find the real, unquoted `[` against the
full accumulated buffer instead of a naive per-chunk substring check. 38 lines changed across both
sync/async entry points plus the new helper; no signature changes.

Tests: added `test_iterable_tasks_from_chunks_ignores_bracket_inside_preceding_string` and its
async counterpart, mirroring the existing `test_iterable_tasks_from_chunks_handles_braces_inside_strings`
pattern, using the `note`-field repro above. Before fix: 2 failed — `assert [] == [Task(name='alpha',
priority=1), Task(name='beta', priority=2)]` (both streamed tasks silently dropped). After fix: all
6 tests in `tests/v2/test_iterable_streaming.py` pass. `ruff check` is clean on both changed files.

## Issue ticket number and link

No existing issue tracks this bug. Distinct from the already-merged PR #2340 (a consolidation
bundle whose iterable.py portion fixed brace-in-string detection in `get_object`) — this fixes a
different detection bug (array-start bracket, not object-boundary brace) in a different function;
`get_object` itself is unchanged.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation. (Bug fix to internal streaming
  detection; no documented behavior changed.)
