### PR TITLE
Update Cerebras documentation examples

### DIFF
--- a/docs/blog/posts/introducing-structured-outputs-with-cerebras-inference.md
+++ b/docs/blog/posts/introducing-structured-outputs-with-cerebras-inference.md
@@ -65,7 +65,7 @@ Once you've done so, you can use the following code to get started.
 import instructor
 from pydantic import BaseModel
 
-client = instructor.from_provider("cerebras/llama3.1-70b")
+client = instructor.from_provider("cerebras/gpt-oss-120b")
 
 
 class Person(BaseModel):
@@ -74,7 +74,7 @@ class Person(BaseModel):
 
 
 resp = client.create(
-    model="llama3.1-70b",
+    model="gpt-oss-120b",
     messages=[
         {
             "role": "user",
@@ -109,7 +109,7 @@ class Person(BaseModel):
 
 
 resp = client.create(
-    model="llama3.1-70b",
+    model="gpt-oss-120b",
     messages=[
         {
             "role": "user",

--- a/docs/integrations/cerebras.md
+++ b/docs/integrations/cerebras.md
@@ -22,7 +22,7 @@ import instructor
 from cerebras.cloud.sdk import Cerebras
 from pydantic import BaseModel
 
-client = instructor.from_provider("cerebras/llama3.1-70b")
+client = instructor.from_provider("cerebras/gpt-oss-120b")
 
 class User(BaseModel):
     name: str
@@ -51,7 +51,7 @@ from pydantic import BaseModel
 import asyncio
 
 client = instructor.from_provider(
-    "cerebras/llama3.1-70b",
+    "cerebras/gpt-oss-120b",
     async_client=True,
 )
 
@@ -84,7 +84,7 @@ from pydantic import BaseModel
 import instructor
 from cerebras.cloud.sdk import Cerebras
 
-client = instructor.from_provider("cerebras/llama3.1-70b")
+client = instructor.from_provider("cerebras/gpt-oss-120b")
 
 
 class Address(BaseModel):
@@ -149,7 +149,7 @@ from pydantic import BaseModel
 from typing import Iterable
 
 client = instructor.from_provider(
-    "cerebras/llama3.1-70b",
+    "cerebras/gpt-oss-120b",
     mode=instructor.Mode.MD_JSON,
 )
 
@@ -187,7 +187,7 @@ from pydantic import BaseModel
 from typing import Iterable
 
 client = instructor.from_provider(
-    "cerebras/llama3.1-70b",
+    "cerebras/gpt-oss-120b",
     mode=instructor.Mode.MD_JSON,
 )
 


### PR DESCRIPTION
## Summary

- Moves the Cerebras integration guide and blog examples from retired Llama 3.1 to gpt-oss-120b.
- The current public catalog is `gpt-oss-120b`, `zai-glm-4.7`, and `gemma-4-31b`.

## Why

The previous model ID was retired or the fixed catalog was missing a currently available Cerebras model. This could produce failed requests, stale autocomplete, or misleading examples.

## Validation

- Documentation diff check and comparison with the live Cerebras model endpoint.
- Source of truth: https://api.cerebras.ai/public/v1/models