### PR TITLE
fix(citations): escape substring quotes before fuzzy span matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Citations**: `CitationMixin` now escapes substring quotes before fuzzy-matching them against the context, so quotes containing regex metacharacters (e.g. unbalanced parentheses or brackets) resolve their span instead of raising `regex.error` during validation.
+
+---
+
 ## [1.15.5] - 2026-06-28
 
 ### Fixed

--- a/instructor/v2/dsl/citation.py
+++ b/instructor/v2/dsl/citation.py
@@ -80,7 +80,10 @@ class CitationMixin(BaseModel):
     ) -> Generator[tuple[int, int], None, None]:
         import regex
 
-        minor = quote
+        # Escape the quote so regex metacharacters in LLM-generated text
+        # (e.g. unbalanced parentheses or brackets) are matched literally
+        # instead of crashing the fuzzy search with a regex compile error.
+        minor = regex.escape(quote)
         major = context
 
         errs_ = 0

--- a/tests/v2/test_citation.py
+++ b/tests/v2/test_citation.py
@@ -1,0 +1,82 @@
+"""Tests for CitationMixin span resolution.
+
+Covers the regex-escaping behavior in ``_get_span``: LLM-generated quotes may
+contain regex metacharacters, which must be matched literally rather than
+compiled as a pattern.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("regex")
+
+from instructor.v2.dsl.citation import CitationMixin  # noqa: E402
+
+
+class Answer(CitationMixin):
+    pass
+
+
+def test_quote_with_regex_metacharacters_does_not_crash() -> None:
+    """A quote with unbalanced parentheses must resolve, not raise regex.error."""
+    context = "The margin is 50% (approx) this quarter."
+
+    answer = Answer.model_validate(
+        {"substring_quotes": ["50% (approx"]},
+        context={"context": context},
+    )
+
+    # The span is found and normalized back to the exact context substring.
+    assert answer.substring_quotes == ["50% (approx"]
+
+
+@pytest.mark.parametrize(
+    "quote",
+    [
+        "cost [USD]",  # brackets
+        "a+b*c",  # quantifiers
+        "path\\to\\file",  # backslashes
+        "who? (maybe)",  # optional + parens
+    ],
+)
+def test_various_metacharacter_quotes_resolve(quote: str) -> None:
+    context = f"prefix {quote} suffix"
+
+    answer = Answer.model_validate(
+        {"substring_quotes": [quote]},
+        context={"context": context},
+    )
+
+    assert answer.substring_quotes == [quote]
+
+
+def test_non_matching_quote_is_dropped() -> None:
+    """Quotes absent from the context are removed rather than kept."""
+    context = "Nothing relevant here."
+
+    answer = Answer.model_validate(
+        {"substring_quotes": ["(totally unrelated)"]},
+        context={"context": context},
+    )
+
+    assert answer.substring_quotes == []
+
+
+def test_fuzzy_matching_still_works_after_escaping() -> None:
+    """Escaping the literal quote must not disable fuzzy (edit-distance) matching."""
+    context = "The margin is 50% (approx) this quarter."
+
+    # One-character typo ("aprox") within the default edit budget.
+    answer = Answer.model_validate(
+        {"substring_quotes": ["50% (aprox)"]},
+        context={"context": context},
+    )
+
+    assert answer.substring_quotes == ["50% (approx)"]
+
+
+def test_no_context_leaves_quotes_untouched() -> None:
+    answer = Answer.model_validate({"substring_quotes": ["anything (raw"]})
+
+    assert answer.substring_quotes == ["anything (raw"]


### PR DESCRIPTION
## Describe your changes

`CitationMixin._get_span` interpolated the LLM-generated quote directly into a
`regex` fuzzy-match pattern:

```python
minor = quote
s = regex.search(f"({minor}){{e<={errs_}}}", major)
```

Because the quote is never escaped, any regex metacharacter in the model's
`substring_quotes` — unbalanced parentheses/brackets, `*`, `+`, `?`, `\`, etc.,
all common in real prose — is interpreted as part of the pattern. This either
raises `regex.error` (crashing validation) or silently matches the wrong span,
instead of the documented behavior of *finding the span or dropping the quote*.

Reproduction:

```python
context = "The margin is 50% (approx) this quarter."
Answer.model_validate(
    {"substring_quotes": ["50% (approx"]},   # unbalanced paren from the LLM
    context={"context": context},
)
# regex.error: missing ) at position 19
```

### Fix

Escape the quote with `regex.escape()` before building the pattern so it is
matched literally. Fuzzy (edit-distance) matching is unaffected — a quote with a
one-character typo still resolves within the default edit budget.

### Changes
- `instructor/v2/dsl/citation.py`: `regex.escape(quote)` before the fuzzy search.
- `tests/v2/test_citation.py`: new tests — metacharacter quotes resolve instead of crashing, non-matching quotes are dropped, fuzzy matching still works, and no-context input is untouched. (These fail on `main` and pass with the fix.)
- `CHANGELOG.md`: entry under `[Unreleased]`.

## Issue ticket number and link

Closes #2431 — https://github.com/567-labs/instructor/issues/2431

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.
