### PR TITLE
docs(vertex): move model= from genai.Client() to from_genai()

### DIFF
--- a/docs/integrations/vertex.md
+++ b/docs/integrations/vertex.md
@@ -267,8 +267,8 @@ client = from_genai(
         vertexai=True,
         project="your-project",
         location="us-central1",
-        model="gemini-3-flash"
-    )
+    ),
+    model="gemini-3-flash",
 )
 ```
 


### PR DESCRIPTION
## Summary

Fixes an incorrect code example in the Vertex AI migration guide where `model=` was passed to `genai.Client()` instead of `from_genai()`.

The `genai.Client()` constructor does not accept a `model` parameter — passing it there is silently ignored. The `model` argument belongs to `from_genai()`, which uses it to set the default model for all requests.

Fixes #2416

## Changes

- `docs/integrations/vertex.md` — corrected the "Option 2" example in the Migration to Google GenAI section

**Before (incorrect):**
```python
client = from_genai(
    genai.Client(
        vertexai=True,
        project="your-project",
        location="us-central1",
        model="gemini-3-flash"   # ❌ not a valid Client() param
    )
)
```

**After (correct):**
```python
client = from_genai(
    genai.Client(
        vertexai=True,
        project="your-project",
        location="us-central1",
    ),
    model="gemini-3-flash",   # ✅ belongs to from_genai()
)
```

## Testing

Documentation-only change. Verified against the `google-genai` SDK source — `genai.Client.__init__` does not accept a `model` parameter.

Note: This PR was developed with AI assistance.