### PR TITLE
fix(anthropic): return tool_result for every tool_use on reask

### DIFF
--- a/instructor/v2/providers/anthropic/handlers.py
+++ b/instructor/v2/providers/anthropic/handlers.py
@@ -426,7 +426,10 @@ class AnthropicToolsHandler(AnthropicHandlerBase):
             return kwargs
 
         assistant_content = []
-        tool_use_id = None
+        # Anthropic requires a tool_result for *every* tool_use in the prior turn.
+        # Collect all ids — overwriting a single id drops results for PARALLEL_TOOLS
+        # and makes the reask request fail with 400 (issue #2485).
+        tool_use_ids: list[str] = []
         for content in response.content:
             try:
                 dumped_content = content.model_dump(exclude_none=True)  # type: ignore[attr-defined]
@@ -434,10 +437,14 @@ class AnthropicToolsHandler(AnthropicHandlerBase):
                 dumped_content = content.model_dump()  # type: ignore[attr-defined]
             assistant_content.append(dumped_content)
             if content.type == "tool_use":
-                tool_use_id = content.id
+                tool_use_ids.append(content.id)
 
         reask_msgs = [{"role": "assistant", "content": assistant_content}]
-        if tool_use_id is not None:
+        if tool_use_ids:
+            error_content = (
+                "Validation Error found:\n"
+                f"{exception}\nRecall the function correctly, fix the errors"
+            )
             reask_msgs.append(
                 {
                     "role": "user",
@@ -445,12 +452,10 @@ class AnthropicToolsHandler(AnthropicHandlerBase):
                         {
                             "type": "tool_result",
                             "tool_use_id": tool_use_id,
-                            "content": (
-                                "Validation Error found:\n"
-                                f"{exception}\nRecall the function correctly, fix the errors"
-                            ),
+                            "content": error_content,
                             "is_error": True,
                         }
+                        for tool_use_id in tool_use_ids
                     ],
                 }
             )

--- a/tests/coverage/test_anthropic_handlers_coverage.py
+++ b/tests/coverage/test_anthropic_handlers_coverage.py
@@ -580,7 +580,14 @@ def test_parallel_tools_prepare_reask_and_parse_real_tool_blocks() -> None:
     assert list(handler.parse_response(None, parallel_type)) == []
     assert list(handler.parse_response(object(), parallel_type)) == []
     reask = handler.handle_reask({"messages": []}, response, ValueError("bad job"))
-    assert reask["messages"][-1]["content"][0]["tool_use_id"] == "toolu_three"
+    # Anthropic requires a tool_result for *every* tool_use block (#2485).
+    reask_results = reask["messages"][-1]["content"]
+    assert [block["tool_use_id"] for block in reask_results] == [
+        "toolu_one",
+        "toolu_two",
+        "toolu_three",
+    ]
+    assert all(block.get("is_error") is True for block in reask_results)
 
 
 def test_json_prepare_reask_and_parse_anthropic_and_openai_shaped_responses() -> None:


### PR DESCRIPTION
## Summary

When Anthropic returns multiple `tool_use` blocks (normal for `Mode.PARALLEL_TOOLS`) and a validation error triggers a reask, `handle_reask` only kept the **last** `tool_use_id`. Anthropic requires a `tool_result` for *every* prior `tool_use`, so the retry request itself failed with:

```
400 invalid_request_error: tool_use ids were found without tool_result blocks
```

## Fix

Collect all `tool_use` ids and emit one `tool_result` per id (same error content, `is_error=True`).

## Test

```text
python -m pytest tests/coverage/test_anthropic_handlers_coverage.py -q
# 24 passed
```

Regression assertion now checks all three `tool_use_id`s are present.

Fixes #2485