### PR TITLE
fix(citation): tolerate validation_context without a 'context' key

### DIFF
--- a/instructor/v2/dsl/citation.py
+++ b/instructor/v2/dsl/citation.py
@@ -66,8 +66,12 @@ class CitationMixin(BaseModel):
         if info.context is None:
             return self
 
-        # Get the context from the info
+        # Get the context from the info. Callers may pass a validation_context
+        # dict without a "context" key (or with a non-string value); treat that
+        # as "no source text" rather than crashing in regex.search (#2459).
         text_chunks = info.context.get("context", None)
+        if not isinstance(text_chunks, str):
+            return self
 
         # Get the spans of the substring_phrase in the context
         spans = list(self.get_spans(text_chunks))

--- a/tests/v2/test_citation_missing_context.py
+++ b/tests/v2/test_citation_missing_context.py
@@ -1,0 +1,30 @@
+"""Regression test for #2459 — validation_context without 'context' key."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from instructor import CitationMixin
+
+
+class User(CitationMixin, BaseModel):
+    name: str = Field(description="The name of the person")
+
+
+def test_validate_sources_tolerates_missing_context_key():
+    user = User.model_validate(
+        {"name": "Jason", "substring_quotes": ["Jason"]},
+        context={"foo": "bar"},
+    )
+    assert user.name == "Jason"
+    # Quotes are left as-is when there is no source text to resolve against.
+    assert user.substring_quotes == ["Jason"]
+
+
+def test_validate_sources_still_resolves_when_context_present():
+    context = "Jason was a student. Jason is 20 years old."
+    user = User.model_validate(
+        {"name": "Jason", "substring_quotes": ["Jason was a student"]},
+        context={"context": context},
+    )
+    assert "Jason was a student" in user.substring_quotes


### PR DESCRIPTION
## Summary
`CitationMixin.validate_sources` crashed with:

```
TypeError: expected string or bytes-like object
```

when `validation_context` was provided but did not contain a `"context"` key (or contained a non-string value). `info.context.get("context", None)` returned `None`, which was passed into `regex.search`.

## Change
If the resolved context is not a `str`, return the model unchanged instead of attempting span resolution.

## Test plan
- [x] Added `tests/v2/test_citation_missing_context.py`
- Manual: repro from the issue no longer raises

Fixes #2459.
