### PR TITLE
fix(bedrock): forward default model from provider

### DIFF
--- a/instructor/v2/auto_client.py
+++ b/instructor/v2/auto_client.py
@@ -1023,6 +1023,7 @@ def _build_bedrock(
             client,
             mode=default_mode,
             async_client=async_client,
+            model=model_name,
             **kwargs,
         )
         logger.info(

--- a/tests/coverage/test_auto_client_coverage.py
+++ b/tests/coverage/test_auto_client_coverage.py
@@ -373,7 +373,12 @@ def test_bedrock_forwards_explicit_region_credentials_and_mode(
         "aws_session_token": "explicit-token",
         "region_name": "eu-west-1",
     }
-    assert result == {"mode": Mode.JSON, "async_client": True, "max_tokens": 19}
+    assert result == {
+        "mode": Mode.JSON,
+        "async_client": True,
+        "model": "amazon.titan",
+        "max_tokens": 19,
+    }
 
 
 def test_bedrock_reads_all_environment_credentials(


### PR DESCRIPTION
## Summary

- Forward the model parsed by the Bedrock auto-client to the Bedrock client factory.
- Add a regression assertion for the forwarded default model.

## Root cause

The Bedrock auto-client selected a mode from the model string but never passed that string as the factory's default model. Calls that omitted `model` therefore reached Bedrock without the required `modelId`.

## Validation

- Targeted auto-client and Bedrock coverage tests: 31 passed.
- Ruff check for the two changed files passed.
