### PR TITLE
fix(v2): isolate kwargs for retry to prevent cache key divergence (#2454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **v2 caching**: Isolate retry-bound `kwargs` so reask-handler mutations to `messages` cannot leak back into the caller's `new_kwargs` and cause the cache lookup/store keys to diverge after any retry. Without this fix, `cache=` silently stops caching any request that needed at least one reask. ([#2454](https://github.com/567-labs/instructor/issues/2454))
 - **v2 message handling**: Preserve caller-owned message lists and nested content across request preparation and retries for OpenAI-compatible, Cohere, Mistral, OpenRouter, Writer, and xAI handlers. ([#2417](https://github.com/567-labs/instructor/issues/2417), [#2428](https://github.com/567-labs/instructor/issues/2428))
 - **v2 JSON extraction**: Prefer the final complete top-level JSON value in text responses and retain every JSON object when multiple objects arrive in one streaming chunk.
 - **v2 schemas**: Treat fields with Pydantic `default_factory` values as optional in generated OpenAI tool schemas.
@@ -79,7 +80,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 - **Hooks**: `completion:error` and `completion:last_attempt` handlers now receive `attempt_number`, `max_attempts`, and `is_last_attempt` as keyword arguments. Old-style handlers remain fully backward-compatible.
-- **Anthropic**: `from_provider("anthropic/...")` now sets a `User-Agent: instructor/<version>` header on the Anthropic client
+- **Anthropic**: `from_provider("anthropic/...")` now sets a `User-agent: instructor/<version>` header on the Anthropic client
 
 ### Fixed
 - **Anthropic usage**: Initialize usage correctly for `ANTHROPIC_REASONING_TOOLS` and `ANTHROPIC_PARALLEL_TOOLS` modes — previously fell through to OpenAI usage tracking with wrong field names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 - **Hooks**: `completion:error` and `completion:last_attempt` handlers now receive `attempt_number`, `max_attempts`, and `is_last_attempt` as keyword arguments. Old-style handlers remain fully backward-compatible.
-- **Anthropic**: `from_provider("anthropic/...")` now sets a `User-agent: instructor/<version>` header on the Anthropic client
+- **Anthropic**: `from_provider("anthropic/...")` now sets a `User-Agent: instructor/<version>` header on the Anthropic client
 
 ### Fixed
 - **Anthropic usage**: Initialize usage correctly for `ANTHROPIC_REASONING_TOOLS` and `ANTHROPIC_PARALLEL_TOOLS` modes — previously fell through to OpenAI usage tracking with wrong field names

--- a/instructor/v2/core/patch.py
+++ b/instructor/v2/core/patch.py
@@ -177,6 +177,36 @@ def apatch(
     return patch(client, mode=mode, provider=provider)
 
 
+def _isolate_kwargs_for_retry(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of `kwargs` whose top-level ``messages``/``contents``/
+    ``chat_history`` list is a fresh object, so retry-loop mutations are
+    not observable through the caller's `new_kwargs`.
+
+    Reask handlers in the registry do ``kwargs = kwargs.copy()`` (a shallow
+    copy) and then mutate the shared ``messages`` list in place via
+    ``.extend()`` / ``.append()`` to append validation-feedback turns for
+    the next retry attempt. That is correct behavior *inside* the retry
+    loop, but it must not leak back to the outer `new_kwargs` in the patch
+    wrapper: the cache store key is computed from `new_kwargs["messages"]`
+    *after* `retry_sync_v2` / `retry_async_v2` returns, and if that list
+    has been mutated to include the reask turns it no longer matches the
+    cache lookup key computed *before* the retry -- silently breaking
+    caching for any request that needed at least one retry (issue #2454).
+
+    Only the list container is copied; the individual message dicts
+    inside it are shared. This is sufficient because reask handlers only
+    append/extend new dicts -- they do not mutate existing entries -- and
+    the cache key is computed from the JSON serialization of the list,
+    which is invariant to whether the dicts are aliased or not.
+    """
+    isolated = dict(kwargs)
+    for key in ("messages", "contents", "chat_history"):
+        value = isolated.get(key)
+        if isinstance(value, list):
+            isolated[key] = list(value)
+    return isolated
+
+
 def _create_sync_wrapper(
     func: Callable[..., Any],
     provider: Provider,
@@ -247,7 +277,16 @@ def _create_sync_wrapper(
                 if cached is not None:
                     return cached  # type: ignore[return-value]
 
-        # Use v2 retry logic with registry handlers
+        # Use v2 retry logic with registry handlers.
+        #
+        # Pass an isolated copy of `new_kwargs` so reask handlers (which do
+        # `kwargs = kwargs.copy()` -- a shallow copy -- and then mutate the
+        # shared `messages` list in place via `.extend()` / `.append()`)
+        # cannot leak those mutations back to `new_kwargs`. The cache
+        # store key below is recomputed from `new_kwargs["messages"]` after
+        # the retry returns, and must match the lookup key above; if the
+        # reask turns were observable here the cache would silently miss on
+        # every request that needed a retry. See issue #2454.
         response = retry_sync_v2(
             func=func,
             response_model=response_model,
@@ -256,7 +295,7 @@ def _create_sync_wrapper(
             context=context,
             max_retries=max_retries,
             args=args,
-            kwargs=new_kwargs,
+            kwargs=_isolate_kwargs_for_retry(new_kwargs),
             strict=strict,
             hooks=hooks,
         )
@@ -359,7 +398,16 @@ def _create_async_wrapper(
                 if cached is not None:
                     return cached  # type: ignore[return-value]
 
-        # Use v2 retry logic with registry handlers
+        # Use v2 retry logic with registry handlers.
+        #
+        # Pass an isolated copy of `new_kwargs` so reask handlers (which do
+        # `kwargs = kwargs.copy()` -- a shallow copy -- and then mutate the
+        # shared `messages` list in place via `.extend()` / `.append()`)
+        # cannot leak those mutations back to `new_kwargs`. The cache store
+        # key below is recomputed from `new_kwargs["messages"]` after the
+        # retry returns, and must match the lookup key above; if the reask
+        # turns were observable here the cache would silently miss on every
+        # request that needed a retry. See issue #2454.
         response = await retry_async_v2(
             func=func,
             response_model=response_model,
@@ -368,7 +416,7 @@ def _create_async_wrapper(
             context=context,
             max_retries=max_retries,
             args=args,
-            kwargs=new_kwargs,
+            kwargs=_isolate_kwargs_for_retry(new_kwargs),
             strict=strict,
             hooks=hooks,
         )

--- a/tests/v2/test_issue_2454.py
+++ b/tests/v2/test_issue_2454.py
@@ -1,0 +1,159 @@
+"""Regression test for issue #2454: `cache=` silently stops caching any
+request that needed at least one retry.
+
+When the first call to a patched create function triggers a validation
+failure (and thus a reask), the successful response from the retry
+attempt must be cached under the same key that an identical follow-up
+call will look up. Before the fix, the reask handler's in-place
+mutation of the shared `messages` list diverged the lookup key
+(computed before retry) from the store key (computed after retry,
+when `new_kwargs["messages"]` had been mutated to include the
+validation-feedback turns). The net effect: any request that ever
+needed a retry was effectively un-cached, forcing every identical
+follow-up call back through the real LLM.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+from openai.types.completion_usage import CompletionUsage
+from pydantic import BaseModel
+
+from instructor.cache import AutoCache
+from instructor.v2.core.mode import Mode
+from instructor.v2.core.patch import patch_v2
+from instructor.v2.core.providers import Provider
+
+
+class Answer(BaseModel):
+    name: str
+    age: int
+
+
+def _make_tool_call_response(arguments: str, call_id: str) -> ChatCompletion:
+    tool_call = ChatCompletionMessageToolCall(
+        id=call_id,
+        type="function",
+        function=Function(name="Answer", arguments=arguments),
+    )
+    message = ChatCompletionMessage(
+        role="assistant", content=None, tool_calls=[tool_call]
+    )
+    choice = Choice(index=0, message=message, finish_reason="tool_calls", logprobs=None)
+    return ChatCompletion(
+        id="chatcmpl-test",
+        choices=[choice],
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        usage=CompletionUsage(completion_tokens=5, prompt_tokens=10, total_tokens=15),
+    )
+
+
+def test_cache_survives_reask_loop_sync() -> None:
+    """Forces a validation failure on the first attempt, then a success
+    on the second. The second identical client.create() must hit the
+    cache and must NOT call the underlying LLM again.
+    """
+    call_count = {"n": 0}
+
+    def fake_create(*_args: Any, **_kwargs: Any) -> ChatCompletion:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Validation fails: `age` is missing
+            return _make_tool_call_response('{"name": "Ada"}', "call_1")
+        # Validation succeeds
+        return _make_tool_call_response('{"name": "Ada", "age": 37}', "call_2")
+
+    create_fn = patch_v2(fake_create, provider=Provider.OPENAI, mode=Mode.TOOLS)
+    cache = AutoCache(maxsize=10)
+
+    messages = [{"role": "user", "content": "Ada is 37 years old"}]
+
+    r1 = create_fn(
+        model="gpt-4o-mini",
+        messages=messages,
+        response_model=Answer,
+        max_retries=2,
+        cache=cache,
+    )
+    assert isinstance(r1, Answer)
+    assert r1.name == "Ada"
+    assert r1.age == 37
+    # First call needed 1 retry -> 2 LLM calls
+    assert call_count["n"] == 2
+
+    # Second, IDENTICAL call. Must hit the cache, must NOT call fake_create.
+    r2 = create_fn(
+        model="gpt-4o-mini",
+        messages=messages,
+        response_model=Answer,
+        max_retries=2,
+        cache=cache,
+    )
+    assert isinstance(r2, Answer)
+    assert r2.name == "Ada"
+    assert r2.age == 37
+    # If this assertion fails, the cache key computed at store time no
+    # longer matches the key computed at lookup time -- i.e. the reask
+    # handler has mutated `new_kwargs["messages"]` in place between the
+    # two key computations. See issue #2454.
+    assert call_count["n"] == 2, (
+        "Cache miss after retry: second identical call re-invoked the LLM "
+        f"(call_count={call_count['n']}). The cache lookup/store keys "
+        "diverged -- see issue #2454."
+    )
+
+
+@pytest.mark.asyncio
+async def test_cache_survives_reask_loop_async() -> None:
+    """Same regression as the sync test, but exercising the async wrapper
+    (`_create_async_wrapper` -> `retry_async_v2`). The cache key
+    divergence affects both wrappers because they share the same
+    `new_kwargs` aliasing pattern.
+    """
+    call_count = {"n": 0}
+
+    async def fake_create_async(*_args: Any, **_kwargs: Any) -> ChatCompletion:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _make_tool_call_response('{"name": "Ada"}', "call_1")
+        return _make_tool_call_response('{"name": "Ada", "age": 37}', "call_2")
+
+    create_fn = patch_v2(fake_create_async, provider=Provider.OPENAI, mode=Mode.TOOLS)
+    cache = AutoCache(maxsize=10)
+
+    messages = [{"role": "user", "content": "Ada is 37 years old"}]
+
+    r1 = await create_fn(
+        model="gpt-4o-mini",
+        messages=messages,
+        response_model=Answer,
+        max_retries=2,
+        cache=cache,
+    )
+    assert isinstance(r1, Answer)
+    assert r1.age == 37
+    assert call_count["n"] == 2
+
+    r2 = await create_fn(
+        model="gpt-4o-mini",
+        messages=messages,
+        response_model=Answer,
+        max_retries=2,
+        cache=cache,
+    )
+    assert isinstance(r2, Answer)
+    assert r2.age == 37
+    assert call_count["n"] == 2, (
+        "Async cache miss after retry: second identical call re-invoked "
+        f"the LLM (call_count={call_count['n']}). See issue #2454."
+    )


### PR DESCRIPTION
## Summary

Fixes #2454.

When `cache=` is used and the first LLM call fails validation, the reask loop appends a failed tool-call turn and a validation-feedback turn to `messages`. All 13 v2 providers do this with `kwargs = kwargs.copy()` (shallow) followed by in-place `kwargs["messages"].extend/append(...)`.

Because `patch.py` passes `new_kwargs` *by reference* into the retry function and then computes the cache **store** key from `new_kwargs["messages"]` *after* the retry returns, the store key diverges from the lookup key: the store key now includes the failed tool-call turn + feedback turn, so no future call can ever produce that same key. The successful result is cached under an unreachable key — effectively a silent cache miss for every retried request.

## Root cause

The data flow that produces the divergence:

1. `patch.py` computes the cache **lookup** key from `new_kwargs.get("messages")` *before* calling `retry_sync_v2` / `retry_async_v2`.
2. It passes `new_kwargs` by reference into the retry function.
3. Inside the retry loop, reask handlers do `kwargs = kwargs.copy()` (shallow) and then `kwargs["messages"].extend(reask_msgs)` / `.append(...)` — mutating the shared `messages` list object in place.
4. After the retry returns, `patch.py` computes the cache **store** key from `new_kwargs.get("messages")` — which now includes the failed tool-call turn + validation-feedback turn.
5. The store key diverges from the lookup key. The successful result is cached under a key that no future identical call will ever produce, so every follow-up call goes back through the real LLM.

This affects **all 13 v2 providers** that have reask handlers with the same `kwargs = kwargs.copy()` + in-place `messages.extend/append` pattern: `openai`, `anthropic`, `gemini`, `genai`, `cohere`, `mistral`, `vertexai`, `perplexity`, `openrouter`, `writer`, `xai`, `bedrock`, `groq`.

## Fix

Pass an isolated copy of `new_kwargs` into the retry function so reask-handler mutations to `messages` / `contents` / `chat_history` are not observable through the caller's `new_kwargs`. The store key is then computed from the same pristine `new_kwargs` the lookup key was computed from, so the two keys always agree.

This closes the door for *any* future handler making the same shallow-copy-then-mutate mistake, rather than fixing each of the 13 provider handlers individually (option a from the issue).

The new helper `_isolate_kwargs_for_retry()` only copies the list container for the three known message-bearing kwargs (`messages`, `contents`, `chat_history`); the individual message dicts are shared, which is sufficient because reask handlers only `append`/`extend` new dicts — they never mutate existing entries — and the cache key is computed from the JSON serialization of the list, which is invariant to whether the dicts are aliased or not.

## Tests

Adds `tests/v2/test_issue_2454.py` with sync + async regression tests that:

- Force a validation failure on the first LLM call (`{"name": "Ada"}` — missing `age`) and a success on the second (`{"name": "Ada", "age": 37}`).
- Call the patched `create_fn` twice with identical inputs.
- Assert that the second call does **not** re-invoke the underlying LLM (`call_count == 2`, not `3`).

Both tests fail on unmodified `main` (`call_count == 3` instead of `2`) and pass with this fix.

```
$ uv run pytest tests/v2/test_issue_2454.py -v
============================= test session starts ==============================
platform darwin -- Python 3.11.15, pytest-8.4.2, pluggy-1.6.0
collecting ... collected 2 items

tests/v2/test_issue_2454.py::test_cache_survives_reask_loop_sync PASSED [ 50%]
tests/v2/test_issue_2454.py::test_cache_survives_reask_loop_async PASSED [100%]

============================== 2 passed in 0.98s ===============================
```

No regressions in the existing v2 / cache suites (the 2 pre-existing `mistralai` import failures are unrelated — the `mistralai` package is an optional dependency not installed locally and the failures exist on `main`):

```
$ uv run pytest tests/v2/ tests/cache/ -q
2 failed, 1575 passed, 170 skipped
# failed: tests/v2/test_messages_not_mutated.py::test_prepare_request_does_not_alias_caller_messages[mistral-json_schema_mode]
# failed: tests/v2/test_messages_not_mutated.py::test_reask_does_not_mutate_caller_messages[mistral-json_schema_mode]
# both: ModuleNotFoundError: No module named 'mistralai'
```

Lint, format, and type checks all pass:

```
$ uv run ruff check instructor/v2/core/patch.py tests/v2/test_issue_2454.py
All checks passed!
$ uv run ruff format --check instructor/v2/core/patch.py tests/v2/test_issue_2454.py
2 files already formatted
$ uv run ty check instructor/v2/core/patch.py
All checks passed!
```

## Checklist

- [x] Fix is minimal and surgical — one new helper + two call-site changes.
- [x] Regression test added that fails on `main` and passes with the fix.
- [x] Sync + async paths both covered.
- [x] No existing tests broken (the 2 `mistralai` failures pre-date this PR).
- [x] CHANGELOG entry added under `[Unreleased]`.
- [x] `ruff check`, `ruff format --check`, `ty check` all clean.

Closes #2454.