### PR TITLE
fix(cache): isolate retry-loop kwargs so cache store key matches lookup key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **v2 caching**: Isolate retry-bound `kwargs` so reask-handler mutations to `messages` cannot leak back into the caller's `new_kwargs` and cause the cache lookup/store keys to diverge after any retry. Without this fix, `cache=` silently stops caching any request that needed at least one reask. ([#2454](https://github.com/567-labs/instructor/issues/2454))
 - **v2 message handling**: Preserve caller-owned message lists and nested content across request preparation and retries for OpenAI-compatible, Cohere, Mistral, OpenRouter, Writer, and xAI handlers. ([#2417](https://github.com/567-labs/instructor/issues/2417), [#2428](https://github.com/567-labs/instructor/issues/2428))
 - **v2 JSON extraction**: Prefer the final complete top-level JSON value in text responses and retain every JSON object when multiple objects arrive in one streaming chunk.
 - **v2 schemas**: Treat fields with Pydantic `default_factory` values as optional in generated OpenAI tool schemas.

--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -38,6 +38,23 @@ def copy_messages_for_mutation(messages: list[dict[str, Any]]) -> list[dict[str,
     return copied
 
 
+def isolate_retry_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Return kwargs with a shallow copy of the messages/contents/chat_history list.
+
+    Reask handlers append/extend that list in place during the retry loop (see
+    `copy_messages_for_mutation` above for the equivalent problem one layer up, in
+    `prepare_request`). Passing the caller-facing kwargs dict straight into the retry
+    loop means those mutations land on the exact same list object the caller passed
+    in, which corrupts any code that reads it again afterward, e.g. computing a cache
+    key from it both before and after the retry loop runs.
+    """
+    for key_name in ("messages", "contents", "chat_history"):
+        value = kwargs.get(key_name)
+        if isinstance(value, list):
+            return {**kwargs, key_name: list(value)}
+    return kwargs
+
+
 def dump_message(message: ChatCompletionMessage) -> ChatCompletionMessageParam:
     ret: ChatCompletionMessageParam = {
         "role": message.role,

--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -47,12 +47,18 @@ def isolate_retry_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     loop means those mutations land on the exact same list object the caller passed
     in, which corrupts any code that reads it again afterward, e.g. computing a cache
     key from it both before and after the retry loop runs.
+
+    Each of the three candidate keys is isolated independently rather than stopping
+    at the first match, so a kwargs dict carrying more than one of them (not used by
+    any current provider, but not precluded by the shape of kwargs either) doesn't
+    leave the others aliased to the caller's list.
     """
+    isolated = dict(kwargs)
     for key_name in ("messages", "contents", "chat_history"):
-        value = kwargs.get(key_name)
+        value = isolated.get(key_name)
         if isinstance(value, list):
-            return {**kwargs, key_name: list(value)}
-    return kwargs
+            isolated[key_name] = list(value)
+    return isolated
 
 
 def dump_message(message: ChatCompletionMessage) -> ChatCompletionMessageParam:

--- a/instructor/v2/core/patch.py
+++ b/instructor/v2/core/patch.py
@@ -20,6 +20,7 @@ from instructor.v2.core.templating import handle_templating
 from instructor.v2.core.utils import is_async
 from instructor.v2.core.exceptions import RegistryValidationMixin
 from instructor.v2.core.registry import mode_registry
+from instructor.v2.core.messages import isolate_retry_kwargs
 from instructor.v2.core.response_model import prepare_response_model
 from instructor.v2.core.retry import retry_async_v2, retry_sync_v2
 
@@ -247,7 +248,9 @@ def _create_sync_wrapper(
                 if cached is not None:
                     return cached  # type: ignore[return-value]
 
-        # Use v2 retry logic with registry handlers
+        # Use v2 retry logic with registry handlers. Pass an isolated copy of the
+        # messages list so reask-handler mutations during the retry loop can't leak
+        # back into new_kwargs, which is read again below for the cache store key.
         response = retry_sync_v2(
             func=func,
             response_model=response_model,
@@ -256,7 +259,7 @@ def _create_sync_wrapper(
             context=context,
             max_retries=max_retries,
             args=args,
-            kwargs=new_kwargs,
+            kwargs=isolate_retry_kwargs(new_kwargs),
             strict=strict,
             hooks=hooks,
         )
@@ -359,7 +362,9 @@ def _create_async_wrapper(
                 if cached is not None:
                     return cached  # type: ignore[return-value]
 
-        # Use v2 retry logic with registry handlers
+        # Use v2 retry logic with registry handlers. Pass an isolated copy of the
+        # messages list so reask-handler mutations during the retry loop can't leak
+        # back into new_kwargs, which is read again below for the cache store key.
         response = await retry_async_v2(
             func=func,
             response_model=response_model,
@@ -368,7 +373,7 @@ def _create_async_wrapper(
             context=context,
             max_retries=max_retries,
             args=args,
-            kwargs=new_kwargs,
+            kwargs=isolate_retry_kwargs(new_kwargs),
             strict=strict,
             hooks=hooks,
         )

--- a/tests/cache/test_cache_integration.py
+++ b/tests/cache/test_cache_integration.py
@@ -3,7 +3,7 @@ import types
 import instructor
 from instructor.cache import AutoCache
 from openai.types.chat import ChatCompletionMessageParam
-from pydantic import BaseModel, Field  # type: ignore[import-not-found]
+from pydantic import BaseModel, Field, field_validator  # type: ignore[import-not-found]
 
 
 def test_auto_cache_prevents_duplicate_provider_calls(monkeypatch):
@@ -43,3 +43,61 @@ def test_auto_cache_prevents_duplicate_provider_calls(monkeypatch):
     # Second call with identical inputs – should hit cache, no new provider call
     _ = client.create(messages=list(messages), response_model=User, cache=cache)
     assert call_counter["n"] == 1, "Cache miss – provider was called again"
+
+
+def test_auto_cache_prevents_duplicate_calls_after_a_retry(monkeypatch):
+    _ = monkeypatch
+    """Regression test: a call that needed a retry must still be cacheable.
+
+    Reask handlers append/extend the request's messages list in place. If that
+    list is the same object patch.py reads again to compute the cache store key,
+    the store key ends up different from the lookup key computed before the
+    retry, so a later, identical call never hits the cache.
+    """
+
+    class Answer(BaseModel):
+        value: int
+
+        @field_validator("value")
+        @classmethod
+        def must_be_positive(cls, v: int) -> int:
+            if v < 0:
+                raise ValueError("value must be positive")
+            return v
+
+    call_counter = {"n": 0}
+
+    def fake_completion(*_args, **_kwargs):
+        call_counter["n"] += 1
+        # First call ever returns an invalid value, forcing exactly one retry.
+        value = -5 if call_counter["n"] == 1 else 42
+        content = Answer.model_construct(value=value).model_dump_json()
+        return types.SimpleNamespace(
+            choices=[
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(content=content),
+                    finish_reason="stop",
+                )
+            ],
+            usage={},
+        )
+
+    cache = AutoCache(maxsize=10)
+    client = instructor.from_litellm(fake_completion, mode=instructor.Mode.JSON)
+    messages: list[ChatCompletionMessageParam] = [
+        {"role": "user", "content": "what is 6 times 7?"}
+    ]
+
+    result1 = client.create(
+        messages=list(messages), response_model=Answer, max_retries=2, cache=cache
+    )
+    assert result1.value == 42
+    assert call_counter["n"] == 2, "First call should need exactly one retry"
+
+    result2 = client.create(
+        messages=list(messages), response_model=Answer, max_retries=2, cache=cache
+    )
+    assert result2.value == 42
+    assert call_counter["n"] == 2, (
+        "Second, identical call should hit the cache instead of calling the provider again"
+    )


### PR DESCRIPTION
Fixes #2454.

## What's broken

`_create_sync_wrapper`/`_create_async_wrapper` (`instructor/v2/core/patch.py`) compute a cache lookup key from `new_kwargs["messages"]` before calling `retry_sync_v2`/`retry_async_v2`, and recompute the store key from the same `new_kwargs["messages"]` after the retry call returns, but pass `new_kwargs` into the retry call by reference.

Each reask handler (`reask_tools`, `reask_md_json`, `reask_default`, `reask_responses_tools` in `providers/openai/handlers.py`, and Anthropic's `handle_reask`) does `kwargs = kwargs.copy()` then `kwargs["messages"].append(...)`/`.extend(...)`. The shallow dict copy doesn't copy the `messages` list, so this mutates the exact list object `patch.py`'s `new_kwargs` still points to.

Any request that needed at least one retry ends up with a store key computed from the post-retry, reask-polluted `messages` list, different from the lookup key computed from the pristine one before the retry loop ran. The result is correct, but it gets cached under a key nothing will ever look up again, so an identical follow-up request always misses and re-triggers a real LLM call.

## Fix

Added `isolate_retry_kwargs()` in `messages.py`, right next to the existing `copy_messages_for_mutation` helper (added for #2417/#2428, which fixed the analogous problem one layer up in `prepare_request`). It returns `kwargs` with a shallow copy of whichever of `messages`/`contents`/`chat_history` is present, so mutations during the retry loop land on a private list and can never leak back into the `kwargs` dict `patch.py` reads again for the cache store key, regardless of what an individual reask handler does internally.

Used it at both call sites where `new_kwargs` is handed to the retry layer (sync and async).

## Testing

Added `test_auto_cache_prevents_duplicate_calls_after_a_retry` in `tests/cache/test_cache_integration.py`, next to the existing `test_auto_cache_prevents_duplicate_provider_calls`. It forces exactly one retry (first fake response fails a Pydantic validator, second succeeds), then makes an identical second call and asserts the provider function was only invoked twice total (once for the first call's retry, zero more for the second).

Verified both directions:
```
# against the unfixed patch.py/messages.py (git stash)
FAILED tests/cache/test_cache_integration.py::test_auto_cache_prevents_duplicate_calls_after_a_retry
AssertionError: Second, identical call should hit the cache instead of calling the provider again
assert 3 == 2

# against the fix
tests/cache/test_cache_integration.py::test_auto_cache_prevents_duplicate_calls_after_a_retry PASSED
```

Also ran the broader cache/retry suites to check for regressions, all green:
```
tests/cache/ tests/coverage/test_cache_coverage.py tests/coverage/test_core_patch_retry_coverage.py tests/v2/test_retry_runtime.py
55 passed
```

## Issue ticket number and link

Fixes #2454

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation. (not applicable — internal bug fix, no user-facing API or behavior change to document)

