### PR TITLE
fix(gemini): treat caller kwargs as read-only in update_gemini_kwargs

### DIFF
--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -322,7 +322,12 @@ def update_gemini_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     result = kwargs.copy()
 
     if "generation_config" in result:
-        gen_config = result["generation_config"]
+        # Shallow-copy the nested dict so the caller's `generation_config`
+        # is treated as read-only: `dict.copy()` only copies the outer dict,
+        # so mutating the nested one leaks back to the caller and silently
+        # changes accepted parameter names on retry (#2465).
+        gen_config = {**result["generation_config"]}
+        result["generation_config"] = gen_config
 
         for openai_key, gemini_key in _OPENAI_TO_GEMINI_MAP.items():
             if openai_key in gen_config:
@@ -338,7 +343,10 @@ def update_gemini_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
         result.setdefault("safety_settings", {})
         return result
 
-    safety_settings = result.get("safety_settings", {})
+    # Same shallow-copy defense for `safety_settings`: the defaults-fill loop
+    # below writes back through this dict reference, so copy it first to keep
+    # the caller's object unchanged (same bug class as `generation_config`).
+    safety_settings = {**result.get("safety_settings", {})}
     result["safety_settings"] = safety_settings
 
     for category, threshold in default_safety_thresholds.items():

--- a/tests/v2/test_gemini_utils_deterministic.py
+++ b/tests/v2/test_gemini_utils_deterministic.py
@@ -376,6 +376,89 @@ def test_update_gemini_kwargs_applies_safety_defaults(
     assert result["safety_settings"][harassment] == 1
 
 
+def test_update_gemini_kwargs_does_not_mutate_caller_generation_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: #2465 — shallow-copy must not leak nested-dict mutation
+    back to the caller's `generation_config`. Reusing the same options dict
+    across a retry previously changed accepted parameter names in
+    caller-dependent ways."""
+    monkeypatch.setattr(utils, "_default_safety_thresholds", lambda: None)
+
+    caller_generation_config = {"max_tokens": 5, "temperature": 0.7}
+    snapshot_before = dict(caller_generation_config)
+
+    utils.update_gemini_kwargs(
+        {"generation_config": caller_generation_config, "messages": []}
+    )
+
+    assert caller_generation_config == snapshot_before
+
+
+def test_update_gemini_kwargs_does_not_mutate_caller_safety_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: #2465 — the `default_safety_thresholds` fill loop must
+    not mutate the caller's `safety_settings` dict. Same shallow-copy
+    mutation leak class as `generation_config`."""
+    monkeypatch.setattr(
+        utils,
+        "_default_safety_thresholds",
+        lambda: {"HARM_CATEGORY_HATE_SPEECH": 2},
+    )
+
+    caller_safety_settings: dict[str, int] = {"HARM_CATEGORY_HARASSMENT": 1}
+    snapshot_before = dict(caller_safety_settings)
+
+    utils.update_gemini_kwargs(
+        {"messages": [], "safety_settings": caller_safety_settings}
+    )
+
+    assert caller_safety_settings == snapshot_before
+
+
+def test_update_gemini_kwargs_returns_result_with_translated_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guards against an over-broad fix that breaks the translation itself:
+    the returned `result["generation_config"]` must still carry the
+    Gemini-style key."""
+    monkeypatch.setattr(utils, "_default_safety_thresholds", lambda: None)
+
+    result = utils.update_gemini_kwargs(
+        {"generation_config": {"max_tokens": 32, "n": 2}, "messages": []}
+    )
+
+    assert result["generation_config"]["max_output_tokens"] == 32
+    assert result["generation_config"]["candidate_count"] == 2
+    assert "max_tokens" not in result["generation_config"]
+    assert "n" not in result["generation_config"]
+
+
+def test_update_gemini_kwargs_handles_missing_generation_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Edge case: caller passes no `generation_config` key. Must not raise
+    and must not synthesize an empty dict into the caller's kwargs."""
+    monkeypatch.setattr(utils, "_default_safety_thresholds", lambda: None)
+
+    result = utils.update_gemini_kwargs({"messages": []})
+
+    assert "generation_config" not in result
+
+
+def test_update_gemini_kwargs_handles_empty_generation_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Edge case: `generation_config={}`. Must return an empty dict, not
+    raise on a missing-key lookup."""
+    monkeypatch.setattr(utils, "_default_safety_thresholds", lambda: None)
+
+    result = utils.update_gemini_kwargs({"generation_config": {}, "messages": []})
+
+    assert result["generation_config"] == {}
+
+
 def test_handle_gemini_json_rejects_model_kwarg() -> None:
     with pytest.raises(ConfigurationError, match="must be set while patching"):
         utils.handle_gemini_json(Answer, {"messages": [], "model": "gemini-pro"})


### PR DESCRIPTION
## What

`update_gemini_kwargs` no longer mutates the caller's nested `generation_config` and `safety_settings` dicts while translating OpenAI-style keys to Gemini names.

## Why

Fixes #2465. `update_gemini_kwargs` did `result = kwargs.copy()` (shallow), then mutated the nested `generation_config` via `gen_config.pop(openai_key)` / `gen_config[gemini_key] = val` — the nested dict was still the caller's reference. The same leak applied to `safety_settings` (the defaults-fill loop wrote back through the caller's dict). Reusing the same options dict for a retry or later request silently changed accepted parameter names and produced call-order-dependent behavior.

This is the same shallow-copy mutation leak class as #2417 (`messages=` aliasing).

## Approach

Shallow-copy the two nested dicts that `update_gemini_kwargs` mutates, immediately after pulling them off `result`:

```python
gen_config = {**result["generation_config"]}
result["generation_config"] = gen_config
# ... existing rename loop now mutates the copy, not the caller's dict
```

```python
safety_settings = {**result.get("safety_settings", {})}
result["safety_settings"] = safety_settings
# ... existing defaults-fill loop now mutates the copy
```

### Alternatives considered

- `copy.deepcopy(kwargs)` at the top — too broad: `kwargs` may contain Pydantic models, message lists, arbitrary user objects that don't need copying. Adds O(n) cost on every call. Rejected.
- Wrapping every dict operation in a "deep clone everything" helper — same cost issue, and introduces a new abstraction for a single-use purpose.
- Returning a new `generation_config` dict without writing it back to `result` — would require rewriting every subsequent consumer to read from the return value or a new local. More invasive change; current consumers already read `result["generation_config"]`.

## Testing

- New regression tests in `tests/v2/test_gemini_utils_deterministic.py` (5 added, all named for #2465):
  - `test_update_gemini_kwargs_does_not_mutate_caller_generation_config` — snapshots the caller's `generation_config`, asserts it is unchanged after the call.
  - `test_update_gemini_kwargs_does_not_mutate_caller_safety_settings` — same class, for `safety_settings`.
  - `test_update_gemini_kwargs_returns_result_with_translated_keys` — guards against an over-broad fix that breaks the translation itself.
  - `test_update_gemini_kwargs_handles_missing_generation_config` — edge case: no `generation_config` key.
  - `test_update_gemini_kwargs_handles_empty_generation_config` — edge case: `generation_config={}`.
- Full local run: `tests/v2/test_gemini_utils_deterministic.py` 23/23 ✅, `tests/test_genai_config_merging.py` 21/21 ✅, `tests/v2/test_messages_not_mutated.py` (excluding `mistralai`-blocked cases, pre-existing on main) 61/61 ✅.
- `ruff format` + `ruff check` clean.
