### PR TITLE
fix(v2): handle consecutive None-content messages in merge_consecutive_messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **v2 message handling**: `merge_consecutive_messages` no longer crashes with `AttributeError` when two consecutive same-role messages both have `content=None` (e.g. consecutive tool-call-only assistant turns in a replayed conversation history), affecting the OpenAI, Mistral, and Writer JSON-mode handlers.
 - **v2 message handling**: Preserve caller-owned message lists and nested content across request preparation and retries for OpenAI-compatible, Cohere, Mistral, OpenRouter, Writer, and xAI handlers. ([#2417](https://github.com/567-labs/instructor/issues/2417), [#2428](https://github.com/567-labs/instructor/issues/2428))
 - **v2 JSON extraction**: Prefer the final complete top-level JSON value in text responses and retain every JSON object when multiple objects arrive in one streaming chunk.
 - **v2 schemas**: Treat fields with Pydantic `default_factory` values as optional in generated OpenAI tool schemas.

--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -83,6 +83,8 @@ def merge_consecutive_messages(messages: list[dict[str, Any]]) -> list[dict[str,
     for message in messages:
         role = message.get("role", "user")
         new_content = message.get("content", "")
+        if new_content is None:
+            new_content = ""
         if not flat_string and isinstance(new_content, str):
             new_content = [{"type": "text", "text": new_content}]
 

--- a/tests/processing/test_message_processing.py
+++ b/tests/processing/test_message_processing.py
@@ -88,6 +88,27 @@ class TestMergeConsecutiveMessages:
         assert result[2]["role"] == "user"
         assert "I need help" in result[2]["content"]
 
+    def test_consecutive_none_content(self):
+        """Consecutive same-role messages with content=None (e.g. tool-call-only
+        assistant turns) must not crash the merge."""
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1"}],
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_2"}],
+            },
+        ]
+        result = merge_consecutive_messages(messages)
+        assert len(result) == 2
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "assistant"
+
 
 class TestGetMessageContent:
     """Test the get_message_content function."""


### PR DESCRIPTION
## Describe your changes

`merge_consecutive_messages` (`instructor/v2/core/messages.py`) crashes with `AttributeError: 'NoneType' object has no attribute 'append'` when two consecutive same-role messages both have `content=None` — a normal shape for back-to-back tool-call-only assistant turns (e.g. `{"role": "assistant", "content": None, "tool_calls": [...]}`) replayed as conversation history.

Root cause: `new_content = message.get("content", "")` — `dict.get(key, default)` only substitutes the default when the key is *absent*, not when its value is explicitly `None`. So `new_content` stays `None`, fails the `isinstance(new_content, str)` check, and on the second consecutive message of the same role hits `new_messages[-1]["content"].append(new_content)` where `new_messages[-1]["content"]` is itself `None`.

This runs before any network call — it's invoked directly on user-supplied `kwargs["messages"]` from the OpenAI (`Mode.JSON`/`Mode.MD_JSON`), Mistral, and Writer handlers (`instructor/v2/providers/{openai,mistral,writer}/handlers.py`).

Fix: normalize `None` content to `""` right after extraction, matching the function's existing convention of treating `""` as the safe default for missing/empty content.

```python
new_content = message.get("content", "")
if new_content is None:
    new_content = ""
```

## Issue ticket number and link

None found — searched open PRs/issues touching `messages.py` / `merge_consecutive_messages`, no overlap.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation. (bug fix, not a new feature — no doc changes needed)

## Testing

- Added `test_consecutive_none_content` to `tests/processing/test_message_processing.py`; confirmed (via `git stash`) it fails with the exact `AttributeError` against the pre-fix code, passes after.
- Ran `tests/processing/test_message_processing.py`, `tests/processing/test_utils.py`, `tests/test_utils.py`: 77 passed (incl. the new test), same 2 pre-existing failures before/after (`TestUpdateGeminiKwargs::test_*_safety_settings`, need the optional `google-genai` package which isn't installed in my dev environment — unrelated to this change, confirmed identical on `main`).
- `ruff check`, `ruff format --check`, and `ty check` all clean on the changed files.
- Added a `CHANGELOG.md` entry under `[Unreleased] / Fixed` per `CLAUDE.md`'s PR guidelines.

## AI disclosure

This fix was developed with AI assistance (Claude Code): it located the crash via a targeted search for reachable-but-untested code paths, traced the root cause through `dict.get`'s None-vs-missing-key semantics, and drafted the patch/test/changelog entry. I reviewed the diff, independently re-derived the root cause by reading the function and tracing its callers, and ran the test suite and linters myself before opening this PR.