### PR TITLE
fix(v2): consolidate correctness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **v2 message handling**: Preserve caller-owned message lists and nested content across request preparation and retries for OpenAI-compatible, Cohere, Mistral, OpenRouter, Writer, and xAI handlers. ([#2417](https://github.com/567-labs/instructor/issues/2417), [#2428](https://github.com/567-labs/instructor/issues/2428))
+- **v2 JSON extraction**: Prefer the final complete top-level JSON value in text responses and retain every JSON object when multiple objects arrive in one streaming chunk.
+- **v2 schemas**: Treat fields with Pydantic `default_factory` values as optional in generated OpenAI tool schemas.
+- **v2 partial streaming**: Build model instances for present `Optional[BaseModel]` fields during incomplete streams instead of exposing raw dictionaries.
+- **v2 iterable unions**: Generate stable member-derived names such as `IterableAOrB` for both `Union[A, B]` and `A | B` response models.
 - **Mistral/Vertex AI partial streaming**: Avoid forwarding iterable-only parser arguments into completed `Partial` responses, preventing final Pydantic validation errors for sync and async streams.
 - **Batch providers**: Handle missing optional SDKs safely, validate OpenAI batch input before client setup, report exhausted output-file retries clearly, and remove unreachable fallbacks.
 - **OpenAI/Writer tools**: Raise clear response-parsing errors for completions with no choices or tool calls instead of leaking attribute and index errors.

--- a/instructor/v2/core/json.py
+++ b/instructor/v2/core/json.py
@@ -7,15 +7,35 @@ from collections.abc import AsyncGenerator, Generator, Iterable
 
 
 def extract_json_from_codeblock(content: str) -> str:
-    """Extract the first JSON object- or array-like span from a text block."""
-    for start_index, start_char in enumerate(content):
-        if start_char not in "{[":
-            continue
+    """Extract the last JSON object- or array-like span from a text block.
+
+    Returns the LAST complete JSON object, not the first. The LLM's own
+    structured output is the authoritative JSON and appears last; JSON that
+    appeared earlier may have originated from user input embedded in the
+    prompt and was referenced in the model's reasoning. Returning the first
+    object allowed prompt-injection to hijack the parsed output.
+    """
+    candidates: list[str] = []
+    search_index = 0
+    while search_index < len(content):
+        start_index = next(
+            (
+                index
+                for index in range(search_index, len(content))
+                if content[index] in "{["
+            ),
+            None,
+        )
+        if start_index is None:
+            break
+
+        start_char = content[start_index]
 
         end_stack = ["}" if start_char == "{" else "]"]
         in_string = False
         escape_next = False
 
+        candidate_found = False
         for end_index in range(start_index + 1, len(content)):
             char = content[end_index]
 
@@ -40,8 +60,16 @@ def extract_json_from_codeblock(content: str) -> str:
                         json.loads(candidate)
                     except Exception:
                         break
-                    return candidate
+                    candidates.append(candidate)
+                    search_index = end_index + 1
+                    candidate_found = True
+                    break
 
+        if not candidate_found:
+            search_index = start_index + 1
+
+    if candidates:
+        return candidates[-1]
     return content
 
 
@@ -117,7 +145,7 @@ def extract_json_from_stream(chunks: Iterable[str]) -> Generator[str, None, None
                             yield from buffer
                             buffer = []
                             json_started = False
-                            break
+                            continue
 
                 buffer.append(char)
                 continue
@@ -207,7 +235,7 @@ async def extract_json_from_stream_async(
                                 yield buffered_char
                             buffer = []
                             json_started = False
-                            break
+                            continue
 
                 buffer.append(char)
                 continue

--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -19,6 +19,25 @@ def extract_messages(kwargs: dict[str, Any]) -> Any:
     return []
 
 
+def copy_messages_for_mutation(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return a copy of `messages` that is safe to mutate in place.
+
+    Handlers that inject a system/instruction message do so by mutating a
+    `messages` list and its dict elements directly (`.insert()`, `.append()`,
+    `message["content"] += ...`). Since `kwargs.copy()` is shallow, `messages`
+    is otherwise the exact list (and dict) objects the caller passed in, so
+    those in-place edits would corrupt the caller's own conversation state.
+    """
+    copied = [dict(message) for message in messages]
+    for message in copied:
+        content = message.get("content")
+        if isinstance(content, list):
+            message["content"] = [
+                dict(item) if isinstance(item, dict) else item for item in content
+            ]
+    return copied
+
+
 def dump_message(message: ChatCompletionMessage) -> ChatCompletionMessageParam:
     ret: ChatCompletionMessageParam = {
         "role": message.role,

--- a/instructor/v2/dsl/iterable.py
+++ b/instructor/v2/dsl/iterable.py
@@ -262,13 +262,15 @@ def IterableModel(
         task_name = name
     else:
         # Handle `Union[A, B]` / `A | B` task types.
-        # `types.UnionType` does not have `__name__`, so fall back to a stable name.
-        task_name = getattr(subtask_class, "__name__", None)
-        if task_name is None and get_origin(subtask_class) in _UNION_ORIGINS:
+        # Both `typing.Union[A, B]` and PEP 604 `A | B` expose ``__name__ == "Union"``
+        # (and `types.UnionType` normalizes to ``typing.Union`` on modern Python), so we
+        # must detect a union *origin* first and build the name from its members --
+        # otherwise every union collapses to the unhelpful ``IterableUnion``.
+        if get_origin(subtask_class) in _UNION_ORIGINS:
             members = get_args(subtask_class)
             task_name = "Or".join(getattr(m, "__name__", str(m)) for m in members)
-        if task_name is None:
-            task_name = str(subtask_class)
+        else:
+            task_name = getattr(subtask_class, "__name__", None) or str(subtask_class)
 
     name = f"Iterable{task_name}"
 

--- a/instructor/v2/dsl/partial.py
+++ b/instructor/v2/dsl/partial.py
@@ -44,6 +44,27 @@ UNION_ORIGINS = (Union, UNION_TYPE) if UNION_TYPE is not None else (Union,)
 _processing_models: set[type] = set()
 
 
+def _unwrap_optional_base_model(annotation: Any) -> type[BaseModel] | None:
+    """Return the BaseModel subclass for a type annotation, unwrapping Optional[T].
+
+    Handles:
+    - Direct BaseModel subclass  →  returns it as-is
+    - ``Optional[T]`` / ``Union[T, None]`` where T is a BaseModel  →  returns T
+    - Arbitrary ``Union`` with multiple non-None args  →  returns None (ambiguous)
+    - Any other annotation  →  returns None
+    """
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+    origin = get_origin(annotation)
+    if origin in UNION_ORIGINS:
+        non_none_args = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if len(non_none_args) == 1:
+            arg = non_none_args[0]
+            if isinstance(arg, type) and issubclass(arg, BaseModel):
+                return arg
+    return None
+
+
 class MakeFieldsOptional:
     pass
 
@@ -149,15 +170,17 @@ def _build_partial_object(
         field_type = field_info.annotation if field_info else None
 
         if field_complete and field_type is not None:
-            if isinstance(field_type, type) and issubclass(field_type, BaseModel):
-                result[field_name] = field_type.model_validate(field_value, **kwargs)
+            _base_model = _unwrap_optional_base_model(field_type)
+            if _base_model is not None:
+                result[field_name] = _base_model.model_validate(field_value, **kwargs)
                 continue
 
         if isinstance(field_value, dict):
-            nested_model = None
-            if field_type is not None and isinstance(field_type, type):
-                if issubclass(field_type, BaseModel):
-                    nested_model = field_type
+            nested_model = (
+                _unwrap_optional_base_model(field_type)
+                if field_type is not None
+                else None
+            )
 
             if nested_model:
                 result[field_name] = _build_partial_object(
@@ -213,10 +236,10 @@ def _build_partial_list(
         item_path = f"{path}[{i}]"
         item_complete = tracker.is_path_complete(item_path)
 
-        if item_complete and item_type and isinstance(item_type, type):
-            if issubclass(item_type, BaseModel) and isinstance(item, dict):
-                result.append(item_type.model_validate(item, **kwargs))
-                continue
+        _item_model = _unwrap_optional_base_model(item_type) if item_type else None
+        if item_complete and _item_model is not None and isinstance(item, dict):
+            result.append(_item_model.model_validate(item, **kwargs))
+            continue
 
         result.append(item)
 

--- a/instructor/v2/providers/cohere/handlers.py
+++ b/instructor/v2/providers/cohere/handlers.py
@@ -21,6 +21,7 @@ from instructor.v2.core.errors import ConfigurationError, ResponseParsingError
 from instructor.v2.core.json import extract_json_from_codeblock
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.core.handler import ModeHandler
+from instructor.v2.core.messages import copy_messages_for_mutation
 from instructor.v2.dsl.iterable import IterableBase
 from instructor.v2.dsl.partial import PartialBase
 
@@ -70,6 +71,8 @@ def _convert_messages_to_cohere_v2(kwargs: dict[str, Any]) -> dict[str, Any]:
     """Clean up kwargs for Cohere V2 format (OpenAI-compatible)."""
     new_kwargs = kwargs.copy()
     new_kwargs.pop("_cohere_client_version", None)
+    if "messages" in new_kwargs:
+        new_kwargs["messages"] = copy_messages_for_mutation(new_kwargs["messages"])
 
     # Rename model_name to model if needed
     if "model_name" in new_kwargs and "model" not in new_kwargs:

--- a/instructor/v2/providers/mistral/handlers.py
+++ b/instructor/v2/providers/mistral/handlers.py
@@ -40,7 +40,11 @@ from instructor.v2.core.json import (
     extract_json_from_stream_async,
 )
 from instructor.v2.providers.openai.schema import generate_openai_schema
-from instructor.v2.core.messages import dump_message, merge_consecutive_messages
+from instructor.v2.core.messages import (
+    copy_messages_for_mutation,
+    dump_message,
+    merge_consecutive_messages,
+)
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.core.handler import ModeHandler
 
@@ -247,6 +251,7 @@ class MistralToolsHandler(MistralHandlerBase):
     ) -> tuple[type[BaseModel] | None, dict[str, Any]]:
         """Prepare request with tool definitions."""
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
 
         if response_model is None:
             return None, new_kwargs
@@ -389,6 +394,7 @@ class MistralJSONSchemaHandler(MistralHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
 
         # Use Mistral's helper to create response format
         from mistralai.extra import response_format_from_pydantic_model
@@ -495,7 +501,7 @@ class MistralMDJSONHandler(MistralHandlerBase):
         )
 
         # Add system message with schema
-        messages = new_kwargs.get("messages", [])
+        messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
         if messages and messages[0]["role"] != "system":
             messages.insert(
                 0,

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -41,7 +41,11 @@ from instructor.v2.core.json import (
     extract_json_from_stream,
     extract_json_from_stream_async,
 )
-from instructor.v2.core.messages import dump_message, merge_consecutive_messages
+from instructor.v2.core.messages import (
+    copy_messages_for_mutation,
+    dump_message,
+    merge_consecutive_messages,
+)
 from instructor.v2.providers.openai.schema import generate_openai_schema
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.core.handler import ModeHandler
@@ -619,6 +623,7 @@ class OpenAIToolsHandler(OpenAIHandlerBase):
     ) -> tuple[Any, dict[str, Any]]:
         """Prepare request with tool definitions."""
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
 
         if response_model is None:
             return None, new_kwargs
@@ -744,6 +749,7 @@ class OpenAIJSONSchemaHandler(OpenAIHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         schema = response_model.model_json_schema()
         new_kwargs["response_format"] = {
             "type": "json_schema",
@@ -829,7 +835,7 @@ class OpenAIJSONHandler(OpenAIHandlerBase):
             Make sure to return an instance of the JSON, not the schema itself
             """
         )
-        messages = new_kwargs.get("messages", [])
+        messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
         if messages and messages[0]["role"] != "system":
             messages.insert(
                 0,
@@ -919,7 +925,7 @@ class OpenAIMDJSONHandler(OpenAIHandlerBase):
         )
 
         # Add system message with schema
-        messages = new_kwargs.get("messages", [])
+        messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
         if messages and messages[0]["role"] != "system":
             messages.insert(
                 0,
@@ -1007,6 +1013,7 @@ class OpenAIParallelToolsHandler(OpenAIHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         if new_kwargs.get("stream", False):
             raise ConfigurationError(
                 "stream=True is not supported when using PARALLEL_TOOLS mode"
@@ -1092,6 +1099,7 @@ class OpenAIResponsesToolsHandler(OpenAIHandlerBase):
         self._register_streaming_from_kwargs(response_model, kwargs)
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
 
         # Handle max_tokens to max_output_tokens conversion
         if new_kwargs.get("max_tokens") is not None:

--- a/instructor/v2/providers/openai/schema.py
+++ b/instructor/v2/providers/openai/schema.py
@@ -23,9 +23,12 @@ def generate_openai_schema(model: type[BaseModel]) -> dict[str, Any]:
             if "description" not in parameters["properties"][name]:
                 parameters["properties"][name]["description"] = description
 
-    parameters["required"] = sorted(
-        k for k, v in parameters["properties"].items() if "default" not in v
-    )
+    # Reuse Pydantic's own required set, which excludes any field that has a
+    # default -- whether that default is a plain value (``default=``) or a
+    # ``default_factory=``. Deriving it from the presence of a ``"default"``
+    # key in each property missed default_factory fields (whose defaults are
+    # never emitted into the JSON schema) and wrongly marked them required.
+    parameters["required"] = sorted(schema.get("required", []))
 
     if "description" not in schema:
         schema["description"] = (

--- a/instructor/v2/providers/openrouter/handlers.py
+++ b/instructor/v2/providers/openrouter/handlers.py
@@ -33,6 +33,7 @@ class OpenRouterJSONSchemaHandler(OpenAIJSONSchemaHandler):
         if response_model is None:
             return None, kwargs
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         return handle_openrouter_structured_outputs(response_model, new_kwargs)
 
     def handle_reask(

--- a/instructor/v2/providers/writer/handlers.py
+++ b/instructor/v2/providers/writer/handlers.py
@@ -20,7 +20,11 @@ from instructor.v2.core.providers import Provider
 from instructor.v2.core.errors import IncompleteOutputException, ResponseParsingError
 from instructor.v2.core.json import extract_json_from_codeblock
 from instructor.v2.providers.openai.schema import generate_openai_schema
-from instructor.v2.core.messages import dump_message, merge_consecutive_messages
+from instructor.v2.core.messages import (
+    copy_messages_for_mutation,
+    dump_message,
+    merge_consecutive_messages,
+)
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.providers.openai.handlers import OpenAIHandlerBase
 
@@ -142,6 +146,7 @@ class WriterToolsHandler(WriterHandlerBase):
         self._register_streaming_from_kwargs(response_model, kwargs)
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         schema = generate_openai_schema(response_model)
 
         new_kwargs["tools"] = [{"type": "function", "function": schema}]
@@ -241,7 +246,7 @@ class WriterMDJSONHandler(WriterHandlerBase):
         )
 
         # Add system message with schema
-        messages = new_kwargs.get("messages", [])
+        messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
         if messages and messages[0]["role"] != "system":
             messages.insert(
                 0,
@@ -322,6 +327,7 @@ class WriterJSONSchemaHandler(WriterHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         self._register_streaming_from_kwargs(response_model, new_kwargs)
         return handle_writer_json(response_model, new_kwargs)
 

--- a/instructor/v2/providers/xai/handlers.py
+++ b/instructor/v2/providers/xai/handlers.py
@@ -52,6 +52,7 @@ from instructor.v2.core.json import (
 )
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.core.handler import ModeHandler
+from instructor.v2.core.messages import copy_messages_for_mutation
 
 
 def _convert_messages(messages: list[dict[str, Any]]) -> list[Any]:
@@ -396,6 +397,7 @@ class XAIToolsHandler(XAIHandlerBase):
     ) -> tuple[type[BaseModel] | None, dict[str, Any]]:
         """Prepare request with tool definitions for xAI."""
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
 
         if response_model is None:
             return None, new_kwargs
@@ -520,6 +522,7 @@ class XAIParallelToolsHandler(XAIHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         if new_kwargs.get("stream", False):
             from instructor.v2.core.errors import ConfigurationError
 
@@ -591,6 +594,7 @@ class XAIJSONSchemaHandler(XAIHandlerBase):
             return None, kwargs
 
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         schema = response_model.model_json_schema()
 
         # Store schema info for xAI SDK's parse() method
@@ -703,7 +707,7 @@ class XAIMDJSONHandler(XAIHandlerBase):
         )
 
         # Add system message with schema
-        messages = new_kwargs.get("messages", [])
+        messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
         if messages and messages[0]["role"] != "system":
             messages.insert(
                 0,

--- a/tests/core/test_schema_utils.py
+++ b/tests/core/test_schema_utils.py
@@ -151,6 +151,25 @@ def test_required_fields_generation():
     assert "email" not in required
 
 
+def test_default_factory_fields_not_required():
+    """Fields with a default_factory have a default and must not be required."""
+
+    class ModelWithFactory(BaseModel):
+        name: str
+        items: list[str] = Field(default_factory=list)
+        tags: dict[str, str] = Field(default_factory=dict)
+
+    schema = generate_openai_schema(ModelWithFactory)
+    required = schema["parameters"]["required"]
+
+    # Only ``name`` has no default; the default_factory fields are optional.
+    assert required == ["name"]
+    # And it should agree with Pydantic's own required set.
+    assert set(required) == set(
+        ModelWithFactory.model_json_schema().get("required", [])
+    )
+
+
 def test_field_descriptions():
     """Test that field descriptions are preserved."""
     schema = generate_openai_schema(TestModel)

--- a/tests/coverage/test_dsl_iter_parallel_coverage.py
+++ b/tests/coverage/test_dsl_iter_parallel_coverage.py
@@ -264,10 +264,7 @@ def test_iterable_model_supports_custom_names_union_names_and_forward_refs() -> 
 
     assert named.__name__ == "IterableQueuedEmail"
     assert named.__doc__ == "Queued email jobs"
-    expected_union_name = (
-        "IterableEmailJobOrSmsJob" if sys.version_info < (3, 10) else "IterableUnion"
-    )
-    assert union.__name__ == expected_union_name
+    assert union.__name__ == "IterableEmailJobOrSmsJob"
     assert forward_ref.__name__ == "IterableEmailJob"
     assert forward_ref.model_fields["tasks"].annotation == list["EmailJob"]
 

--- a/tests/coverage/test_dsl_partial_coverage.py
+++ b/tests/coverage/test_dsl_partial_coverage.py
@@ -75,7 +75,7 @@ _build_partial_list = cast(
     vars(partial_module)["_build_partial_list"],
 )
 _unwrap_optional_base_model = cast(
-    Callable[[Any], type[BaseModel] | None],
+    Callable[[Any], Optional[type[BaseModel]]],
     vars(partial_module)["_unwrap_optional_base_model"],
 )
 

--- a/tests/coverage/test_dsl_partial_coverage.py
+++ b/tests/coverage/test_dsl_partial_coverage.py
@@ -74,6 +74,10 @@ _build_partial_list = cast(
     ],
     vars(partial_module)["_build_partial_list"],
 )
+_unwrap_optional_base_model = cast(
+    Callable[[Any], type[BaseModel] | None],
+    vars(partial_module)["_unwrap_optional_base_model"],
+)
 
 
 class TextChunk:
@@ -87,6 +91,10 @@ class TextChunk:
 class UnprintableChunk:
     def __str__(self) -> str:
         raise ValueError("cannot render chunk")
+
+
+def test_optional_base_model_unwrap_rejects_optional_scalars() -> None:
+    assert _unwrap_optional_base_model(Optional[int]) is None
 
 
 def test_partial_builder_validates_complete_nested_values_and_keeps_open_values() -> (

--- a/tests/coverage/test_openai_handlers_coverage.py
+++ b/tests/coverage/test_openai_handlers_coverage.py
@@ -738,12 +738,16 @@ def test_json_prompt_handlers_extend_list_system_content_and_create_system_messa
     list_messages = [
         {"role": "system", "content": [{"type": "text", "text": "Extract users."}]}
     ]
+    string_messages = [{"role": "system", "content": "Extract users."}]
 
     _, with_list = handler.prepare_request(User, {"messages": list_messages})
+    _, with_string = handler.prepare_request(User, {"messages": string_messages})
     _, without_messages = handler.prepare_request(User, {"messages": []})
 
     assert "Extract users." in with_list["messages"][0]["content"][0]["text"]
     assert "json_schema" in with_list["messages"][0]["content"][0]["text"]
+    assert "Extract users." in with_string["messages"][0]["content"]
+    assert "json_schema" in with_string["messages"][0]["content"]
     assert without_messages["messages"][0]["role"] == "system"
     assert "User" in without_messages["messages"][0]["content"]
     if isinstance(handler, OpenAIMDJSONHandler):

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -1197,3 +1197,86 @@ class TestRecursiveModels:
         assert result.content[0].text == "Introduction paragraph"
         assert result.content[1].title == "Section 1.1"
         assert result.content[1].content[1].title == "Subsection 1.1.1"
+
+
+class TestOptionalNestedBaseModelDuringPartialStreaming:
+    """Regression tests for Optional[BaseModel] field handling during partial streaming.
+
+    When the root JSON is incomplete (stream still in flight), _build_partial_object()
+    is called instead of model_validate().  Fields annotated as ``Optional[NestedModel]``
+    (equivalently ``Union[NestedModel, None]``) used to be stored as raw ``dict`` objects
+    because the guard ``isinstance(field_type, type)`` returns False for generic aliases
+    like ``Optional[NestedModel]``.
+
+    The fix adds ``_unwrap_optional_base_model()`` which unwraps the Optional wrapper, so
+    callers get proper model instances with attribute access instead of plain dicts.
+    """
+
+    def test_optional_nested_basemodel_is_model_instance_during_incomplete_stream(self):
+        """Optional[NestedModel] fields must yield NestedModel instances, not raw dicts."""
+
+        class Inner(BaseModel):
+            value: int
+
+        class Outer(BaseModel):
+            name: str
+            inner: Optional[Inner] = None
+
+        partial = Partial[Outer]
+
+        # Incomplete JSON — root closing brace is missing, so _build_partial_object runs
+        chunks = ['{"name": "alice", "inner": {"value": 42}']
+
+        results = list(_partial_api(partial).model_from_chunks(chunks))
+        assert len(results) == 1
+        obj = results[0]
+
+        # Before the fix: obj.inner was a plain dict {"value": 42}
+        assert isinstance(obj.inner, Inner), (
+            f"Expected Inner instance, got {type(obj.inner)}: {obj.inner!r}"
+        )
+        assert obj.inner.value == 42
+
+    def test_optional_nested_basemodel_attribute_access_does_not_raise(self):
+        """Attribute access on an Optional[BaseModel] field must not raise AttributeError."""
+
+        class Address(BaseModel):
+            city: str
+            zip_code: str
+
+        class Person(BaseModel):
+            name: str
+            address: Optional[Address] = None
+
+        partial = Partial[Person]
+
+        # Root still open — simulates mid-stream state
+        chunks = ['{"name": "bob", "address": {"city": "NYC", "zip_code": "10001"}']
+
+        results = list(_partial_api(partial).model_from_chunks(chunks))
+        obj = results[-1]
+
+        # Would raise AttributeError on a raw dict before the fix
+        assert obj.address.city == "NYC"
+        assert obj.address.zip_code == "10001"
+
+    def test_optional_nested_basemodel_absent_field_stays_none(self):
+        """When the Optional[BaseModel] field is absent, its default (None) must not change."""
+
+        class Inner(BaseModel):
+            value: int
+
+        class Outer(BaseModel):
+            name: str
+            inner: Optional[Inner] = None
+
+        partial = Partial[Outer]
+
+        # inner field completely absent; root also incomplete
+        chunks = ['{"name": "carol"']
+
+        results = list(_partial_api(partial).model_from_chunks(chunks))
+        obj = results[-1]
+
+        # Must remain None — not an empty Inner() instance
+        assert obj.inner is None

--- a/tests/dsl/test_simple_types.py
+++ b/tests/dsl/test_simple_types.py
@@ -170,3 +170,43 @@ def test_list_of_model_pipe_union_generates_clean_name():
     assert "|" not in prepared.__name__
     assert "." not in prepared.__name__
     assert prepared.__name__ == "IterableAOrB"
+
+
+def test_list_of_model_typing_union_generates_clean_name():
+    """`List[Union[A, B]]` must derive its Iterable name from the union members.
+
+    Both `typing.Union[A, B]` and PEP 604 `A | B` expose ``__name__ == "Union"``, so a
+    naive ``__name__`` lookup collapses every union to ``IterableUnion``. The name should
+    instead be built from the member names (``IterableAOrB``).
+    """
+
+    class A(BaseModel):
+        x: int
+
+    class B(BaseModel):
+        y: str
+
+    prepared = prepare_response_model(List[Union[A, B]])  # noqa: UP006
+    assert prepared is not None
+    assert prepared.__name__ == "IterableAOrB"
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Union pipe syntax is only available in Python 3.10+",
+)
+def test_list_of_model_three_way_union_generates_clean_name():
+    """A union with more than two members joins every member name with ``Or``."""
+
+    class A(BaseModel):
+        x: int
+
+    class B(BaseModel):
+        y: str
+
+    class C(BaseModel):
+        z: float
+
+    prepared = prepare_response_model(list[A | B | C])
+    assert prepared is not None
+    assert prepared.__name__ == "IterableAOrBOrC"

--- a/tests/v2/test_cohere_handlers.py
+++ b/tests/v2/test_cohere_handlers.py
@@ -601,6 +601,16 @@ class TestCohereMessageConversion:
 
         assert "strict" not in result
 
+    def test_convert_v2_without_messages(self):
+        """Test that message-free kwargs remain message-free."""
+        from instructor.v2.providers.cohere.handlers import (
+            _convert_messages_to_cohere_v2,
+        )
+
+        result = _convert_messages_to_cohere_v2({"model": "command-r-plus"})
+
+        assert "messages" not in result
+
 
 # ============================================================================
 # Text Extraction Tests

--- a/tests/v2/test_json_helpers.py
+++ b/tests/v2/test_json_helpers.py
@@ -38,6 +38,21 @@ def test_extract_json_from_codeblock_handles_even_backslashes_before_quote() -> 
     assert extract_json_from_codeblock(content) == '{"path":"C:\\\\","name":"Ada"}'
 
 
+def test_extract_json_from_codeblock_returns_last_top_level_candidate() -> None:
+    content = (
+        'The user supplied {"is_verified":true}. '
+        'The result is {"person":{"name":"Ada"}}.'
+    )
+
+    assert extract_json_from_codeblock(content) == '{"person":{"name":"Ada"}}'
+
+
+def test_extract_json_from_codeblock_preserves_nested_candidate() -> None:
+    content = 'prefix {"person":{"name":"Ada"}} suffix'
+
+    assert extract_json_from_codeblock(content) == '{"person":{"name":"Ada"}}'
+
+
 def test_extract_json_from_stream_handles_plain_json() -> None:
     assert "".join(extract_json_from_stream(["before ", '{"a":', "1}", " after"])) == (
         '{"a":1}'
@@ -89,6 +104,17 @@ def test_extract_json_from_stream_preserves_triple_backticks_in_plain_string() -
     assert "".join(extract_json_from_stream(chunks)) == '{"code":"```py```"}'
 
 
+def test_extract_json_from_stream_yields_all_objects_in_one_chunk() -> None:
+    # A complete object must not swallow a second object sharing its chunk.
+    chunks = ['{"a":1}{"b":2}']
+    assert "".join(extract_json_from_stream(chunks)) == '{"a":1}{"b":2}'
+
+
+def test_extract_json_from_stream_yields_all_objects_in_fenced_chunk() -> None:
+    chunks = ['```json\n{"a":1}{"b":2}\n```']
+    assert "".join(extract_json_from_stream(chunks)) == '{"a":1}{"b":2}'
+
+
 def test_extract_json_from_stream_preserves_backticks_in_fenced_string() -> None:
     chunks = ["```json\n", '{"code":"`inline`"}', "\n```"]
 
@@ -128,6 +154,16 @@ async def test_extract_json_from_stream_async_handles_array_root() -> None:
         "".join([chunk async for chunk in extract_json_from_stream_async(chunks())])
         == '[{"a":1}]'
     )
+
+
+@pytest.mark.asyncio
+async def test_extract_json_from_stream_async_yields_all_objects_in_chunk() -> None:
+    async def chunks():
+        yield '{"a":1}{"b":2}'
+
+    assert "".join(
+        [chunk async for chunk in extract_json_from_stream_async(chunks())]
+    ) == ('{"a":1}{"b":2}')
 
 
 @pytest.mark.asyncio

--- a/tests/v2/test_messages_not_mutated.py
+++ b/tests/v2/test_messages_not_mutated.py
@@ -96,7 +96,7 @@ def test_prepare_request_does_not_alias_caller_messages(
     caller_messages = [{"role": "user", "content": "hi"}]
     original_snapshot = deepcopy(caller_messages)
     kwargs: dict[str, Any] = {"model": "test", "messages": caller_messages}
-    response_model = Iterable[Answer] if mode is Mode.PARALLEL_TOOLS else Answer
+    response_model: Any = Iterable[Answer] if mode is Mode.PARALLEL_TOOLS else Answer
 
     handlers = mode_registry.get_handlers(provider, mode)
     _, new_kwargs = handlers.request_handler(
@@ -217,7 +217,7 @@ def test_reask_does_not_mutate_caller_messages(provider: Provider, mode: Mode) -
 
     caller_messages = [{"role": "user", "content": "hi"}]
     original_snapshot = deepcopy(caller_messages)
-    response_model = Iterable[Answer] if mode is Mode.PARALLEL_TOOLS else Answer
+    response_model: Any = Iterable[Answer] if mode is Mode.PARALLEL_TOOLS else Answer
 
     handlers = mode_registry.get_handlers(provider, mode)
     _, new_kwargs = handlers.request_handler(

--- a/tests/v2/test_messages_not_mutated.py
+++ b/tests/v2/test_messages_not_mutated.py
@@ -1,0 +1,229 @@
+"""Regression tests for the messages= aliasing bug (see GitHub issue #2417).
+
+`client.create()` must treat `messages=` as a read-only input. Internally,
+`prepare_request` must never hand back the caller's own list object, or
+leave the caller's message dicts open to in-place mutation, because both
+`prepare_request` itself (JSON/MD_JSON's system-message injection) and
+`handle_reask` (the retry path) mutate whatever `messages` list/dicts they
+are handed.
+
+Note on the aliasing check: comparing `new_kwargs["messages"] is not
+caller_messages` alone is not sufficient -- `OpenAIJSONHandler` and
+`OpenAIMDJSONHandler` mutate the *input* list/dicts in place before
+rebuilding `messages` into a genuinely new list via
+`merge_consecutive_messages()`, so an identity check on the final result
+would pass even though the caller's original objects were already
+corrupted. These tests instead snapshot `caller_messages` with `deepcopy`
+before the call and assert it is unchanged afterward.
+
+The provider lists below are imported directly from the shared OpenAI-compat
+handler module so this test stays in sync with the source registrations
+rather than duplicating them.
+
+Independently-implemented handlers (Mistral, Cohere, Writer, xAI, OpenRouter)
+reproduce the same anti-pattern in their own provider-specific code and were
+previously tracked here as known-broken `xfail` cases. They are now fixed too
+and folded into `FIXED_PAIRS` below.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from copy import deepcopy
+from typing import Any
+
+import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+from openai.types.completion_usage import CompletionUsage
+from pydantic import BaseModel
+
+from instructor.v2.core.mode import Mode
+from instructor.v2.core.providers import Provider
+from instructor.v2.core.registry import mode_registry
+from instructor.v2.core.retry import retry_sync_v2
+from instructor.v2.providers.openai.handlers import (
+    OPENAI_COMPAT_PROVIDERS,
+    OPENAI_JSON_SCHEMA_PROVIDERS,
+    OPENAI_PARALLEL_TOOL_PROVIDERS,
+)
+
+
+class Answer(BaseModel):
+    name: str
+    age: int
+
+
+# (provider, mode) pairs whose handlers were patched to stop aliasing
+# `messages`. Covers both the shared OpenAI-compat handler classes and the
+# independently-implemented provider-specific handlers (Mistral, Cohere,
+# Writer, xAI, OpenRouter) that reproduced the same anti-pattern separately.
+FIXED_PAIRS: list[tuple[Provider, Mode]] = [
+    *((provider, Mode.TOOLS) for provider in OPENAI_COMPAT_PROVIDERS),
+    *((provider, Mode.JSON_SCHEMA) for provider in OPENAI_JSON_SCHEMA_PROVIDERS),
+    *((provider, Mode.PARALLEL_TOOLS) for provider in OPENAI_PARALLEL_TOOL_PROVIDERS),
+    *((provider, Mode.JSON) for provider in OPENAI_COMPAT_PROVIDERS),
+    *((provider, Mode.MD_JSON) for provider in OPENAI_COMPAT_PROVIDERS),
+    (Provider.OPENAI, Mode.RESPONSES_TOOLS),
+    (Provider.MISTRAL, Mode.TOOLS),
+    (Provider.MISTRAL, Mode.JSON_SCHEMA),
+    (Provider.MISTRAL, Mode.MD_JSON),
+    (Provider.COHERE, Mode.JSON_SCHEMA),
+    (Provider.COHERE, Mode.MD_JSON),
+    (Provider.WRITER, Mode.TOOLS),
+    (Provider.WRITER, Mode.JSON_SCHEMA),
+    (Provider.WRITER, Mode.MD_JSON),
+    (Provider.XAI, Mode.TOOLS),
+    (Provider.XAI, Mode.PARALLEL_TOOLS),
+    (Provider.XAI, Mode.JSON_SCHEMA),
+    (Provider.XAI, Mode.MD_JSON),
+    (Provider.OPENROUTER, Mode.JSON_SCHEMA),
+]
+
+
+@pytest.mark.parametrize(
+    ("provider", "mode"),
+    FIXED_PAIRS,
+    ids=[f"{provider.value}-{mode.value}" for provider, mode in FIXED_PAIRS],
+)
+def test_prepare_request_does_not_alias_caller_messages(
+    provider: Provider, mode: Mode
+) -> None:
+    caller_messages = [{"role": "user", "content": "hi"}]
+    original_snapshot = deepcopy(caller_messages)
+    kwargs: dict[str, Any] = {"model": "test", "messages": caller_messages}
+    response_model = Iterable[Answer] if mode is Mode.PARALLEL_TOOLS else Answer
+
+    handlers = mode_registry.get_handlers(provider, mode)
+    _, new_kwargs = handlers.request_handler(
+        response_model=response_model, kwargs=kwargs
+    )
+
+    assert new_kwargs["messages"] is not caller_messages
+    # Deep-content check, not just identity: a handler can rebuild
+    # `new_kwargs["messages"]` into a fresh list while still having mutated
+    # the caller's original list/dicts in place before doing so.
+    assert caller_messages == original_snapshot
+
+
+def _make_tool_call_response(arguments: str, call_id: str) -> ChatCompletion:
+    tool_call = ChatCompletionMessageToolCall(
+        id=call_id,
+        type="function",
+        function=Function(name="Answer", arguments=arguments),
+    )
+    message = ChatCompletionMessage(
+        role="assistant", content=None, tool_calls=[tool_call]
+    )
+    choice = Choice(index=0, message=message, finish_reason="tool_calls", logprobs=None)
+    return ChatCompletion(
+        id="chatcmpl-test",
+        choices=[choice],
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        usage=CompletionUsage(completion_tokens=5, prompt_tokens=10, total_tokens=15),
+    )
+
+
+def test_client_create_does_not_mutate_caller_messages_after_reask() -> None:
+    """End-to-end: a validation failure followed by a successful retry must
+    leave the caller's original `messages` list completely untouched."""
+    call_count = {"n": 0}
+
+    def fake_openai_create(*_args: Any, **_kwargs: Any) -> ChatCompletion:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _make_tool_call_response('{"name": "Ada"}', "call_1")
+        return _make_tool_call_response('{"name": "Ada", "age": 37}', "call_2")
+
+    caller_messages = [{"role": "user", "content": "Ada is 37 years old"}]
+
+    handlers = mode_registry.get_handlers(Provider.OPENAI, Mode.TOOLS)
+    response_model, new_kwargs = handlers.request_handler(
+        response_model=Answer,
+        kwargs={"model": "gpt-4o-mini", "messages": caller_messages},
+    )
+
+    result = retry_sync_v2(
+        func=fake_openai_create,
+        response_model=response_model,
+        provider=Provider.OPENAI,
+        mode=Mode.TOOLS,
+        context=None,
+        max_retries=2,
+        args=(),
+        kwargs=new_kwargs,
+        strict=True,
+        hooks=None,
+    )
+
+    assert isinstance(result, Answer)
+    assert result.name == "Ada"
+    assert result.age == 37
+    assert caller_messages == [{"role": "user", "content": "Ada is 37 years old"}]
+
+
+REASK_MUTATION_PAIRS: list[tuple[Provider, Mode]] = [
+    (Provider.MISTRAL, Mode.TOOLS),
+    (Provider.MISTRAL, Mode.JSON_SCHEMA),
+    (Provider.COHERE, Mode.JSON_SCHEMA),
+    (Provider.WRITER, Mode.TOOLS),
+    (Provider.WRITER, Mode.JSON_SCHEMA),
+    (Provider.XAI, Mode.TOOLS),
+    (Provider.XAI, Mode.PARALLEL_TOOLS),
+    (Provider.XAI, Mode.JSON_SCHEMA),
+    (Provider.OPENROUTER, Mode.JSON_SCHEMA),
+]
+
+
+@pytest.mark.parametrize(
+    ("provider", "mode"),
+    REASK_MUTATION_PAIRS,
+    ids=[f"{provider.value}-{mode.value}" for provider, mode in REASK_MUTATION_PAIRS],
+)
+def test_reask_does_not_mutate_caller_messages(provider: Provider, mode: Mode) -> None:
+    """Simulates the actual retry path (prepare_request -> handle_reask) for
+    provider-specific handlers, since `prepare_request` alone never touches
+    `messages` for these modes -- the append only happens once a reask
+    actually runs, which a prepare_request-only check would miss."""
+    tool_call = ChatCompletionMessageToolCall(
+        id="call_1",
+        type="function",
+        function=Function(name="Answer", arguments='{"name": "Ada"}'),
+    )
+    response = ChatCompletion(
+        id="chatcmpl-test",
+        choices=[
+            Choice(
+                index=0,
+                message=ChatCompletionMessage(
+                    role="assistant", content="stub", tool_calls=[tool_call]
+                ),
+                finish_reason="tool_calls",
+                logprobs=None,
+            )
+        ],
+        created=0,
+        model="m",
+        object="chat.completion",
+        usage=CompletionUsage(completion_tokens=1, prompt_tokens=1, total_tokens=2),
+    )
+    exception = ValueError("1 validation error for Answer\nage\n  Field required")
+
+    caller_messages = [{"role": "user", "content": "hi"}]
+    original_snapshot = deepcopy(caller_messages)
+    response_model = Iterable[Answer] if mode is Mode.PARALLEL_TOOLS else Answer
+
+    handlers = mode_registry.get_handlers(provider, mode)
+    _, new_kwargs = handlers.request_handler(
+        response_model=response_model,
+        kwargs={"model": "test", "messages": caller_messages},
+    )
+    handlers.reask_handler(new_kwargs, response, exception)
+
+    assert caller_messages == original_snapshot


### PR DESCRIPTION
## Summary

- preserve caller-owned message lists and nested content across request preparation and retries for OpenAI-compatible, Cohere, Mistral, OpenRouter, Writer, and xAI handlers
- return the final complete top-level JSON candidate without collapsing nested payloads, and retain every object when multiple streamed JSON values share one chunk
- keep `default_factory` fields optional in OpenAI tool schemas
- build model instances for present `Optional[BaseModel]` fields during partial streaming
- derive iterable union names from their members for both `Union[A, B]` and `A | B`

Closes #2417.
Closes #2428.

Supersedes #2412, #2413, #2418, #2419, #2420, #2424, and #2427.

## Validation

- `pytest` focused regression suite: 181 passed, 1 skipped, 2 credentialed live tests deselected
- broader offline/local run: 1,741 passed and 138 skipped; 24 credentialed provider tests failed only because external API endpoints were unavailable
- Ruff lint: passed
- Ruff format check: passed
- `ty check` on all touched runtime modules: passed
- commit hooks: Ruff, formatting, and `ty` passed

## Notes

This consolidation preserves the original contributors' authorship in the commit trailers. It also corrects an edge case in #2424's proposed scanner: nested objects remain part of their enclosing top-level payload rather than being selected as the final candidate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core request prep, retry, and JSON parsing paths across many providers; the last-JSON heuristic alters structured-output behavior but is intentional for injection resistance.
> 
> **Overview**
> This PR bundles several **v2 runtime correctness fixes** that were previously spread across multiple issues/PRs, plus regression tests and changelog entries.
> 
> **Caller-owned `messages` are no longer mutated** during `prepare_request` or retries. A new `copy_messages_for_mutation` deep-copies message dicts (including list-shaped `content`), and OpenAI-compatible, Mistral, Cohere, Writer, xAI, and OpenRouter handlers now copy `messages` before injecting system/schema prompts or extending history on reask.
> 
> **JSON parsing is safer and more complete.** `extract_json_from_codeblock` now selects the **last** valid top-level JSON object in text (so embedded user JSON in prompts cannot hijack parsing). Stream extractors **keep scanning** after a finished object so multiple JSON values in one chunk are all emitted.
> 
> **Tool schemas and streaming models** align better with Pydantic: OpenAI tool `required` lists reuse Pydantic’s `required` set (so `default_factory` fields are optional), partial streaming builds instances for **`Optional[BaseModel]`** nested fields, and iterable union response models get stable names like `IterableAOrB` for both `Union[A, B]` and `A | B`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00f343d7a7c95ceb45f93b45c3e6b62fd6642d5b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->