### PR TITLE
docs(from_provider): note OpenAI-compatible multi-model gateway base_url

### DIFF
--- a/docs/concepts/from_provider.md
+++ b/docs/concepts/from_provider.md
@@ -181,6 +181,14 @@ client = instructor.from_provider(
     "openai/gpt-4o-mini", organization="org-your-org-id", timeout=30.0
 )
 
+# OpenAI-compatible multi-model gateways (same client pattern via base_url)
+# Example: DaoXE at https://api.daoxe.com/v1
+client = instructor.from_provider(
+    "openai/gpt-4o-mini",
+    api_key="YOUR_GATEWAY_KEY",
+    base_url="https://api.daoxe.com/v1",
+)
+
 # For Anthropic
 client = instructor.from_provider("anthropic/claude-3-5-sonnet", max_tokens=4096)
 


### PR DESCRIPTION
## Summary

`from_provider` already accepts OpenAI client kwargs such as `base_url`. This PR documents that the same pattern works with OpenAI-compatible multi-model gateways — DaoXE (`https://api.daoxe.com/v1`) is one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Existing OpenAI/Anthropic/Google examples unchanged
- [ ] Gateway example is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>