### PR TITLE
fix: prevent CitationMixin crash when validation_context is missing 'context' key (#2459)

### DIFF
--- a/instructor/v2/dsl/citation.py
+++ b/instructor/v2/dsl/citation.py
@@ -69,6 +69,9 @@ class CitationMixin(BaseModel):
         # Get the context from the info
         text_chunks = info.context.get("context", None)
 
+        if text_chunks is None:
+            return self
+
         # Get the spans of the substring_phrase in the context
         spans = list(self.get_spans(text_chunks))
         # Replace the substring_phrase with the actual substring


### PR DESCRIPTION
### Description
This PR addresses an issue where `CitationMixin.validate_sources` crashes with a `TypeError` if a user provides a `validation_context` dictionary but omits the expected `"context"` key. 

Previously, when the `"context"` key was missing, `info.context.get("context", None)` returned `None`. This `None` value was then passed directly into `self.get_spans()`, which caused the underlying `regex.search` engine to crash because it expected a string or bytes-like object.

### Changes Proposed
- Added a defensive check (`if text_chunks is None: return self`) directly after the `.get()` lookup in `instructor/v2/dsl/citation.py`.
- This safely skips source validation and returns the model instance untouched rather than crashing the application.

### Related Issues
Closes #2459