### PR TITLE
fix(openai): copy schema before strict mutation to prevent lru_cache poisoning

### DIFF
--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -648,7 +648,11 @@ class OpenAIToolsHandler(OpenAIHandlerBase):
             new_kwargs["tools"] = handle_parallel_model(cast(Any, response_model))
             new_kwargs["tool_choice"] = "auto"
         else:
-            schema = generate_openai_schema(response_model)
+            # Shallow-copy to avoid mutating the lru_cache return value.
+            # generate_openai_schema caches the same dict object; writing
+            # "strict" into it would permanently affect every future call for
+            # this model, even when strict=False.
+            schema = dict(generate_openai_schema(response_model))
 
             # Check for strict parameter
             use_strict = new_kwargs.pop("strict", False)

--- a/tests/core/test_schema_utils.py
+++ b/tests/core/test_schema_utils.py
@@ -215,5 +215,24 @@ def test_anthropic_schema_uses_openai_base():
     assert anthropic_schema["input_schema"] == TestModel.model_json_schema()
 
 
+def test_cached_schema_same_object():
+    """generate_openai_schema returns the same dict object on every call (lru_cache).
+
+    This means callers MUST NOT mutate the returned dict directly; they should
+    copy it first. OpenAIToolsHandler.prepare_request does this by shallow-copying
+    before writing "strict" into the schema.
+    """
+
+    class ImmutableModel(BaseModel):
+        value: int
+
+    s1 = generate_provider_openai_schema(ImmutableModel)
+    s2 = generate_provider_openai_schema(ImmutableModel)
+
+    # Both calls return the exact same object — any direct mutation would
+    # affect all future callers, which is why handlers must copy before mutating.
+    assert s1 is s2
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/v2/test_openai_compat_handlers.py
+++ b/tests/v2/test_openai_compat_handlers.py
@@ -139,3 +139,34 @@ def test_legacy_modes_remain_accepted(provider: Provider) -> None:
     for legacy_mode in spec.legacy_modes:
         assert normalize_mode(provider, legacy_mode) != legacy_mode
         assert mode_registry.is_registered(provider, legacy_mode)
+
+
+def test_strict_mode_does_not_pollute_schema_cache() -> None:
+    """strict=True must not permanently corrupt the lru_cache for subsequent calls.
+
+    generate_openai_schema uses lru_cache, so it returns the same dict object on
+    every call. If the TOOLS handler writes "strict" directly into that dict, all
+    future calls for the same model (even without strict=True) receive a schema
+    that already carries "strict": True. The fix is a shallow copy before mutation.
+    """
+
+    class StrictCacheModel(BaseModel):
+        x: int
+
+    handler = _handlers(Provider.OPENAI, Mode.TOOLS)
+
+    # First call with strict=True.
+    _, result_strict = handler.request_handler(
+        StrictCacheModel,
+        {"messages": [{"role": "user", "content": "test"}], "strict": True},
+    )
+    assert result_strict["tools"][0]["function"].get("strict") is True
+
+    # Second call WITHOUT strict=True must not inherit the mutation.
+    _, result_plain = handler.request_handler(
+        StrictCacheModel,
+        {"messages": [{"role": "user", "content": "test"}]},
+    )
+    assert "strict" not in result_plain["tools"][0]["function"], (
+        "lru_cache was poisoned: 'strict' key survived a non-strict call"
+    )


### PR DESCRIPTION
## Summary

- `generate_openai_schema` uses `@functools.lru_cache`, returning the same dict object on every call for a given model
- `OpenAIToolsHandler.prepare_request` was writing `schema["strict"] = True` directly into that cached object, permanently tainting it for all subsequent callers in the same process
- Fix: shallow-copy the dict before mutating (`schema = dict(generate_openai_schema(response_model))`)

Closes #2450

## What changed

`instructor/v2/providers/openai/handlers.py`  one-line fix, added comment explaining why the copy is required.

## Tests

Two regression tests added:

- `tests/core/test_schema_utils.py::test_cached_schema_same_object`  documents that `lru_cache` returns the same object (the precondition for the bug)
- `tests/v2/test_openai_compat_handlers.py::test_strict_mode_does_not_pollute_schema_cache`  calls `prepare_request` with `strict=True`, then again without it, and asserts the second result carries no `"strict"` key. This test fails on the unfixed code and passes after the fix.

## Test plan

- [ ] `uv run pytest tests/core/test_schema_utils.py tests/v2/test_openai_compat_handlers.py -v`
- [ ] `uv run ruff check instructor/v2/providers/openai/handlers.py tests/core/test_schema_utils.py tests/v2/test_openai_compat_handlers.py`