### PR TITLE
fix(core): deep-copy messages in prepare_request to prevent caller mutation

### DIFF
--- a/instructor/v2/providers/anthropic/handlers.py
+++ b/instructor/v2/providers/anthropic/handlers.py
@@ -421,7 +421,7 @@ class AnthropicToolsHandler(AnthropicHandlerBase):
         response: Message,
         exception: Exception,
     ) -> dict[str, Any]:
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         if response is None or not hasattr(response, "content"):
             kwargs["messages"].append(
                 {
@@ -687,7 +687,7 @@ class AnthropicJSONHandler(AnthropicHandlerBase):
         response: Message,
         exception: Exception,
     ) -> dict[str, Any]:
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         text_blocks = [c for c in response.content if c.type == "text"]
         if not text_blocks:
             text_content = "No text content found in response"
@@ -862,7 +862,7 @@ class AnthropicStructuredOutputsHandler(AnthropicHandlerBase):
         exception: Exception,
     ) -> dict[str, Any]:
         # Use same reask logic as JSON mode
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         text_blocks = [c for c in response.content if c.type == "text"]
         if not text_blocks:
             text_content = "No text content found in response"

--- a/instructor/v2/providers/cohere/handlers.py
+++ b/instructor/v2/providers/cohere/handlers.py
@@ -68,7 +68,7 @@ def _convert_messages_to_cohere_v1(kwargs: dict[str, Any]) -> dict[str, Any]:
 
 def _convert_messages_to_cohere_v2(kwargs: dict[str, Any]) -> dict[str, Any]:
     """Clean up kwargs for Cohere V2 format (OpenAI-compatible)."""
-    new_kwargs = kwargs.copy()
+    new_kwargs = {**kwargs, 'messages': [dict(m) for m in kwargs.get('messages', [])]}
     new_kwargs.pop("_cohere_client_version", None)
 
     # Rename model_name to model if needed

--- a/instructor/v2/providers/mistral/handlers.py
+++ b/instructor/v2/providers/mistral/handlers.py
@@ -251,7 +251,7 @@ class MistralToolsHandler(MistralHandlerBase):
         kwargs: dict[str, Any],
     ) -> tuple[type[BaseModel] | None, dict[str, Any]]:
         """Prepare request with tool definitions."""
-        new_kwargs = kwargs.copy()
+        new_kwargs = {**kwargs, 'messages': [dict(m) for m in kwargs.get('messages', [])]}
 
         if response_model is None:
             return None, new_kwargs
@@ -393,7 +393,7 @@ class MistralJSONSchemaHandler(MistralHandlerBase):
         if response_model is None:
             return None, kwargs
 
-        new_kwargs = kwargs.copy()
+        new_kwargs = {**kwargs, 'messages': [dict(m) for m in kwargs.get('messages', [])]}
 
         # Use Mistral's helper to create response format
         from mistralai.extra import response_format_from_pydantic_model
@@ -485,7 +485,7 @@ class MistralMDJSONHandler(MistralHandlerBase):
         if response_model is None:
             return None, kwargs
 
-        new_kwargs = kwargs.copy()
+        new_kwargs = {**kwargs, 'messages': [dict(m) for m in kwargs.get('messages', [])]}
         schema = response_model.model_json_schema()
 
         message = dedent(

--- a/instructor/v2/providers/mistral/handlers.py
+++ b/instructor/v2/providers/mistral/handlers.py
@@ -293,7 +293,7 @@ class MistralToolsHandler(MistralHandlerBase):
         exception: Exception,
     ) -> dict[str, Any]:
         """Handle reask for tools mode."""
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         reask_msgs: list[Any] = [dump_message(response.choices[0].message)]
 
         for tool_call in response.choices[0].message.tool_calls:
