### PR TITLE
fix(batch): accept empty structured results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **Batch results**: Accept empty structured objects so Pydantic models can apply field defaults for OpenAI and Anthropic batch responses.
 - **v2 message handling**: Preserve caller-owned message lists and nested content across request preparation and retries for OpenAI-compatible, Cohere, Mistral, OpenRouter, Writer, and xAI handlers. ([#2417](https://github.com/567-labs/instructor/issues/2417), [#2428](https://github.com/567-labs/instructor/issues/2428))
 - **v2 JSON extraction**: Prefer the final complete top-level JSON value in text responses and retain every JSON object when multiple objects arrive in one streaming chunk.
 - **v2 schemas**: Treat fields with Pydantic `default_factory` values as optional in generated OpenAI tool schemas.

--- a/instructor/batch/processor.py
+++ b/instructor/batch/processor.py
@@ -189,7 +189,7 @@ class BatchProcessor(Generic[T]):
                 custom_id = data.get("custom_id", "unknown")
                 extracted_data = self._extract_from_response(data)
 
-                if extracted_data:
+                if extracted_data is not None:
                     try:
                         # Parse into response model
                         result = self.response_model(**extracted_data)

--- a/tests/test_batch_processor_coverage.py
+++ b/tests/test_batch_processor_coverage.py
@@ -23,6 +23,10 @@ class Person(BaseModel):
     age: int
 
 
+class DefaultedResult(BaseModel):
+    status: str = "ok"
+
+
 class RecordingProvider:
     def __init__(self, results: str = "") -> None:
         self.results = results
@@ -273,6 +277,39 @@ def test_openai_results_distinguish_success_validation_extraction_and_json_error
     assert results[3].custom_id == "unknown"
     assert results[3].error_type == "json_parse_error"
     assert results[3].raw_data == {"raw_line": "not-json"}
+
+
+@pytest.mark.parametrize(
+    ("model", "content"),
+    [
+        ("openai/gpt-4.1-mini", openai_result("empty", "{}")),
+        (
+            "anthropic/claude-sonnet",
+            json.dumps(
+                {
+                    "custom_id": "empty",
+                    "result": {
+                        "type": "succeeded",
+                        "message": {"content": [{"type": "tool_use", "input": {}}]},
+                    },
+                }
+            ),
+        ),
+    ],
+)
+def test_parse_results_accepts_empty_object_for_defaulted_model(
+    provider: RecordingProvider,
+    model: str,
+    content: str,
+) -> None:
+    del provider
+    processor = BatchProcessor(model, DefaultedResult)
+
+    results = processor.parse_results(content)
+
+    assert results == [
+        BatchSuccess(custom_id="empty", result=DefaultedResult(status="ok"))
+    ]
 
 
 def test_anthropic_results_support_tool_use_and_text_fallback(


### PR DESCRIPTION
## Summary

Allow valid empty structured objects in batch results to reach Pydantic validation.

## Problem

`BatchProcessor.parse_results()` treats an extracted `{}` response as an
extraction failure. Models whose fields have defaults therefore receive a
`BatchError` instead of a successfully validated result.

This affects both OpenAI JSON-schema batch responses and Anthropic tool-use
batch responses.

## Root cause

The parser used a truthiness check for `extracted_data`, conflating an empty
dictionary with the `None` sentinel returned when no structured result could
be extracted.

## Fix

Check explicitly for `None`. Empty dictionaries are now validated normally,
while absent and malformed results retain the existing error behavior.

## Test plan

- Added a regression covering an OpenAI batch response containing `{}`
- Added the equivalent Anthropic tool-use response
- Verified both fail before the fix and pass afterward
- Ran the focused batch suite, broad offline suite, Ruff, ty, and pre-commit

## Compatibility considerations

This is backwards-compatible. Only valid empty mappings change behavior;
missing or malformed results continue to produce `BatchError`.

## Issue ticket number and link

N/A — independently discovered; no matching issue found