### PR TITLE
fix(mistral): raise retryable error and reask correctly when response has no tool_calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - **Mistral/Vertex AI partial streaming**: Avoid forwarding iterable-only parser arguments into completed `Partial` responses, preventing final Pydantic validation errors for sync and async streams.
 - **Batch providers**: Handle missing optional SDKs safely, validate OpenAI batch input before client setup, report exhausted output-file retries clearly, and remove unreachable fallbacks.
 - **OpenAI/Writer tools**: Raise clear response-parsing errors for completions with no choices or tool calls instead of leaking attribute and index errors.
+- **Mistral tools**: Raise a retryable response-parsing error when a completion contains no tool calls and fall back to a plain user correction during reask, so prose-only replies trigger a re-ask instead of aborting the retry loop with `TypeError`.
 - **Fireworks streaming**: Keep non-streaming async calls non-streaming and return streaming async generators without incorrectly awaiting them.
 - **GenAI uploads**: Respect `max_retries=0` without an unwanted sleep or polling request, allow recovery on the final permitted retry, and report nameless pending uploads clearly before polling.
 - **Gemini/GenAI messages**: Honor an explicit system message for unstructured requests, remove the unsupported raw `system` argument, and reject invalid scalar message content clearly.

--- a/instructor/v2/providers/mistral/handlers.py
+++ b/instructor/v2/providers/mistral/handlers.py
@@ -28,7 +28,10 @@ from pydantic import BaseModel
 
 from instructor.v2.core.mode import Mode
 from instructor.v2.core.providers import Provider
-from instructor.v2.core.errors import IncompleteOutputException
+from instructor.v2.core.errors import (
+    IncompleteOutputException,
+    ResponseParsingError,
+)
 from instructor.v2.dsl.iterable import IterableBase
 from instructor.v2.dsl.parallel import ParallelBase, get_types_array
 from instructor.v2.dsl.partial import PartialBase
