### PR TITLE
fix(cli): read OpenAI FileObject via attribute access, not subscript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **CLI files**: `files list` and `files upload` no longer crash with `TypeError: 'FileObject' object is not subscriptable` — `generate_file_table` and `upload` now read the OpenAI SDK's `FileObject` (a Pydantic model) via attribute access instead of dict-style subscripting.
 - **v2 message handling**: Preserve caller-owned message lists and nested content across request preparation and retries for OpenAI-compatible, Cohere, Mistral, OpenRouter, Writer, and xAI handlers. ([#2417](https://github.com/567-labs/instructor/issues/2417), [#2428](https://github.com/567-labs/instructor/issues/2428))
 - **v2 JSON extraction**: Prefer the final complete top-level JSON value in text responses and retain every JSON object when multiple objects arrive in one streaming chunk.
 - **v2 schemas**: Treat fields with Pydantic `default_factory` values as optional in generated OpenAI tool schemas.

--- a/instructor/cli/files.py
+++ b/instructor/cli/files.py
@@ -28,11 +28,11 @@ def generate_file_table(files: list[openai.types.FileObject]) -> Table:
 
     for file in files:
         table.add_row(
-            file["id"],
-            str(file["bytes"]),
-            str(datetime.fromtimestamp(file["created_at"])),
-            file["filename"],
-            file["purpose"],
+            file.id,
+            str(file.bytes),
+            str(datetime.fromtimestamp(file.created_at)),
+            file.filename,
+            file.purpose,
         )
 
     return table
@@ -61,7 +61,7 @@ def upload(
     file_purpose = cast(Literal["fine-tune", "assistants"], purpose)
     with open(filepath, "rb") as file:
         response = client.files.create(file=file, purpose=file_purpose)
-    file_id = response["id"]
+    file_id = response.id
     with console.status(f"Monitoring upload: {file_id}...") as status:
         status.spinner_style = "dots"
         while True:

--- a/tests/cli/test_files.py
+++ b/tests/cli/test_files.py
@@ -1,0 +1,29 @@
+"""Tests for instructor.cli.files."""
+
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key-for-cli-import")
+
+from openai.types import FileObject
+
+from instructor.cli.files import generate_file_table
+
+
+def test_generate_file_table_uses_attribute_access():
+    """FileObject (and other OpenAI SDK response objects) are Pydantic
+    models, not dicts — generate_file_table must read fields via attribute
+    access, not `file["id"]`-style subscripting, which raises TypeError."""
+    file = FileObject(
+        id="file-abc123",
+        bytes=1024,
+        created_at=1700000000,
+        filename="training.jsonl",
+        object="file",
+        purpose="fine-tune",
+        status="processed",
+    )
+
+    table = generate_file_table([file])
+
+    rendered_first_column = table.columns[0]._cells
+    assert list(rendered_first_column) == ["file-abc123"]


### PR DESCRIPTION
## Describe your changes

`openai.types.FileObject` is a Pydantic model, not a dict/`TypedDict` — it isn't subscriptable. `generate_file_table()` (backing `instructor files list`) and `upload()` (backing `instructor files upload`) both read it with `file["id"]`-style indexing, so **every invocation of either command crashes**:

```
$ OPENAI_API_KEY=dummy uv run python -c "
from openai.types import FileObject
from instructor.cli.files import generate_file_table
f = FileObject(id='file-abc123', bytes=1024, created_at=1700000000,
                filename='t.jsonl', object='file', purpose='fine-tune', status='processed')
generate_file_table([f])
"
TypeError: 'FileObject' object is not subscriptable
```

The sibling `instructor/cli/jobs.py`'s `generate_table()` already reads the analogous OpenAI SDK object via attribute access (`job.id`, `job.status`, ...), confirming `files.py` is the outlier, not an intentional pattern.

Fix: `file["id"]` → `file.id` (and `bytes`/`created_at`/`filename`/`purpose`) in `generate_file_table`, and `response["id"]` → `response.id` in `upload()` (same bug, `client.files.create()` also returns a `FileObject`).

## Issue ticket number and link

None found — searched open PRs/issues touching `cli/files.py`, no overlap.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. (CLI utility, not core — added a focused unit test)
- [ ] If it is a core feature, I have added documentation. (bug fix, no behavior/doc change needed)

## Testing

- Added `tests/cli/test_files.py::test_generate_file_table_uses_attribute_access`; confirmed (via `git stash`) it fails with the exact `TypeError` against the pre-fix code, passes after.
- `ruff check`, `ruff format --check`, `ty check` all clean on the changed files.
- Added a `CHANGELOG.md` entry under `[Unreleased] / Fixed` per `CLAUDE.md`'s PR guidelines.

## AI disclosure

Developed with AI assistance (Claude Code), which located the crash via a search across `instructor/cli/` for functions untouched by any test, and noticed both call sites shared the same root cause. I reviewed the diff, independently confirmed the fix against the sibling `jobs.py` pattern, and ran the test/lint/type checks myself before opening this PR.