### PR TITLE
fix(v2): extract PEP 604 union members in iterable responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - **v2 schemas**: Treat fields with Pydantic `default_factory` values as optional in generated OpenAI tool schemas.
 - **v2 partial streaming**: Build model instances for present `Optional[BaseModel]` fields during incomplete streams instead of exposing raw dictionaries.
 - **v2 iterable unions**: Generate stable member-derived names such as `IterableAOrB` for both `Union[A, B]` and `A | B` response models.
+- **v2 iterable unions**: Extract members of a PEP 604 `A | B` iterable response model instead of raising `AttributeError` on `types.UnionType`; the extractor now recognizes both union forms like the naming path already did.
 - **Mistral/Vertex AI partial streaming**: Avoid forwarding iterable-only parser arguments into completed `Partial` responses, preventing final Pydantic validation errors for sync and async streams.
 - **Batch providers**: Handle missing optional SDKs safely, validate OpenAI batch input before client setup, report exhausted output-file retries clearly, and remove unreachable fallbacks.
 - **OpenAI/Writer tools**: Raise clear response-parsing errors for completions with no choices or tool calls instead of leaking attribute and index errors.

--- a/instructor/v2/dsl/iterable.py
+++ b/instructor/v2/dsl/iterable.py
@@ -140,7 +140,7 @@ class IterableBase:
         **kwargs: Any,
     ):
         assert cls.task_type is not None
-        if get_origin(cls.task_type) is Union:
+        if get_origin(cls.task_type) in _UNION_ORIGINS:
             union_members = get_args(cls.task_type)
             for member in union_members:
                 try:

--- a/tests/v2/test_iterable_streaming.py
+++ b/tests/v2/test_iterable_streaming.py
@@ -54,3 +54,21 @@ def test_iterable_tasks_from_chunks_handles_braces_inside_strings() -> None:
         User(name="Alice", bio="happy :}"),
         User(name="Bob", bio="plain"),
     ]
+
+
+class Admin(BaseModel):
+    role: str
+
+
+def test_extract_cls_task_type_supports_pep604_union() -> None:
+    # `Iterable[User | Admin]` (PEP 604 union) exposes `types.UnionType` as its
+    # origin, which the extractor used to miss (it only checked `is Union`),
+    # falling through to `UnionType.model_validate_json` and raising
+    # AttributeError. The union naming path already handles both forms.
+    iterable_model = cast(Any, IterableModel(User | Admin))
+
+    user = iterable_model.extract_cls_task_type('{"name": "Alice", "bio": "hi"}')
+    assert user == User(name="Alice", bio="hi")
+
+    admin = iterable_model.extract_cls_task_type('{"role": "owner"}')
+    assert admin == Admin(role="owner")


### PR DESCRIPTION
`extract_cls_task_type` checked `get_origin(...) is Union`, so `Iterable[A | B]` (whose origin is `types.UnionType`) fell through to `UnionType.model_validate_json` and raised `AttributeError`, while `Iterable[Union[A, B]]` worked.

Reuse the existing `_UNION_ORIGINS` tuple that the union-naming path already uses, so both forms are handled in one place. Adds a test extracting both members; CHANGELOG updated.
