### PR TITLE
fix: build partial model instances for incomplete list[BaseModel] items during streaming

### DIFF
--- a/instructor/v2/dsl/partial.py
+++ b/instructor/v2/dsl/partial.py
@@ -241,6 +241,12 @@ def _build_partial_list(
             result.append(_item_model.model_validate(item, **kwargs))
             continue
 
+        if _item_model is not None and isinstance(item, dict):
+            result.append(
+                _build_partial_object(item, _item_model, tracker, item_path, **kwargs)
+            )
+            continue
+
         result.append(item)
 
     return result

--- a/tests/coverage/test_dsl_partial_coverage.py
+++ b/tests/coverage/test_dsl_partial_coverage.py
@@ -127,7 +127,14 @@ def test_partial_builder_validates_complete_nested_values_and_keeps_open_values(
     assert result.metadata == {"source": "stream", "attempt": 2}
     assert result.featured == Item(number=7, state=State.READY)
     assert result.items[0] == Item(number=8, state=State.PENDING)
-    assert result.items[1] == {"number": "9", "state": "rea"}
+    # Open (incomplete) list items are recursed into partial model instances,
+    # consistent with how a singular open nested field is handled (see
+    # test_partial_builder_recurses_into_open_nested_model_and_handles_scalars):
+    # unvalidated/partial values are kept, but the item stays a typed instance
+    # instead of degrading to a raw dict.
+    assert isinstance(result.items[1], Item)
+    assert result.items[1].number == "9"
+    assert result.items[1].state == "rea"
 
 
 def test_partial_builder_recurses_into_open_nested_model_and_handles_scalars() -> None:

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -1280,3 +1280,30 @@ class TestOptionalNestedBaseModelDuringPartialStreaming:
 
         # Must remain None — not an empty Inner() instance
         assert obj.inner is None
+
+    def test_partial_list_returns_model_instance_for_incomplete_trailing_item(self):
+        """The trailing (still-streaming) item in a list[BaseModel] field must be
+        a partial model instance, not a raw dict -- consistent with how a
+        singular open nested BaseModel field is already handled."""
+
+        class Item(BaseModel):
+            name: str
+            qty: int
+
+        class Order(BaseModel):
+            items: list[Item]
+
+        partial = Partial[Order]
+
+        # First item complete, second item mid-stream (incomplete).
+        chunks = [
+            '{"items": [{"name": "apple", "qty": 3}, {"name": "banana", "qty"'
+        ]
+
+        results = list(_partial_api(partial).model_from_chunks(chunks))
+        obj = results[-1]
+
+        assert isinstance(obj.items[0], Item)
+        # Would be a raw dict before the fix, raising AttributeError on .name
+        assert isinstance(obj.items[-1], Item)
+        assert obj.items[-1].name == "banana"


### PR DESCRIPTION
### Summary
Fixes a type asymmetry in `_build_partial_list` where the trailing (still-streaming)
item in a `list[BaseModel]` field was appended as a raw `dict` instead of a partial
model instance.

### Problem
When the root JSON is incomplete during streaming, `_build_partial_object` correctly
builds a partial model instance (via `model_construct`) for a singular open nested
`BaseModel` field. `_build_partial_list` does the same for *complete* list items, but
for the *incomplete* trailing item it fell through to `result.append(item)`, leaving
a raw dict.

This breaks the type contract users rely on when iterating a streamed list
(`for item in partial.items: item.name`) -- the last item raises `AttributeError`
until it completes.

### Fix
Route incomplete list items through the same `_build_partial_object` call already
used for singular open nested fields, when an item model is known. 6 lines, no new
abstractions.

### Testing
- Added `test_partial_list_returns_model_instance_for_incomplete_trailing_item`,
  confirmed to fail on `main` and pass with this change.
- Updated one pre-existing test in `tests/coverage/test_dsl_partial_coverage.py`
  that asserted the old (inconsistent) raw-dict behavior for open list items --
  its own sibling test in the same file already established that singular open
  nested fields recurse into partial instances, so this aligns list items with
  that existing, tested contract.
- Full `tests/dsl/test_partial.py` + `tests/coverage/test_dsl_partial_coverage.py`
  suite: 65 passed, 2 skipped (pre-existing), 0 failed.