### PR TITLE
fix: avoid mutating Gemini generation config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **Gemini config**: Avoid mutating caller-owned `generation_config` dictionaries while translating request options. ([#2465](https://github.com/567-labs/instructor/issues/2465))
 - **v2 message handling**: Preserve caller-owned message lists and nested content across request preparation and retries for OpenAI-compatible, Cohere, Mistral, OpenRouter, Writer, and xAI handlers. ([#2417](https://github.com/567-labs/instructor/issues/2417), [#2428](https://github.com/567-labs/instructor/issues/2428))
 - **v2 JSON extraction**: Prefer the final complete top-level JSON value in text responses and retain every JSON object when multiple objects arrive in one streaming chunk.
 - **v2 schemas**: Treat fields with Pydantic `default_factory` values as optional in generated OpenAI tool schemas.

--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -322,7 +322,8 @@ def update_gemini_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     result = kwargs.copy()
 
     if "generation_config" in result:
-        gen_config = result["generation_config"]
+        gen_config = result["generation_config"].copy()
+        result["generation_config"] = gen_config
 
         for openai_key, gemini_key in _OPENAI_TO_GEMINI_MAP.items():
             if openai_key in gen_config:

--- a/tests/v2/test_gemini_utils_deterministic.py
+++ b/tests/v2/test_gemini_utils_deterministic.py
@@ -308,6 +308,18 @@ def test_handle_gemini_json_adds_schema_prompt(monkeypatch: pytest.MonkeyPatch) 
     assert kwargs["generation_config"]["response_mime_type"] == "application/json"
 
 
+def test_update_gemini_kwargs_does_not_mutate_generation_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(utils, "_default_safety_thresholds", lambda: None)
+    generation_config = {"max_tokens": 5}
+
+    result = utils.update_gemini_kwargs({"generation_config": generation_config})
+
+    assert generation_config == {"max_tokens": 5}
+    assert result["generation_config"] == {"max_output_tokens": 5}
+
+
 def test_handle_gemini_json_guards_empty_or_missing_messages(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Describe your changes

Copy the caller-owned `generation_config` before translating OpenAI-compatible option names to Gemini names. This keeps request preparation from deleting keys such as `max_tokens` from reusable caller state.

Adds a deterministic regression test and an Unreleased changelog entry.

## Issue ticket number and link

Closes #2465

## Validation

- `uv run pytest -q tests/v2/test_gemini_utils_deterministic.py` (19 passed)
- `uv run ruff check instructor/v2/providers/gemini/utils.py tests/v2/test_gemini_utils_deterministic.py`
- `uv run ruff format --check instructor/v2/providers/gemini/utils.py tests/v2/test_gemini_utils_deterministic.py`
- `uv run ty check instructor/v2/providers/gemini/utils.py tests/v2/test_gemini_utils_deterministic.py`

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.