### PR TITLE
fix(logging): redact common credential aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **v2 request logging**: Redact common OAuth and Google API credential aliases from nested debug-log kwargs without hiding non-secret token configuration. ([#2490](https://github.com/567-labs/instructor/issues/2490))
 - **v2 message handling**: Preserve caller-owned message lists and nested content across request preparation and retries for OpenAI-compatible, Cohere, Mistral, OpenRouter, Writer, and xAI handlers. ([#2417](https://github.com/567-labs/instructor/issues/2417), [#2428](https://github.com/567-labs/instructor/issues/2428))
 - **v2 JSON extraction**: Prefer the final complete top-level JSON value in text responses and retain every JSON object when multiple objects arrive in one streaming chunk.
 - **v2 schemas**: Treat fields with Pydantic `default_factory` values as optional in generated OpenAI tool schemas.

--- a/instructor/v2/core/response.py
+++ b/instructor/v2/core/response.py
@@ -70,7 +70,17 @@ T_ParamSpec = ParamSpec("T_ParamSpec")
 T = TypeVar("T")
 
 _SENSITIVE_KEYS: frozenset[str] = frozenset(
-    {"api_key", "api_secret", "authorization", "token", "x_api_key"}
+    {
+        "access_token",
+        "api_key",
+        "api_secret",
+        "authorization",
+        "client_secret",
+        "refresh_token",
+        "token",
+        "x_api_key",
+        "x_goog_api_key",
+    }
 )
 
 

--- a/tests/coverage/test_core_response_coverage.py
+++ b/tests/coverage/test_core_response_coverage.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 from collections.abc import Callable
+from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -105,6 +106,45 @@ def test_redaction_handles_tuples_without_mutating_input() -> None:
         )
     }
     assert kwargs["metadata"][0]["api-secret"] == "private"
+
+
+@pytest.mark.parametrize(
+    "credential_key",
+    [
+        "access_token",
+        "refresh-token",
+        "X-Goog-Api-Key",
+        "Client-Secret",
+        "api_key",
+        "Authorization",
+    ],
+)
+def test_redaction_hides_common_credential_aliases(
+    credential_key: str,
+) -> None:
+    kwargs = {
+        "extra_headers": {
+            credential_key: "private",
+            "x-request-id": "request-123",
+        }
+    }
+    original = deepcopy(kwargs)
+
+    result = _redact_kwargs(kwargs)
+
+    assert result["extra_headers"][credential_key] == "[redacted]"
+    assert result["extra_headers"]["x-request-id"] == "request-123"
+    assert kwargs == original
+
+
+def test_redaction_preserves_non_secret_token_configuration() -> None:
+    kwargs = {
+        "max_tokens": 256,
+        "token_budget": 1_000,
+        "headers": {"content-type": "application/json"},
+    }
+
+    assert _redact_kwargs(kwargs) == kwargs
 
 
 def test_registry_load_failure_is_best_effort(


### PR DESCRIPTION
## What

Extend v2 request-log redaction to cover common OAuth and Google API
credential aliases in nested request kwargs.

## Why

Keys such as `x-goog-api-key`, `client_secret`, `access_token`, and
`refresh_token` currently remain visible in DEBUG logs. This can expose
credentials to persistent log sinks.

Fixes #2490

## Changes

- Add normalized credential aliases to the existing strict allowlist.
- Preserve the current recursive handling of dictionaries, lists, and tuples.
- Add parameterized regression coverage for nested headers, case and
  hyphen variants, input immutability, and non-secret token configuration.
- Add an Unreleased changelog entry.

The implementation intentionally avoids substring matching so fields such as
`max_tokens` and `token_budget` are not unnecessarily hidden.

## Testing

- `pytest tests/coverage/test_core_response_coverage.py tests/processing/test_process_response.py -q`
  - `31 passed`
- `pytest tests/v2 -q`
  - `1569 passed, 171 skipped`
- `ruff check instructor/v2/core/response.py tests/coverage/test_core_response_coverage.py`
- `ruff format --check instructor/v2/core/response.py tests/coverage/test_core_response_coverage.py`
- `ty check --python O:\.venv-py311 instructor/v2/core/response.py tests/coverage/test_core_response_coverage.py`
- `git diff --check`
