### PR TITLE
feat(bedrock): support Amazon Bedrock API key (bearer token) auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Bedrock**: `from_provider("bedrock/...", api_key=...)` now forwards the value as an Amazon Bedrock API key (bearer token) via `AWS_BEARER_TOKEN_BEDROCK`, so Bedrock works with a single `api_key` like other providers instead of requiring SigV4 credentials. ([#2408](https://github.com/567-labs/instructor/issues/2408))
+
+---
+
 ## [1.15.5] - 2026-06-28
 
 ### Fixed

--- a/docs/integrations/bedrock.md
+++ b/docs/integrations/bedrock.md
@@ -65,6 +65,25 @@ Or configure using AWS CLI:
 aws configure
 ```
 
+### Using a Bedrock API key
+
+Amazon Bedrock also supports [API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html) (bearer tokens) as a simpler alternative to SigV4 credentials. Pass the key directly to `from_provider`:
+
+```python
+import instructor
+
+client = instructor.from_provider(
+    "bedrock/claude-3-5-sonnet-20241022",
+    api_key="your_bedrock_api_key",
+)
+```
+
+Or set it in the environment, which botocore reads natively:
+
+```bash
+export AWS_BEARER_TOKEN_BEDROCK=your_bedrock_api_key
+```
+
 ## Sync Example
 
 ```python

--- a/instructor/v2/auto_client.py
+++ b/instructor/v2/auto_client.py
@@ -969,7 +969,7 @@ def _build_bedrock(
     model_name: str,
     async_client: bool,
     mode: Mode | None,
-    api_key: str | None,  # noqa: ARG001
+    api_key: str | None,
     kwargs: dict[str, Any],
     provider_info: dict[str, str],
 ) -> InstructorType:
@@ -977,6 +977,13 @@ def _build_bedrock(
         import os
         import boto3
         from instructor.v2.providers.bedrock.client import from_bedrock
+
+        # Amazon Bedrock API keys (bearer tokens) are consumed by botocore via the
+        # AWS_BEARER_TOKEN_BEDROCK environment variable (supported since boto3 1.39.0).
+        # When an api_key is supplied explicitly, forward it so Bedrock works with a
+        # single api_key like every other provider, instead of requiring SigV4 creds.
+        if api_key:
+            os.environ["AWS_BEARER_TOKEN_BEDROCK"] = api_key
 
         # Get AWS configuration from environment or kwargs
         if "region" in kwargs:

--- a/tests/v2/test_auto_client_deterministic.py
+++ b/tests/v2/test_auto_client_deterministic.py
@@ -205,6 +205,70 @@ def test_build_bedrock_chooses_default_mode_from_model_name(
     assert calls[1]["mode"] == Mode.MD_JSON
 
 
+def _stub_bedrock_deps(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Stub boto3 and from_bedrock, returning the list of from_bedrock kwargs."""
+    boto3_module = ModuleType("boto3")
+
+    def fake_client(_service_name: str, **_kwargs: Any) -> object:
+        return object()
+
+    setattr(boto3_module, "client", fake_client)  # noqa: B010
+    monkeypatch.setitem(__import__("sys").modules, "boto3", boto3_module)
+
+    import instructor.v2.providers.bedrock.client as bedrock_client
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_from_bedrock(_client: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(bedrock_client, "from_bedrock", fake_from_bedrock)
+    return calls
+
+
+def test_build_bedrock_forwards_api_key_as_bearer_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+    _stub_bedrock_deps(monkeypatch)
+
+    auto_client._build_bedrock(
+        provider="bedrock",
+        model_name="anthropic.claude-3-7-sonnet",
+        async_client=False,
+        mode=None,
+        api_key="bedrock-api-key-abc123",
+        kwargs={},
+        provider_info={"provider": "bedrock", "operation": "initialize"},
+    )
+
+    import os
+
+    assert os.environ["AWS_BEARER_TOKEN_BEDROCK"] == "bedrock-api-key-abc123"
+
+
+def test_build_bedrock_without_api_key_leaves_bearer_token_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "preexisting-token")
+    _stub_bedrock_deps(monkeypatch)
+
+    auto_client._build_bedrock(
+        provider="bedrock",
+        model_name="anthropic.claude-3-7-sonnet",
+        async_client=False,
+        mode=None,
+        api_key=None,
+        kwargs={},
+        provider_info={"provider": "bedrock", "operation": "initialize"},
+    )
+
+    import os
+
+    assert os.environ["AWS_BEARER_TOKEN_BEDROCK"] == "preexisting-token"
+
+
 def test_build_ollama_uses_tool_mode_only_for_tool_capable_models(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Describe your changes

`from_provider("bedrock/...", api_key=...)` previously ignored the `api_key`
argument (it was marked `# noqa: ARG001` in `_build_bedrock`), silently falling
back to the default SigV4 credential chain with no warning. Every other provider
(`openai/...`, `anthropic/...`, etc.) works with a single `api_key`, so Bedrock
was the odd one out.

Amazon Bedrock now supports [API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html)
(bearer tokens), which botocore consumes natively via the
`AWS_BEARER_TOKEN_BEDROCK` environment variable (supported since boto3 1.39.0,
July 2025 — see the [AWS announcement](https://aws.amazon.com/blogs/machine-learning/accelerate-ai-development-with-amazon-bedrock-api-keys/)).

This PR forwards an explicitly-passed `api_key` to that environment variable in
`_build_bedrock`, so:

```python
import instructor

client = instructor.from_provider(
    "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
    api_key="bedrock-api-key-...",  # now used as the Bedrock bearer token
)
```

The env-var-only path (`export AWS_BEARER_TOKEN_BEDROCK=...`) already worked
because botocore reads it directly; this change only adds the explicit `api_key`
ergonomics and leaves any pre-existing `AWS_BEARER_TOKEN_BEDROCK` untouched when
no `api_key` is provided.

### Changes
- `instructor/v2/auto_client.py`: forward `api_key` → `AWS_BEARER_TOKEN_BEDROCK` in `_build_bedrock`; drop the `# noqa: ARG001`.
- `tests/v2/test_auto_client_deterministic.py`: two deterministic tests (no live AWS) — one asserting the token is set when `api_key` is passed, one asserting an existing token is left alone when it isn't.
- `docs/integrations/bedrock.md`: document the Bedrock API-key auth option.
- `CHANGELOG.md`: entry under `[Unreleased]`.

## Issue ticket number and link

Closes #2408 — https://github.com/567-labs/instructor/issues/2408

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.