@@ -224,8 +227,19 @@ class MistralHandlerBase(ModeHandler):
         Mistral returns tool call arguments as either a string or a dict,
         so we need to handle both cases.
         """
-        tool_call = response.choices[0].message.tool_calls[0]
-        args = tool_call.function.arguments
+        message = response.choices[0].message
+        tool_calls = getattr(message, "tool_calls", None) or []
+        if not tool_calls:
+            # The model replied in prose instead of calling the tool (e.g.
+            # models that don't honor tool_choice="any", refusals, or
+            # OpenAI-compatible gateways). Raise a retryable parsing error so
+            # the retry machinery re-asks instead of crashing with TypeError.
+            raise ResponseParsingError(
+                "No tool calls found in Mistral response",
+                mode=self.mode.name,
+                raw_response=response,
+            )
+        args = tool_calls[0].function.arguments
         if isinstance(args, dict):
             return json.dumps(args)
         return args
@@ -294,9 +308,25 @@ class MistralToolsHandler(MistralHandlerBase):
     ) -> dict[str, Any]:
         """Handle reask for tools mode."""
         kwargs = kwargs.copy()
-        reask_msgs: list[Any] = [dump_message(response.choices[0].message)]
+        message = response.choices[0].message
+        reask_msgs: list[Any] = [dump_message(message)]
 
-        for tool_call in response.choices[0].message.tool_calls:
+        tool_calls = message.tool_calls or []
+        if not tool_calls:
+            # The model answered in prose without calling the tool, so there is
+            # no tool_call_id to attach a tool-role message to. Fall back to a
+            # plain user correction instead of iterating None.
+            reask_msgs.append(
+                {
+                    "role": "user",
+                    "content": (
+                        f"Validation Error found:\n{exception}\n"
+                        "Recall the function correctly, fix the errors"
+                    ),
+                }
+            )
+
+        for tool_call in tool_calls:
             reask_msgs.append(
                 {
                     "role": "tool",
@@ -347,7 +377,7 @@ class MistralToolsHandler(MistralHandlerBase):
             type_registry = {t.__name__: t for t in the_types}
 
             def parallel_generator() -> Generator[BaseModel, None, None]:
-                for tool_call in response.choices[0].message.tool_calls:
+                for tool_call in response.choices[0].message.tool_calls or []:
                     name = tool_call.function.name
                     if name in type_registry:
                         model_class = type_registry[name]

--- a/tests/coverage/test_mistral_coverage.py
+++ b/tests/coverage/test_mistral_coverage.py
@@ -24,7 +24,7 @@ from mistralai.models import (
 from pydantic import BaseModel
 
 import instructor.v2.providers.mistral.client as mistral_client
-from instructor.v2.core.errors import ClientError, ModeError
+from instructor.v2.core.errors import ClientError, ModeError, ResponseParsingError
 from instructor.v2.core.mode import Mode
 from instructor.v2.core.multimodal import PDF
 from instructor.v2.core.providers import Provider
@@ -403,6 +403,38 @@ def test_parallel_tool_request_and_response_support_multiple_models() -> None:
     assert request["tool_choice"] == "any"
     assert "tools" not in original
     assert parsed == [User(name="Ada", age=36), Answer(answer=42.0)]
+
+
+def test_tools_handler_survives_prose_response_without_tool_calls() -> None:
+    # Models that ignore tool_choice="any" (or refuse) return a plain assistant
+    # message with tool_calls=None. Parsing must raise a retryable
+    # ResponseParsingError instead of TypeError, reask must fall back to a user
+    # correction instead of iterating None, and the parallel generator must
+    # yield nothing instead of crashing.
+    handler = MistralToolsHandler()
+    prose = response(content="I cannot call the tool for that.")
+
+    with pytest.raises(ResponseParsingError, match="No tool calls found"):
+        handler.parse_response(prose, User)
+
+    reask_kwargs = handler.handle_reask(
+        {"messages": [{"role": "user", "content": "Extract the user"}]},
+        prose,
+        ValueError("age must be an int"),
+    )
+    assert len(reask_kwargs["messages"]) == 3
+    assert reask_kwargs["messages"][1]["role"] == "assistant"
+    correction = reask_kwargs["messages"][-1]
+    assert correction["role"] == "user"
+    assert "age must be an int" in correction["content"]
+    assert "Recall the function correctly" in correction["content"]
+
+    parallel_model, _ = handler.prepare_request(
+        cast(type[BaseModel], Iterable[Union[User, Answer]]),
+        {"messages": [{"role": "user", "content": "Extract all results"}]},
+    )
+    assert parallel_model is not None
+    assert list(handler.parse_response(prose, parallel_model)) == []
 
 
 def test_tools_streaming_iterable_parser_uses_task_list_chunks() -> None:

--- a/tests/v2/test_mistral_handlers.py
+++ b/tests/v2/test_mistral_handlers.py
@@ -195,6 +195,52 @@ class TestMistralToolsHandler:
         assert tool_msg["role"] == "tool"
         assert "Validation Error" in tool_msg["content"]
 
+    def test_parse_response_without_tool_calls_raises_retryable_error(self, handler):
+        """Test parsing a prose response with no tool calls raises ResponseParsingError.
+
+        Some models ignore tool_choice="any" and reply with plain text, leaving
+        tool_calls as None. Parsing must raise a retryable ResponseParsingError
+        (not a bare TypeError) so the retry machinery can re-ask.
+        """
+        from instructor.v2.core.errors import ResponseParsingError
+
+        response = MockResponse(content="I cannot answer that as a tool call.")
+
+        with pytest.raises(ResponseParsingError, match="No tool calls found"):
+            handler.response_parser(response, Answer)
+
+    def test_handle_reask_without_tool_calls_adds_user_correction(self, handler):
+        """Test handle_reask falls back to a user message when tool_calls is None.
+
+        There is no tool_call_id to attach a tool-role message to, so the
+        handler must append a plain user correction instead of iterating None.
+        """
+        kwargs = {"messages": [{"role": "user", "content": "Original"}]}
+        response = MockResponse(content="The answer is four.")
+        exception = ValueError("Validation failed")
+
+        result = handler.reask_handler(kwargs, response, exception)
+
+        assert len(result["messages"]) == 3
+        correction = result["messages"][-1]
+        assert correction["role"] == "user"
+        assert "Validation Error" in correction["content"]
+        assert "Validation failed" in correction["content"]
+
+    def test_parallel_parse_response_without_tool_calls_yields_nothing(self, handler):
+        """Test the parallel generator tolerates tool_calls=None without crashing."""
+        from collections.abc import Iterable
+        from typing import Union
+
+        class Other(BaseModel):
+            value: int
+
+        response = MockResponse(content="No tools were called.")
+
+        result = handler.response_parser(response, Iterable[Union[Answer, Other]])
+
+        assert list(result) == []
+
     def test_tools_handler_preserves_extra_kwargs(self, handler):
         """Test TOOLS handler preserves extra kwargs."""
         kwargs = {


### PR DESCRIPTION
## What happens

When a Mistral model replies with a plain-text assistant message and no tool call (models that ignore `tool_choice="any"`, content-filter/refusal text, or OpenAI-compatible gateways routed through the Mistral provider), `message.tool_calls` is `None` and TOOLS mode crashes twice:

1. **Parse layer** — `MistralHandlerBase._extract_tool_call_json` indexes `response.choices[0].message.tool_calls[0]` and raises `TypeError: 'NoneType' object is not subscriptable`. `TypeError` is not in `_RETRYABLE_PARSE_ERRORS` (`instructor/v2/core/retry.py`), so tenacity reraises immediately: the user gets an `InstructorRetryException` wrapping a bare `TypeError` after exactly **1** attempt, regardless of `max_retries`. The model is never re-asked.
2. **Reask layer** — even if parsing raised a retryable error, `MistralToolsHandler.handle_reask` iterates `for tool_call in response.choices[0].message.tool_calls:` on the same `None` and raises `TypeError: 'NoneType' object is not iterable`.

The parallel-tools generator in `parse_response` has the same unguarded iteration.

## Repro (no API key needed)

Driving the registered `(Provider.MISTRAL, Mode.TOOLS)` handlers with a fake `create()` that returns a prose response first and a valid tool call second:

- before: parse raises `TypeError: 'NoneType' object is not subscriptable`; reask raises `TypeError: 'NoneType' object is not iterable`; `retry_sync_v2` with `max_retries=2` aborts after **1** API call.
- after: parse raises a retryable `ResponseParsingError`, reask appends a plain user correction, and the retry loop makes a **2nd** API call and returns the validated model.

## Fix

Mirror the existing OpenAI handler contract in the Mistral provider:

- `_extract_tool_call_json` raises `ResponseParsingError("No tool calls found in Mistral response", ...)` when `tool_calls` is `None`/empty — retryable, so the retry machinery re-asks (the OpenAI parse path already does this).
- `handle_reask` falls back to a plain `user` correction message when there are no tool calls — there is no `tool_call_id` to attach a `tool`-role message to. Same shape as the OpenAI-side fix in #2448.
- The parallel-tools generator iterates `tool_calls or []` so it yields nothing instead of crashing.

This is the Mistral counterpart of #2448 (which touches only `instructor/v2/providers/openai/handlers.py`), plus the parse-layer guard that has no OpenAI analog.

## Testing

- New unit tests in `tests/v2/test_mistral_handlers.py` and `tests/coverage/test_mistral_coverage.py` (mock responses, no API key). All 4 fail on `main` with the exact `TypeError`s above and pass with this change.
- Full offline suites pass locally with the CI commands: `tests/v2` (1585 passed, 164 skipped), coverage job (`tests/coverage` + `tests/test_batch_processor_coverage.py`: 742 passed), and the full-coverage job (`pytest tests/ -k 'not docs'`: 2834 passed; coverage report 99%, 0 missing statements; `instructor/v2/providers/mistral/handlers.py` at 100% statement + branch).
- `ruff check` / `ruff format --check` on `instructor examples tests` and `ty check` (including `--python-version 3.9 --python-platform all`) all pass.
