### PR TITLE
fix: stop mutating generation_config; keep empty-content function_call

### DIFF
--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -45,11 +45,9 @@ def dump_message(message: ChatCompletionMessage) -> ChatCompletionMessageParam:
     }
     if hasattr(message, "tool_calls") and message.tool_calls is not None:
         ret["tool_calls"] = message.model_dump()["tool_calls"]
-    if (
-        hasattr(message, "function_call")
-        and message.function_call is not None
-        and ret["content"]
-    ):
+    if hasattr(message, "function_call") and message.function_call is not None:
+        # Preserve legacy function calls even when content is None/empty
+        # (common for pure tool/function responses) — see #2464.
         if not isinstance(ret["content"], str):
             response_message = ""
             for content_message in ret["content"]:
@@ -59,7 +57,9 @@ def dump_message(message: ChatCompletionMessage) -> ChatCompletionMessageParam:
                     elif content_message.get("type") == "refusal":
                         response_message += content_message.get("refusal", "")
             ret["content"] = response_message
-        ret["content"] += json.dumps(message.model_dump()["function_call"])
+        ret["content"] = (ret["content"] or "") + json.dumps(
+            message.model_dump()["function_call"]
+        )
     return ret
 
 

--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -322,7 +322,10 @@ def update_gemini_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     result = kwargs.copy()
 
     if "generation_config" in result:
-        gen_config = result["generation_config"]
+        # Shallow-copy the nested dict so OpenAI-key rewrites don't mutate the
+        # caller's generation_config object (#2465).
+        gen_config = dict(result["generation_config"])
+        result["generation_config"] = gen_config
 
         for openai_key, gemini_key in _OPENAI_TO_GEMINI_MAP.items():
             if openai_key in gen_config:

--- a/tests/v2/test_issue_2465_2464.py
+++ b/tests/v2/test_issue_2465_2464.py
@@ -1,0 +1,39 @@
+"""Regression tests for #2465 and #2464."""
+
+from __future__ import annotations
+
+from openai.types.chat import ChatCompletionMessage
+from openai.types.chat.chat_completion_message import FunctionCall
+
+from instructor.v2.core.messages import dump_message
+from instructor.v2.providers.gemini import utils as gemini_utils
+
+
+def test_update_gemini_kwargs_does_not_mutate_caller_generation_config():
+    gemini_utils._default_safety_thresholds.cache_clear()
+    # Avoid depending on google.genai for this pure-dict rewrite path.
+    gemini_utils._default_safety_thresholds = lambda: None  # type: ignore[assignment]
+
+    generation_config = {"max_tokens": 5, "temperature": 0.2}
+    original = dict(generation_config)
+
+    result = gemini_utils.update_gemini_kwargs(
+        {"generation_config": generation_config}
+    )
+
+    assert generation_config == original
+    assert result["generation_config"]["max_output_tokens"] == 5
+    assert "max_tokens" not in result["generation_config"]
+    assert result["generation_config"]["temperature"] == 0.2
+
+
+def test_dump_message_preserves_function_call_when_content_empty():
+    message = ChatCompletionMessage(
+        role="assistant",
+        content=None,
+        function_call=FunctionCall(name="lookup", arguments='{"id":7}'),
+    )
+    dumped = dump_message(message)
+    assert dumped["role"] == "assistant"
+    assert "lookup" in dumped["content"]
+    assert '"id": 7' in dumped["content"] or '"id":7' in dumped["content"]


### PR DESCRIPTION
## Summary
Two small, independent correctness bugs in instructor v2:

### #2465 — `update_gemini_kwargs` mutates caller `generation_config`
`kwargs.copy()` is shallow, so rewriting `max_tokens` → `max_output_tokens` mutated the caller's nested dict. Now the nested dict is copied first.

### #2464 — `dump_message` drops legacy `function_call` when content is empty
Tool/function responses often use `content=None`. The previous `and ret["content"]` guard skipped serialization entirely. Function calls are now always appended (empty string base when content is missing).

## Test plan
- [x] Repro scripts from both issues pass locally
- [x] Added `tests/v2/test_issue_2465_2464.py`

Fixes #2465
Fixes #2464
