### PR TITLE
fix(openai): handle responses with no tool_calls in reask_tools to avoid TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - **Mistral/Vertex AI partial streaming**: Avoid forwarding iterable-only parser arguments into completed `Partial` responses, preventing final Pydantic validation errors for sync and async streams.
 - **Batch providers**: Handle missing optional SDKs safely, validate OpenAI batch input before client setup, report exhausted output-file retries clearly, and remove unreachable fallbacks.
 - **OpenAI/Writer tools**: Raise clear response-parsing errors for completions with no choices or tool calls instead of leaking attribute and index errors.
+- **v2 OpenAI tools reask**: Fall back to a plain user correction when a `Mode.TOOLS` response contains no tool calls (for example, OpenAI-compatible providers that ignore forced `tool_choice`, or a model that answers in prose) instead of iterating `None` and raising `TypeError` during reask.
 - **Fireworks streaming**: Keep non-streaming async calls non-streaming and return streaming async generators without incorrectly awaiting them.
 - **GenAI uploads**: Respect `max_retries=0` without an unwanted sleep or polling request, allow recovery on the final permitted retry, and report nameless pending uploads clearly before polling.
 - **Gemini/GenAI messages**: Honor an explicit system message for unstructured requests, remove the unsupported raw `system` argument, and reject invalid scalar message content clearly.

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -174,8 +174,24 @@ def reask_tools(
         )
         return kwargs
 
-    reask_msgs: list[Any] = [dump_message(response.choices[0].message)]
-    for tool_call in response.choices[0].message.tool_calls:
+    message = response.choices[0].message
+    reask_msgs: list[Any] = [dump_message(message)]
+    tool_calls = message.tool_calls or []
+    if not tool_calls:
+        # Model replied without calling the tool (e.g. OpenAI-compatible
+        # providers that don't honor forced tool_choice). Fall back to a plain
+        # user correction instead of iterating None, mirroring the streaming
+        # branch and the GenAI reask handler.
+        reask_msgs.append(
+            {
+                "role": "user",
+                "content": (
+                    f"Validation Error found:\n{exception}\n"
+                    "Recall the function correctly, fix the errors"
+                ),
+            }
+        )
+    for tool_call in tool_calls:
         reask_msgs.append(
             {
                 "role": "tool",

--- a/tests/coverage/test_openai_handlers_coverage.py
+++ b/tests/coverage/test_openai_handlers_coverage.py
@@ -36,6 +36,7 @@ from instructor.v2.providers.openai.handlers import (
     OpenAIToolsHandler,
     reask_default,
     reask_responses_tools,
+    reask_tools,
 )
 from tests.coverage._openai import chat_chunk, chat_completion, tool_call
 from tests.coverage._streams import async_items
@@ -147,6 +148,26 @@ def test_tools_reask_preserves_assistant_calls_and_adds_one_tool_error_per_call(
             ),
         },
     ]
+
+
+def test_tools_reask_without_tool_call_adds_a_user_correction() -> None:
+    # OpenAI-compatible providers that don't honor forced tool_choice (or a
+    # model that answers in prose) can return a plain assistant message whose
+    # tool_calls is None. reask_tools must fall back to a user correction rather
+    # than iterating None and raising TypeError.
+    response = chat_completion(content="The answer is many.")
+
+    result = reask_tools(
+        {"messages": [{"role": "user", "content": "How many?"}]},
+        response,
+        ValueError("answer must be an int"),
+    )
+
+    assert result["messages"][1]["role"] == "assistant"
+    correction = result["messages"][-1]
+    assert correction["role"] == "user"
+    assert "answer must be an int" in correction["content"]
+    assert "Recall the function correctly" in correction["content"]
 
 
 def test_responses_reask_uses_legacy_arguments_without_inventing_call_details() -> None:


### PR DESCRIPTION
## Problem

`reask_tools()` in `instructor/v2/providers/openai/handlers.py` is the reask handler for `Mode.TOOLS` (registered for OpenAI plus the OpenAI-compatible providers Together, Groq, Fireworks, Cerebras, DeepSeek, OpenRouter, Anyscale and Databricks) and is also used by `OpenAIParallelToolsHandler.handle_reask`.

On the non-streaming path it iterated the tool calls with no guard:

```python
reask_msgs: list[Any] = [dump_message(response.choices[0].message)]
for tool_call in response.choices[0].message.tool_calls:
    ...
```

**Failing scenario:** under `Mode.TOOLS`, a model returns a plain-text assistant message with **no** tool call. This is common with OpenAI-compatible providers that don't honor forced `tool_choice`, or a model that just answers in prose. Parsing then raises `ResponseParsingError` (which is retryable), and the retry loop calls `reask_tools`. But the OpenAI SDK sets `message.tool_calls` to `None` when absent, so `for tool_call in None` raises `TypeError: 'NoneType' object is not iterable`. Since `TypeError` is not retryable, the reask/retry flow aborts and the failure is wrapped into a confusing `InstructorRetryException` around a `TypeError` — the model is never actually re-asked.

## Repro

```python
from openai.types.chat import ChatCompletion
from instructor.v2.providers.openai.handlers import reask_tools

resp = ChatCompletion.model_validate({
    "id": "x", "object": "chat.completion", "created": 1, "model": "gpt-test",
    "choices": [{"index": 0, "finish_reason": "stop",
                 "message": {"role": "assistant", "content": "The answer is many."}}],
})
# resp.choices[0].message.tool_calls is None
reask_tools({"messages": [{"role": "user", "content": "How many?"}]},
            resp, ValueError("answer must be an int"))
# -> TypeError: 'NoneType' object is not iterable
```

## Fix

Normalize `message.tool_calls` to an empty list, and when there is no tool call, append a plain user correction instead of iterating `None`. This mirrors the existing streaming branch of `reask_tools` (which already falls back to a user correction) and the sibling `reask_genai_tools` handler, which explicitly handles the no-function-call case and has its own regression test. The tool-call path is unchanged.

Adds a regression test (`test_tools_reask_without_tool_call_adds_a_user_correction`) covering the no-tool-call case, and a CHANGELOG entry under Unreleased.