### PR TITLE
fix(core): deep-copy messages list in reask handlers to prevent caller mutation

### DIFF
--- a/instructor/v2/providers/anthropic/handlers.py
+++ b/instructor/v2/providers/anthropic/handlers.py
@@ -421,7 +421,7 @@ class AnthropicToolsHandler(AnthropicHandlerBase):
         response: Message,
         exception: Exception,
     ) -> dict[str, Any]:
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         if response is None or not hasattr(response, "content"):
             kwargs["messages"].append(
                 {
@@ -687,7 +687,7 @@ class AnthropicJSONHandler(AnthropicHandlerBase):
         response: Message,
         exception: Exception,
     ) -> dict[str, Any]:
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         text_blocks = [c for c in response.content if c.type == "text"]
         if not text_blocks:
             text_content = "No text content found in response"
@@ -862,7 +862,7 @@ class AnthropicStructuredOutputsHandler(AnthropicHandlerBase):
         exception: Exception,
     ) -> dict[str, Any]:
         # Use same reask logic as JSON mode
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         text_blocks = [c for c in response.content if c.type == "text"]
         if not text_blocks:
             text_content = "No text content found in response"

--- a/instructor/v2/providers/mistral/handlers.py
+++ b/instructor/v2/providers/mistral/handlers.py
@@ -293,7 +293,7 @@ class MistralToolsHandler(MistralHandlerBase):
         exception: Exception,
     ) -> dict[str, Any]:
         """Handle reask for tools mode."""
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         reask_msgs: list[Any] = [dump_message(response.choices[0].message)]
 
         for tool_call in response.choices[0].message.tool_calls:
@@ -415,7 +415,7 @@ class MistralJSONSchemaHandler(MistralHandlerBase):
         exception: Exception,
     ) -> dict[str, Any]:
         """Handle reask for JSON schema mode."""
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         reask_msgs = [
             {
                 "role": "assistant",
@@ -538,7 +538,7 @@ class MistralMDJSONHandler(MistralHandlerBase):
         exception: Exception,
     ) -> dict[str, Any]:
         """Handle reask for MD_JSON mode."""
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         reask_msgs = [
             {
                 "role": "assistant",

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -156,7 +156,7 @@ def reask_tools(
     exception: Exception,
 ):
     """Handle reask for OpenAI tools mode when validation fails."""
-    kwargs = kwargs.copy()
+    kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
 
     if _is_stream_response(response):
         kwargs["messages"].append(
@@ -193,7 +193,7 @@ def reask_responses_tools(
     exception: Exception,
 ):
     """Handle reask for OpenAI responses tools mode when validation fails."""
-    kwargs = kwargs.copy()
+    kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
 
     if response is None or not hasattr(response, "output"):
         kwargs["messages"].append(
@@ -250,7 +250,7 @@ def reask_md_json(
     exception: Exception,
 ):
     """Handle reask for OpenAI JSON modes when validation fails."""
-    kwargs = kwargs.copy()
+    kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
 
     if _is_stream_response(response):
         kwargs["messages"].append(
@@ -293,7 +293,7 @@ def reask_default(
     exception: Exception,
 ):
     """Handle reask for OpenAI default mode when validation fails."""
-    kwargs = kwargs.copy()
+    kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
 
     if _is_stream_response(response):
         kwargs["messages"].append(

--- a/instructor/v2/providers/xai/handlers.py
+++ b/instructor/v2/providers/xai/handlers.py
@@ -86,7 +86,7 @@ def reask_xai_json(
     exception: Exception,
 ):
     """Handle reask for xAI JSON mode when validation fails."""
-    kwargs = kwargs.copy()
+    kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
     reask_msg = {
         "role": "user",
         "content": (
@@ -106,7 +106,7 @@ def reask_xai_tools(
     exception: Exception,
 ):
     """Handle reask for xAI tools mode when validation fails."""
-    kwargs = kwargs.copy()
+    kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
 
     assistant_msg = {
         "role": "assistant",
@@ -429,7 +429,7 @@ class XAIToolsHandler(XAIHandlerBase):
         exception: Exception,
     ) -> dict[str, Any]:
         """Handle reask for tools mode."""
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
 
         # Add assistant response to conversation history
         assistant_msg = {
@@ -610,7 +610,7 @@ class XAIJSONSchemaHandler(XAIHandlerBase):
         exception: Exception,
     ) -> dict[str, Any]:
         """Handle reask for JSON schema mode."""
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         reask_msg = {
             "role": "user",
             "content": f"Validation Errors found:\n{exception}\nRecall the function correctly, fix the errors found in the following attempt:\n{response}",
@@ -743,7 +743,7 @@ class XAIMDJSONHandler(XAIHandlerBase):
         exception: Exception,
     ) -> dict[str, Any]:
         """Handle reask for MD_JSON mode."""
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         reask_msg = {
             "role": "user",
             "content": f"Validation Errors found:\n{exception}\nRecall the function correctly, fix the errors found in the following attempt:\n{response}",


### PR DESCRIPTION
## Describe your changes

Fixes a mutation bug where reask handlers corrupt the caller's `messages` list across retries.

Closes #2428

All reask handlers across OpenAI, Anthropic, Mistral, and xAI providers use `kwargs.copy()` (shallow copy) then mutate `kwargs['messages']` via `.append()`/`.extend()`. Since `dict.copy()` creates a shallow copy, the `messages` list object is shared between the copy and the original dict. This means `.append()`/`.extend()` modifies the caller's messages list in-place, corrupting it across retries.

## Problem

```python
# Original kwargs from caller
kwargs = {"messages": [{"role": "user", "content": "hello"}], ...}

# reask_openai_tools() does:
kwargs = kwargs.copy()          # shallow copy - messages list is SHARED
kwargs["messages"].append(...)  # modifies the SAME list object

# Caller's messages list is now corrupted:
# Original caller still sees the appended message
```

This causes:
- **Data corruption**: The caller's messages accumulate duplicate/extra entries across retries
- **Silent failures**: No exception is raised, but the LLM sees corrupted context
- **Non-deterministic bugs**: Behavior depends on retry count and timing

## Solution

Replace the shallow copy with a shallow dict copy + explicit list copy:

```python
# Before (all 15 reask handlers across 4 providers)
kwargs = kwargs.copy()

# After
kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
```

This creates a new dict with a fresh messages list, so mutations stay isolated to the reask handler's local scope.

## Files changed

- `instructor/v2/providers/openai/handlers.py` — 4 fixes (`reask_tools`, `reask_responses_tools`, `reask_md_json`, `reask_default`)
- `instructor/v2/providers/anthropic/handlers.py` — 3 fixes
- `instructor/v2/providers/mistral/handlers.py` — 3 fixes
- `instructor/v2/providers/xai/handlers.py` — 5 fixes

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/truecallerabreham/instructor/blob/main/CONTRIBUTING.md) guide
- [ ] Lint and type checks pass (`make lint`, `make typecheck`)
- [ ] Tests added if applicable
- [ ] Documentation updated if applicable

## Regression test

```python
import instructor
from openai import OpenAI

client = instructor.from_openai(OpenAI())

def user_message():
    return [{"role": "user", "content": "hello"}]

messages = user_message()

try:
    client.chat.completions.create(
        model="gpt-4o",
        messages=messages,
        max_retries=2,
        response_model=Str,
    )
except Exception:
    pass

# Without fix: messages has 2+ entries (original + reask appends)
# With fix: messages still has exactly 1 entry
assert len(messages) == 1, f"Expected 1, got {len(messages)}"
```
