### PR TITLE
fix(retry): attach _total_usage to successful retry responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **Retry**: Expose cumulative token usage on successful retry responses via `_total_usage` attribute ([#PR](url))
 - **v2 message handling**: Preserve caller-owned message lists and nested content across request preparation and retries for OpenAI-compatible, Cohere, Mistral, OpenRouter, Writer, and xAI handlers. ([#2417](https://github.com/567-labs/instructor/issues/2417), [#2428](https://github.com/567-labs/instructor/issues/2428))
 - **v2 JSON extraction**: Prefer the final complete top-level JSON value in text responses and retain every JSON object when multiple objects arrive in one streaming chunk.
 - **v2 schemas**: Treat fields with Pydantic `default_factory` values as optional in generated OpenAI tool schemas.

--- a/instructor/v2/core/retry.py
+++ b/instructor/v2/core/retry.py
@@ -69,7 +69,7 @@ def _attempt_metadata(
     }
 
 
-def _finalize_parsed_response(parsed: Any, response: Any) -> Any:
+def _finalize_parsed_response(parsed: Any, response: Any, total_usage: Any = None) -> Any:
     if isinstance(parsed, IterableBase):
         parsed = [task for task in parsed.tasks]
     if isinstance(parsed, AdapterBase):
@@ -78,6 +78,7 @@ def _finalize_parsed_response(parsed: Any, response: Any) -> Any:
         return ListResponse.from_list(parsed, raw_response=response)
     if isinstance(parsed, BaseModel):
         parsed._raw_response = response  # type: ignore[attr-defined]
+        parsed._total_usage = total_usage  # type: ignore[attr-defined]
     return parsed
 
 
@@ -222,7 +223,7 @@ def retry_sync_v2(
                         f"Successfully parsed response on attempt "
                         f"{attempt.retry_state.attempt_number}"
                     )
-                    return _finalize_parsed_response(parsed, response)
+                    return _finalize_parsed_response(parsed, response, total_usage)
 
                 except IncompleteOutputException:
                     raise
@@ -467,7 +468,7 @@ async def retry_async_v2(
                         f"Successfully parsed response on attempt "
                         f"{attempt.retry_state.attempt_number}"
                     )
-                    return _finalize_parsed_response(parsed, response)
+                    return _finalize_parsed_response(parsed, response, total_usage)
 
                 except IncompleteOutputException:
                     raise


### PR DESCRIPTION
Fixes #2391.

When retries succeed, `_total_usage` (cumulative token count across all retry attempts) was tracked internally but never attached to the returned model — it was only reachable on failure via `InstructorRetryException.total_usage`. This PR fixes that by adding a `total_usage` parameter to `_finalize_parsed_response` and assigning `parsed._total_usage = total_usage` alongside the existing `parsed._raw_response = response` whenever the parsed result is a `BaseModel`. Both the sync (`retry_sync_v2`) and async (`retry_async_v2`) code paths are updated.