### PR TITLE
fix: prevent CitationMixin crash when context missing 'context' key

### DIFF
--- a/instructor/v2/dsl/citation.py
+++ b/instructor/v2/dsl/citation.py
@@ -69,6 +69,9 @@ class CitationMixin(BaseModel):
         # Get the context from the info
         text_chunks = info.context.get("context", None)
 
+        if text_chunks is None:
+            return self
+
         # Get the spans of the substring_phrase in the context
         spans = list(self.get_spans(text_chunks))
         # Replace the substring_phrase with the actual substring

--- a/tests/dsl/test_citation.py
+++ b/tests/dsl/test_citation.py
@@ -1,0 +1,43 @@
+"""Regression test for CitationMixin crash when context missing 'context' key.
+
+See: https://github.com/567-labs/instructor/issues/2459
+"""
+import pytest
+from pydantic import BaseModel, Field
+
+from instructor import CitationMixin
+
+
+class CitationModel(CitationMixin, BaseModel):
+    answer: str = Field(description="The answer")
+    substring_quotes: list[str] = Field(
+        default_factory=list,
+        description="Quotes supporting the answer",
+    )
+
+
+class TestCitationMixinNoneContext:
+    def test_context_missing_context_key_does_not_crash(self):
+        """validate_sources should not crash when context dict lacks 'context' key."""
+        model = CitationModel.model_validate(
+            {"answer": "test", "substring_quotes": ["test"]},
+            context={"foo": "bar"},
+        )
+        assert model.answer == "test"
+
+    def test_context_is_none_does_not_crash(self):
+        """validate_sources should handle None context gracefully."""
+        model = CitationModel.model_validate(
+            {"answer": "test", "substring_quotes": ["test"]},
+        )
+        assert model.answer == "test"
+
+    def test_context_with_context_key_works_normally(self):
+        """validate_sources should work normally when context key is present."""
+        context = "Jason was a student. Jason is 20 years old."
+        model = CitationModel.model_validate(
+            {"answer": "Jason", "substring_quotes": ["Jason"]},
+            context={"context": context},
+        )
+        assert model.answer == "Jason"
+        assert len(model.substring_quotes) >= 1


### PR DESCRIPTION
## Summary

Fix `CitationMixin.validate_sources` crash when `validation_context` is provided but doesn't contain the expected `"context"` key.

## Problem

`validate_sources` calls `info.context.get("context", None)` which returns `None` if the key is missing. This `None` is passed to `get_spans(None)`, which calls `_get_span(quote, None)`, which calls `regex.search(pattern, None)` — raising `TypeError: expected string or bytes-like object`.

## Fix

Add `if text_chunks is None: return self` after the `.get()` call (1 line).

## Test

Added `tests/dsl/test_citation.py` with 3 regression tests covering:
- Missing `"context"` key in validation_context
- None context
- Normal operation with valid context

## Issue

Closes #2459
