### PR TITLE
fix: preserve empty-content function calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **v2 message handling**: Preserve legacy OpenAI `function_call` payloads when assistant content is empty. ([#2464](https://github.com/567-labs/instructor/issues/2464))
 - **v2 message handling**: Preserve caller-owned message lists and nested content across request preparation and retries for OpenAI-compatible, Cohere, Mistral, OpenRouter, Writer, and xAI handlers. ([#2417](https://github.com/567-labs/instructor/issues/2417), [#2428](https://github.com/567-labs/instructor/issues/2428))
 - **v2 JSON extraction**: Prefer the final complete top-level JSON value in text responses and retain every JSON object when multiple objects arrive in one streaming chunk.
 - **v2 schemas**: Treat fields with Pydantic `default_factory` values as optional in generated OpenAI tool schemas.

--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -45,11 +45,7 @@ def dump_message(message: ChatCompletionMessage) -> ChatCompletionMessageParam:
     }
     if hasattr(message, "tool_calls") and message.tool_calls is not None:
         ret["tool_calls"] = message.model_dump()["tool_calls"]
-    if (
-        hasattr(message, "function_call")
-        and message.function_call is not None
-        and ret["content"]
-    ):
+    if hasattr(message, "function_call") and message.function_call is not None:
         if not isinstance(ret["content"], str):
             response_message = ""
             for content_message in ret["content"]:

--- a/tests/v2/test_messages.py
+++ b/tests/v2/test_messages.py
@@ -1,0 +1,23 @@
+"""Tests for v2 message serialization helpers."""
+
+import json
+
+import pytest
+from openai.types.chat import ChatCompletionMessage
+from openai.types.chat.chat_completion_message import FunctionCall
+
+from instructor.v2.core.messages import dump_message
+
+pytestmark = pytest.mark.unit
+
+
+def test_dump_message_preserves_function_call_with_empty_content() -> None:
+    message = ChatCompletionMessage(
+        role="assistant",
+        content=None,
+        function_call=FunctionCall(name="lookup", arguments='{"id":7}'),
+    )
+
+    result = dump_message(message)
+
+    assert result["content"] == json.dumps({"arguments": '{"id":7}', "name": "lookup"})


### PR DESCRIPTION
## Describe your changes

Preserve legacy OpenAI `function_call` payloads when an assistant response has `None` or empty content. Previously, `dump_message` skipped serialization behind a truthy-content guard and retry messages silently lost the function call.

Adds a focused regression test and an Unreleased changelog entry.

## Issue ticket number and link

Closes #2464

## Validation

- `uv run pytest -q tests/v2/test_messages.py`
- `uv run ruff check instructor/v2/core/messages.py tests/v2/test_messages.py`
- `uv run ruff format --check instructor/v2/core/messages.py tests/v2/test_messages.py`
- `uv run ty check instructor/v2/core/messages.py tests/v2/test_messages.py`

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.