### PR TITLE
fix: extract_json_from_stream corrupts output on balanced-but-non-JSON braces before the payload

### DIFF
--- a/instructor/v2/core/json.py
+++ b/instructor/v2/core/json.py
@@ -142,9 +142,21 @@ def extract_json_from_stream(chunks: Iterable[str]) -> Generator[str, None, None
                         delimiter_stack.pop()
                         if not delimiter_stack:
                             buffer.append(char)
-                            yield from buffer
+                            candidate = "".join(buffer)
                             buffer = []
                             json_started = False
+                            try:
+                                json.loads(candidate)
+                            except ValueError:
+                                # The bracket-balanced span we just closed
+                                # isn't actually valid JSON - e.g. a
+                                # brace-delimited aside in the model's prose
+                                # that happened to appear before the real
+                                # payload. Discard it and keep scanning
+                                # instead of emitting it as if it were the
+                                # extracted JSON.
+                                continue
+                            yield from candidate
                             continue
 
                 buffer.append(char)
@@ -231,10 +243,19 @@ async def extract_json_from_stream_async(
                         delimiter_stack.pop()
                         if not delimiter_stack:
                             buffer.append(char)
-                            for buffered_char in buffer:
-                                yield buffered_char
+                            candidate = "".join(buffer)
                             buffer = []
                             json_started = False
+                            try:
+                                json.loads(candidate)
+                            except ValueError:
+                                # See the matching comment in
+                                # extract_json_from_stream - discard
+                                # bracket-balanced spans that aren't
+                                # actually valid JSON and keep scanning.
+                                continue
+                            for buffered_char in candidate:
+                                yield buffered_char
                             continue
 
                 buffer.append(char)

--- a/tests/v2/test_json_helpers.py
+++ b/tests/v2/test_json_helpers.py
@@ -121,6 +121,24 @@ def test_extract_json_from_stream_preserves_backticks_in_fenced_string() -> None
     assert "".join(extract_json_from_stream(chunks)) == '{"code":"`inline`"}'
 
 
+def test_extract_json_from_stream_discards_non_json_brace_span_before_payload() -> None:
+    # MD_JSON prompts often produce a prose preamble before the actual payload,
+    # and that preamble can itself contain a balanced pair of braces that is not
+    # JSON (e.g. a parenthetical aside). A naive bracket-matching scan treats that
+    # span as "the JSON" once it balances and emits it verbatim, so the real
+    # payload that follows gets appended onto invalid JSON instead of replacing
+    # it. The extractor should recognize the span isn't valid JSON, drop it, and
+    # keep scanning for the real payload.
+    chunks = [
+        "I'll pull out the fields now. ",
+        "{Note: keeping the original casing} ",
+        "Here is the result: ",
+        '{"name":"Ada","age":30}',
+    ]
+
+    assert "".join(extract_json_from_stream(chunks)) == '{"name":"Ada","age":30}'
+
+
 @pytest.mark.asyncio
 async def test_extract_json_from_stream_async_preserves_backticks_in_string() -> None:
     async def chunks():
@@ -175,4 +193,21 @@ async def test_extract_json_from_stream_async_handles_even_backslashes() -> None
     assert (
         "".join([chunk async for chunk in extract_json_from_stream_async(chunks())])
         == '{"path":"C:\\\\","name":"Ada"}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_extract_json_from_stream_async_discards_non_json_brace_span_before_payload() -> None:
+    async def chunks():
+        for chunk in [
+            "I'll pull out the fields now. ",
+            "{Note: keeping the original casing} ",
+            "Here is the result: ",
+            '{"name":"Ada","age":30}',
+        ]:
+            yield chunk
+
+    assert (
+        "".join([chunk async for chunk in extract_json_from_stream_async(chunks())])
+        == '{"name":"Ada","age":30}'
     )


### PR DESCRIPTION
## Problem

In `MD_JSON` mode, the model's response is often plain text with prose
before the actual JSON payload, e.g.:

```
I'll pull out the fields now. {Note: keeping the original casing}
Here is the result: {"name":"Ada","age":30}
```

The non-streaming path (`extract_json_from_codeblock`, used by the
`MD_JSON` response parser for regular responses) handles this correctly -
it scans for every bracket-balanced span that is actually parseable JSON
and returns the last one:

```python
>>> extract_json_from_codeblock(text)
'{"name":"Ada","age":30}'
```

`extract_json_from_stream` (used by the `MD_JSON` *streaming* parser in
the openai/mistral/xai handlers, see `instructor/v2/providers/openai/handlers.py`
around `extract_streaming_json`) doesn't have the same safety net. It
starts capturing as soon as it sees a `{`/`[` outside a string, and once
the bracket depth returns to zero it unconditionally yields whatever it
buffered - without checking it's actually JSON:

```python
>>> "".join(extract_json_from_stream(chunks))
'{Note: keeping the original casing}{"name":"Ada","age":30}'
```

That's not valid JSON, so parsing the streamed response fails even though
the identical text works fine through the non-streaming code path.

## Root cause

Bracket-balanced is necessary but not sufficient for "this is JSON" -
ordinary prose can easily contain a balanced brace pair that isn't JSON
at all (asides, notes, set notation, etc.). `extract_json_from_stream`
buffers a candidate span and, once the stack empties, yields it on faith.

## Fix

When the bracket stack empties, validate the buffered candidate with
`json.loads()` before yielding it. If it doesn't parse, discard it and
keep scanning for the real payload - the same approach
`extract_json_from_codeblock` in the same file already uses for its
candidates. If it does parse, behavior is unchanged (fenced/plain JSON,
multiple concatenated objects, backtick/backslash handling all still
pass). Applied identically to the async counterpart,
`extract_json_from_stream_async`, to keep the two in sync.

## Testing

- Added `test_extract_json_from_stream_discards_non_json_brace_span_before_payload`
  and its async counterpart to `tests/v2/test_json_helpers.py`. Verified
  both fail on the pre-fix code (`git stash`) and pass with the fix.
- `tests/v2/test_json_helpers.py`: 23 passed.
- `tests/processing/test_json_extraction.py`,
  `tests/processing/test_json_extraction_edge_cases.py`,
  `tests/processing/test_utils.py`, `tests/test_utils.py`: 102 passed.
- Full `tests/v2` and `tests/` (excluding `tests/docs`, `tests/llm` which
  need extra optional deps): same pass/fail counts before and after the
  change except for the 2 new tests. The 10 pre-existing failures
  (missing `google-genai`/`jsonref`, network-dependent `auto_client`
  tests, one unrelated `mistral` `json_schema_mode` test) reproduce
  identically on unmodified `main` via `git stash`, confirming they're
  unrelated to this change.
