### PR TITLE
fix(citations): honor the errs tolerance cap in CitationMixin fuzzy span matching

### DIFF
--- a/instructor/v2/dsl/citation.py
+++ b/instructor/v2/dsl/citation.py
@@ -85,7 +85,7 @@ class CitationMixin(BaseModel):
 
         errs_ = 0
         s = regex.search(f"({minor}){{e<={errs_}}}", major)
-        while s is None and errs_ <= errs:
+        while s is None and errs_ < errs:
             errs_ += 1
             s = regex.search(f"({minor}){{e<={errs_}}}", major)
 

--- a/tests/dsl/test_citation.py
+++ b/tests/dsl/test_citation.py
@@ -1,0 +1,26 @@
+"""Tests for CitationMixin fuzzy span matching tolerance."""
+
+from instructor.v2.dsl.citation import CitationMixin
+
+
+class _Answer(CitationMixin):
+    pass
+
+
+def test_quote_within_error_tolerance_matches():
+    # 3 substitutions from the 10-char source (<= errs default of 5): should match.
+    context = "0123456789"
+    result = _Answer.model_validate(
+        {"substring_quotes": ["0123456ZZZ"]}, context={"context": context}
+    )
+    assert result.substring_quotes == ["0123456789"]
+
+
+def test_quote_beyond_error_tolerance_is_dropped():
+    # 6 substitutions from the 10-char source (> errs default of 5): should be
+    # dropped as "not found", not accepted and rewritten to an unrelated span.
+    context = "0123456789"
+    result = _Answer.model_validate(
+        {"substring_quotes": ["0123ZZZZZZ"]}, context={"context": context}
+    )
+    assert result.substring_quotes == []


### PR DESCRIPTION
### What's broken

`CitationMixin._get_span` escalates the allowed regex edit distance in a loop whose guard is evaluated **before** the increment:

```python
errs_ = 0
s = regex.search(f"({minor}){{e<={errs_}}}", major)
while s is None and errs_ <= errs:   # errs defaults to 5
    errs_ += 1
    s = regex.search(f"({minor}){{e<={errs_}}}", major)
```

When `errs_ == errs` (5) the body runs once more, bumping `errs_` to 6 and searching with `{e<=6}`. So the effective fuzzy tolerance is `errs + 1 = 6` — a hallucinated `substring_quote` that is 6 edits from any real source span is accepted and silently rewritten to that unrelated context substring, instead of being dropped as "not found":

```python
class Answer(CitationMixin): pass
Answer.model_validate({"substring_quotes": ["0123ZZZZZZ"]}, context={"context": "0123456789"}).substring_quotes
# before: ['0123456789']   (6 edits away -- should be [])
```

This weakens the citation verification the mixin exists to provide.

### Fix

Change the guard to `errs_ < errs` so the final search runs at exactly `{e<=errs}`. Quotes within `errs` edits still match.

### Tests

Adds `tests/dsl/test_citation.py` (within-tolerance matches; beyond-tolerance dropped). The existing citation coverage in `tests/coverage/test_dsl_small_coverage.py` — which relies on a legitimate 1-edit match — stays green (16). Distinct from #2430 (regex-escape crash), which leaves the loop bound untouched.