@@ -415,7 +415,7 @@ class MistralJSONSchemaHandler(MistralHandlerBase):
         exception: Exception,
     ) -> dict[str, Any]:
         """Handle reask for JSON schema mode."""
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         reask_msgs = [
             {
                 "role": "assistant",
@@ -538,7 +538,7 @@ class MistralMDJSONHandler(MistralHandlerBase):
         exception: Exception,
     ) -> dict[str, Any]:
         """Handle reask for MD_JSON mode."""
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         reask_msgs = [
             {
                 "role": "assistant",

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -156,7 +156,7 @@ def reask_tools(
     exception: Exception,
 ):
     """Handle reask for OpenAI tools mode when validation fails."""
-    kwargs = kwargs.copy()
+    kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
 
     if _is_stream_response(response):
         kwargs["messages"].append(
@@ -193,7 +193,7 @@ def reask_responses_tools(
     exception: Exception,
 ):
     """Handle reask for OpenAI responses tools mode when validation fails."""
-    kwargs = kwargs.copy()
+    kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
 
     if response is None or not hasattr(response, "output"):
         kwargs["messages"].append(
@@ -250,7 +250,7 @@ def reask_md_json(
     exception: Exception,
 ):
     """Handle reask for OpenAI JSON modes when validation fails."""
-    kwargs = kwargs.copy()
+    kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
 
     if _is_stream_response(response):
         kwargs["messages"].append(
@@ -293,7 +293,7 @@ def reask_default(
     exception: Exception,
 ):
     """Handle reask for OpenAI default mode when validation fails."""
-    kwargs = kwargs.copy()
+    kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
 
     if _is_stream_response(response):
         kwargs["messages"].append(

--- a/instructor/v2/providers/xai/handlers.py
+++ b/instructor/v2/providers/xai/handlers.py
@@ -397,7 +397,7 @@ class XAIToolsHandler(XAIHandlerBase):
         kwargs: dict[str, Any],
     ) -> tuple[type[BaseModel] | None, dict[str, Any]]:
         """Prepare request with tool definitions for xAI."""
-        new_kwargs = kwargs.copy()
+        new_kwargs = {**kwargs, 'messages': [dict(m) for m in kwargs.get('messages', [])]}
 
         if response_model is None:
             return None, new_kwargs
@@ -521,7 +521,7 @@ class XAIParallelToolsHandler(XAIHandlerBase):
         if response_model is None:
             return None, kwargs
 
-        new_kwargs = kwargs.copy()
+        new_kwargs = {**kwargs, 'messages': [dict(m) for m in kwargs.get('messages', [])]}
         if new_kwargs.get("stream", False):
             from instructor.v2.core.errors import ConfigurationError
 
@@ -592,7 +592,7 @@ class XAIJSONSchemaHandler(XAIHandlerBase):
         if response_model is None:
             return None, kwargs
 
-        new_kwargs = kwargs.copy()
+        new_kwargs = {**kwargs, 'messages': [dict(m) for m in kwargs.get('messages', [])]}
         schema = response_model.model_json_schema()
 
         # Store schema info for xAI SDK's parse() method
@@ -689,7 +689,7 @@ class XAIMDJSONHandler(XAIHandlerBase):
         if response_model is None:
             return None, kwargs
 
-        new_kwargs = kwargs.copy()
+        new_kwargs = {**kwargs, 'messages': [dict(m) for m in kwargs.get('messages', [])]}
         schema = response_model.model_json_schema()
 
         message = dedent(

--- a/instructor/v2/providers/xai/handlers.py
+++ b/instructor/v2/providers/xai/handlers.py
@@ -86,7 +86,7 @@ def reask_xai_json(
     exception: Exception,
 ):
     """Handle reask for xAI JSON mode when validation fails."""
-    kwargs = kwargs.copy()
+    kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
     reask_msg = {
         "role": "user",
         "content": (
@@ -106,7 +106,7 @@ def reask_xai_tools(
     exception: Exception,
 ):
     """Handle reask for xAI tools mode when validation fails."""
-    kwargs = kwargs.copy()
+    kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
 
     assistant_msg = {
         "role": "assistant",
@@ -429,7 +429,7 @@ class XAIToolsHandler(XAIHandlerBase):
         exception: Exception,
     ) -> dict[str, Any]:
         """Handle reask for tools mode."""
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
 
         # Add assistant response to conversation history
         assistant_msg = {
@@ -610,7 +610,7 @@ class XAIJSONSchemaHandler(XAIHandlerBase):
         exception: Exception,
     ) -> dict[str, Any]:
         """Handle reask for JSON schema mode."""
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         reask_msg = {
             "role": "user",
             "content": f"Validation Errors found:\n{exception}\nRecall the function correctly, fix the errors found in the following attempt:\n{response}",
@@ -743,7 +743,7 @@ class XAIMDJSONHandler(XAIHandlerBase):
         exception: Exception,
     ) -> dict[str, Any]:
         """Handle reask for MD_JSON mode."""
-        kwargs = kwargs.copy()
+        kwargs = {**kwargs, 'messages': list(kwargs['messages'])}
         reask_msg = {
             "role": "user",
             "content": f"Validation Errors found:\n{exception}\nRecall the function correctly, fix the errors found in the following attempt:\n{response}",


### PR DESCRIPTION
## Describe your changes

Fixes a mutation bug where `prepare_request()` methods corrupt the caller's `messages` list on the first call (not just during retries).

Closes #2429

## Problem

Several `prepare_request()` methods use `kwargs.copy()` (shallow copy) or `_convert_messages(kwargs)` which returns a dict with a shared messages list. They then mutate `messages` via `.insert()`, `.append()`, or direct dict key assignment. Since the list and message dicts are shared references, this corrupts the caller's data.

```python
# Example from Mistral json_schema mode:
new_kwargs = kwargs.copy()                          # shallow copy
messages = new_kwargs.get("messages", [])           # SAME list object
messages.insert(0, {"role": "system", "content": ...})  # mutates caller's list
```

```python
# Example from Cohere V2:
new_kwargs = _convert_messages(kwargs)              # shared messages list
last_msg = new_kwargs["messages"][-1]               # SAME dict object
last_msg["content"] = f"..."                        # mutates caller's message
```

## Solution

Deep-copy the messages list and message dicts in `prepare_request()`:

```python
# Before
new_kwargs = kwargs.copy()

# After
new_kwargs = {**kwargs, 'messages': [dict(m) for m in kwargs.get('messages', [])]}
```

## Files changed

- `instructor/v2/providers/cohere/handlers.py` — 1 fix (`_convert_messages_to_cohere_v2`)
- `instructor/v2/providers/mistral/handlers.py` — 3 fixes (tools, json_schema, json_instructions modes)
- `instructor/v2/providers/xai/handlers.py` — 4 fixes (tools, parallel_tools, json_schema, json_instructions modes)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/truecallerabreham/instructor/blob/main/CONTRIBUTING.md) guide
- [ ] Lint and type checks pass (`make lint`, `make typecheck`)
- [ ] Tests added if applicable
- [ ] Documentation updated if applicable

## Reproduction

```python
import instructor
from openai import OpenAI

client = instructor.from_openai(OpenAI())

messages = [{"role": "user", "content": "hello"}]

# First call — prepare_request mutates messages
try:
    client.chat.completions.create(
        model="gpt-4o",
        messages=messages,
        response_model=str,
    )
except Exception:
    pass

# Without fix: messages now has a system message prepended
# With fix: messages unchanged
assert len(messages) == 1
assert messages[0]["role"] == "user"
```
