### PR TITLE
fix(partial): don't fail final stream validation on explicit nulls for required nullable fields

### DIFF
--- a/instructor/v2/dsl/partial.py
+++ b/instructor/v2/dsl/partial.py
@@ -439,13 +439,18 @@ class PartialBase(Generic[T_Model]):
             yield obj
 
         # Final validation: only validate if the JSON is structurally complete
-        # If JSON is incomplete (stream ended mid-object), skip validation
+        # If JSON is incomplete (stream ended mid-object), skip validation.
+        # Validate the accumulated JSON itself rather than a
+        # model_dump(exclude_none=True) round-trip, which would strip fields
+        # the model legitimately returned as null and make required-but-nullable
+        # fields fail re-validation as "missing".
         if final_obj is not None:
             original_model = getattr(cls, "_original_model", None)
             if original_model is not None:
-                if is_json_complete(potential_object.strip() or "{}"):
+                json_str = potential_object.strip() or "{}"
+                if is_json_complete(json_str):
                     original_model.model_validate(
-                        final_obj.model_dump(exclude_none=True), **kwargs
+                        from_json(json_str.encode()), **kwargs
                     )
 
     @classmethod
@@ -474,13 +479,18 @@ class PartialBase(Generic[T_Model]):
             yield obj
 
         # Final validation: only validate if the JSON is structurally complete
-        # If JSON is incomplete (stream ended mid-object), skip validation
+        # If JSON is incomplete (stream ended mid-object), skip validation.
+        # Validate the accumulated JSON itself rather than a
+        # model_dump(exclude_none=True) round-trip, which would strip fields
+        # the model legitimately returned as null and make required-but-nullable
+        # fields fail re-validation as "missing".
         if final_obj is not None:
             original_model = getattr(cls, "_original_model", None)
             if original_model is not None:
-                if is_json_complete(potential_object.strip() or "{}"):
+                json_str = potential_object.strip() or "{}"
+                if is_json_complete(json_str):
                     original_model.model_validate(
-                        final_obj.model_dump(exclude_none=True), **kwargs
+                        from_json(json_str.encode()), **kwargs
                     )
 
     @staticmethod

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -960,6 +960,71 @@ class TestFinalValidationAfterStreaming:
 
         assert "age" in str(exc_info.value)
 
+    def test_final_validation_accepts_explicit_null_for_required_nullable_field(self):
+        """Explicit JSON null for a required-but-nullable field should validate.
+
+        The final validation must not confuse a field the model explicitly
+        returned as null with a field that was never streamed at all.
+        """
+
+        class ModelWithNullable(BaseModel):
+            name: str
+            email: Optional[str]  # Required, but nullable
+
+        PartialModel = Partial[ModelWithNullable]
+
+        chunks = ['{"name": "Al', 'ice", "email"', ": null}"]
+
+        results = list(_partial_api(PartialModel).model_from_chunks(iter(chunks)))
+        assert len(results) > 0
+        final = results[-1]
+        assert final.name == "Alice"
+        assert final.email is None
+
+    def test_final_validation_still_rejects_absent_required_nullable_field(self):
+        """A required nullable field genuinely absent from complete JSON still fails."""
+
+        class ModelWithNullable(BaseModel):
+            name: str
+            email: Optional[str]  # Required, but nullable
+
+        PartialModel = Partial[ModelWithNullable]
+
+        chunks = ['{"name": "Alice"}']  # 'email' truly missing
+
+        with pytest.raises(ValidationError) as exc_info:
+            list(_partial_api(PartialModel).model_from_chunks(iter(chunks)))
+
+        assert "email" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_async_final_validation_accepts_explicit_null_for_required_nullable_field(
+        self,
+    ):
+        """Async streaming should also accept explicit nulls for nullable fields."""
+
+        class ModelWithNullable(BaseModel):
+            name: str
+            email: Optional[str]  # Required, but nullable
+
+        PartialModel = Partial[ModelWithNullable]
+
+        async def async_chunks():
+            yield '{"name": "Al'
+            yield 'ice", "email"'
+            yield ": null}"
+
+        results = []
+        async for obj in _partial_api(PartialModel).model_from_chunks_async(
+            async_chunks()
+        ):
+            results.append(obj)
+
+        assert len(results) > 0
+        final = results[-1]
+        assert final.name == "Alice"
+        assert final.email is None
+
 
 class TestRecursiveModels:
     """Test that Partial handles self-referential models without infinite recursion."""


### PR DESCRIPTION
## Describe your changes

Streaming with `create_partial` raises a spurious `ValidationError` on valid, completed streams whenever the response model has a required-but-nullable field (e.g. `email: Optional[str]` with no default) that the LLM legitimately returns as JSON `null`.

**Repro** (fails on `main` at 47fdb2ca, both sync and async):

```python
from typing import Optional
from pydantic import BaseModel
from instructor.dsl.partial import Partial

class User(BaseModel):
    name: str
    email: Optional[str]  # required, but nullable

chunks = ['{"name": "Al', 'ice", "email"', ': null}']
for obj in Partial[User].model_from_chunks(chunks):
    print(obj)
# pydantic_core ValidationError: 1 validation error for User
# email: Field required [type=missing, input_value={'name': 'Alice'}, ...]
```

**Root cause:** after the last chunk, `PartialBase.model_from_chunks` / `model_from_chunks_async` re-validate the accumulated object via

```python
original_model.model_validate(final_obj.model_dump(exclude_none=True), **kwargs)
```

The `model_dump(exclude_none=True)` round-trip cannot distinguish "field explicitly `null` in the JSON" from "field never streamed" (both end up as `None` on the constructed partial), so explicit nulls are stripped from the dump and pydantic reports the field as missing — even though the stream produced complete, valid JSON and the per-chunk validation of the complete root already succeeded. The same round-trip would also mis-validate models with `Field(exclude=True)` fields.

**Fix:** validate the accumulated JSON string itself (parsed with `jiter.from_json`, already imported) instead of the lossy dump, in both the sync and async paths. This preserves explicit nulls while keeping the guard's intent intact:

- a required field genuinely absent from the completed JSON still raises (existing `TestFinalValidationAfterStreaming` tests still pass), and
- structurally incomplete streams still skip final validation.

**Tests:** added three regression tests in `tests/dsl/test_partial.py` — explicit-null nullable field completes cleanly (sync + async; both fail on `main` with the exact error above), and a genuinely-absent nullable field still raises. Ran `pytest tests/dsl/ tests/coverage/test_dsl_partial_coverage.py`: 90 passed, 2 skipped. `ruff check`/`ruff format --check` and `ty check` clean on the touched files. (The pre-existing `test_citation_keeps_quotes_without_context_and_recovers_fuzzy_quotes` failure in `tests/coverage/test_dsl_small_coverage.py` reproduces identically on a clean checkout and is unrelated — it's targeted by #2430/#2443.)

## Issue ticket number and link

None — found while exercising partial streaming with nullable required fields.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.
