### PR TITLE
docs(vertex): pass model to from_genai

### DIFF
--- a/docs/integrations/vertex.md
+++ b/docs/integrations/vertex.md
@@ -267,8 +267,8 @@ client = from_genai(
         vertexai=True,
         project="your-project",
         location="us-central1",
-        model="gemini-3-flash"
-    )
+    ),
+    model="gemini-3-flash",
 )
 ```
 


### PR DESCRIPTION
## Describe your changes

Correct the Vertex AI migration example so `model` is passed to Instructor's `from_genai` helper instead of `google.genai.Client`.

This matches the two APIs: the Google client configures the Vertex AI connection, while Instructor uses `model` as the default model for requests.

Closes #2416.

## Issue ticket number and link

- #2416: https://github.com/567-labs/instructor/issues/2416

## Verification

- Parsed the updated Python code block with `ast.parse`
- Confirmed the `google-genai` v1.31.0 `Client` signature does not accept `model`
- Confirmed Instructor's `from_genai` helper accepts `model`
- Ran `git diff --check`

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. (Not applicable; documentation-only change.)
- [x] If it is a core feature, I have added documentation.

This PR was prepared with [OpenAI Codex](https://openai.com/codex/).
