### PR TITLE
fix(anthropic): disable parallel tool use for forced single-tool requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **Anthropic tools**: Set `disable_parallel_tool_use` on the forced `tool_choice` for single-model requests, so Anthropic can no longer emit multiple `tool_use` blocks for the same forced tool and have an otherwise-valid response rejected by the parser. ([#2477](https://github.com/567-labs/instructor/issues/2477))
 - **v2 message handling**: Preserve caller-owned message lists and nested content across request preparation and retries for OpenAI-compatible, Cohere, Mistral, OpenRouter, Writer, and xAI handlers. ([#2417](https://github.com/567-labs/instructor/issues/2417), [#2428](https://github.com/567-labs/instructor/issues/2428))
 - **v2 JSON extraction**: Prefer the final complete top-level JSON value in text responses and retain every JSON object when multiple objects arrive in one streaming chunk.
 - **v2 schemas**: Treat fields with Pydantic `default_factory` values as optional in generated OpenAI tool schemas.

--- a/instructor/v2/providers/anthropic/handlers.py
+++ b/instructor/v2/providers/anthropic/handlers.py
@@ -402,6 +402,11 @@ class AnthropicToolsHandler(AnthropicHandlerBase):
                 new_kwargs["tool_choice"] = {
                     "type": "tool",
                     "name": getattr(response_model, "__name__", "response"),
+                    # Without this, Anthropic may still emit multiple tool_use
+                    # blocks for the same forced tool, which the single-model
+                    # parser then rejects even though the model's response was
+                    # otherwise valid.
+                    "disable_parallel_tool_use": True,
                 }
 
         return response_model, new_kwargs

--- a/tests/v2/test_anthropic_handlers.py
+++ b/tests/v2/test_anthropic_handlers.py
@@ -1,0 +1,72 @@
+"""Unit tests for Anthropic v2 handlers.
+
+These tests verify handler behavior without requiring API keys, by calling
+the request-preparation logic directly and inspecting the resulting kwargs.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import pytest
+from pydantic import BaseModel
+
+from instructor import Mode, Provider
+from instructor.v2.core.registry import mode_registry
+
+
+class Answer(BaseModel):
+    """Simple answer model for testing."""
+
+    answer: float
+
+
+@pytest.fixture
+def handler():
+    """Get the Anthropic tools handler from registry."""
+    return mode_registry.get_handlers(Provider.ANTHROPIC, Mode.TOOLS)
+
+
+class TestAnthropicToolsHandlerToolChoice:
+    """Regression tests for #2477: a forced single-tool tool_choice did not
+    set disable_parallel_tool_use, so Anthropic could still emit multiple
+    tool_use blocks for the same forced tool, which the single-model parser
+    then rejected even though the model's response was otherwise valid."""
+
+    def test_single_response_model_disables_parallel_tool_use(self, handler):
+        kwargs = {
+            "messages": [{"role": "user", "content": "What is 2+2?"}],
+            "max_tokens": 100,
+        }
+
+        _, result_kwargs = handler.request_handler(Answer, kwargs)
+
+        assert result_kwargs["tool_choice"] == {
+            "type": "tool",
+            "name": "Answer",
+            "disable_parallel_tool_use": True,
+        }
+
+    def test_parallel_tools_are_not_forced_to_disable_parallel_use(self, handler):
+        # Iterable[T] is the parallel-tools case: the model is *expected* to
+        # emit multiple tool_use blocks here, so tool_choice must stay "auto"
+        # and must not gain disable_parallel_tool_use.
+        kwargs = {
+            "messages": [{"role": "user", "content": "List some answers"}],
+            "max_tokens": 100,
+        }
+
+        _, result_kwargs = handler.request_handler(Iterable[Answer], kwargs)
+
+        assert result_kwargs["tool_choice"] == {"type": "auto"}
+
+    def test_explicit_tool_choice_is_not_overridden(self, handler):
+        kwargs = {
+            "messages": [{"role": "user", "content": "What is 2+2?"}],
+            "max_tokens": 100,
+            "tool_choice": {"type": "auto"},
+        }
+
+        _, result_kwargs = handler.request_handler(Answer, kwargs)
+
+        assert result_kwargs["tool_choice"] == {"type": "auto"}


### PR DESCRIPTION
Fixes #2477

## Summary

`AnthropicToolsHandler.prepare_request()` forces `tool_choice` to a specific named tool when a single (non-parallel, non-thinking) `response_model` is used, but never set `disable_parallel_tool_use`. Anthropic can still emit multiple `tool_use` blocks for that same forced tool, which the single-model parser then rejects — so a valid model response fails at parse time, exactly as described in #2477.

## Fix

Added `"disable_parallel_tool_use": True` to the forced `tool_choice` dict in the single-response-model branch only. Left the `is_parallel` (`Iterable[T]`) and `thinking_enabled` branches untouched — those intentionally use `{"type": "auto"}` and, in the parallel case, actually want multiple tool calls.

## Testing

Added `tests/v2/test_anthropic_handlers.py` with 3 unit tests (no API key/mocking needed, following the existing `test_xai_handlers.py` pattern of calling `request_handler` directly):
- forced single-tool `tool_choice` now includes `disable_parallel_tool_use: True`
- the parallel-tools case is unaffected (still `{"type": "auto"}`, no `disable_parallel_tool_use`)
- an explicitly caller-supplied `tool_choice` is still not overridden

Verified the new test fails against the pre-fix code and passes against the fix. Ran the full `tests/v2/` suite (1478 passed, 160 skipped, 105 deselected) — no regressions.

How I verified: `python -m pytest tests/v2/ -k "not mistral"` (mistral cases skipped/deselected only because the optional `mistralai` SDK wasn't installed in my env, unrelated to this change).