### PR TITLE
fix(release): finalize package metadata and gateway docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [1.15.5] - 2026-08-02
 
 ### Fixed
+- **Package metadata**: Point the published distribution's repository URL at the current `567-labs/instructor` organization and validate it before release.
 - **Retry usage accounting**: Accumulate nested and newly added numeric usage fields across OpenAI and Anthropic retries, including prediction, cache-write, cache-creation, and server-tool counters, without treating boolean metadata as billable usage. ([#2493](https://github.com/567-labs/instructor/issues/2493), [#2500](https://github.com/567-labs/instructor/pull/2500))
 - **OpenAI Responses reask**: Add a fallback correction message when a `RESPONSES_TOOLS` response contains no tool calls (e.g. reasoning-only output), so retries carry validation feedback instead of resending the identical request. ([#2498](https://github.com/567-labs/instructor/pull/2498))
 - **v2 parallel tools**: Preserve raw iterable type hints through the sync and async patch wrappers so parallel tool schemas and results retain every requested model type. ([#2501](https://github.com/567-labs/instructor/pull/2501))

--- a/docs/concepts/from_provider.md
+++ b/docs/concepts/from_provider.md
@@ -181,6 +181,14 @@ client = instructor.from_provider(
     "openai/gpt-4o-mini", organization="org-your-org-id", timeout=30.0
 )
 
+# OpenAI-compatible multi-model gateways (same client pattern via base_url)
+# Example: DaoXE at https://api.daoxe.com/v1
+client = instructor.from_provider(
+    "openai/gpt-4o-mini",
+    api_key="YOUR_GATEWAY_KEY",
+    base_url="https://api.daoxe.com/v1",
+)
+
 # For Anthropic
 client = instructor.from_provider("anthropic/claude-3-5-sonnet", max_tokens=4096)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ build-backend = "hatchling.build"
 package = true
 
 [project.urls]
-repository = "https://github.com/instructor-ai/instructor"
+repository = "https://github.com/567-labs/instructor"
 
 [tool.pytest.ini_options]
 markers = [

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -28,6 +28,11 @@ def _project_version(root: Path) -> str:
     return str(data["project"]["version"])
 
 
+def _repository_url(root: Path) -> str:
+    data = _load_toml(root / "pyproject.toml")
+    return str(data["project"]["urls"]["repository"])
+
+
 def _lock_version(root: Path) -> str:
     data = _load_toml(root / "uv.lock")
     matches = [
@@ -86,9 +91,16 @@ def prepare_release(
     """Validate version metadata and write the matching changelog section."""
     version = _project_version(root)
     lock_version = _lock_version(root)
+    repository_url = _repository_url(root)
     if lock_version != version:
         raise ValueError(
             f"version mismatch: pyproject.toml={version}, uv.lock={lock_version}"
+        )
+    expected_repository_url = f"https://github.com/{REPOSITORY}"
+    if repository_url != expected_repository_url:
+        raise ValueError(
+            "repository URL mismatch: "
+            f"pyproject.toml={repository_url}, expected={expected_repository_url}"
         )
     if expected_version and expected_version != version:
         raise ValueError(

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -10,7 +10,9 @@ SCRIPT = Path(__file__).parents[1] / "scripts" / "prepare_release.py"
 
 def _write_release_files(root: Path, changelog: str) -> None:
     (root / "pyproject.toml").write_text(
-        '[project]\nname = "instructor"\nversion = "1.2.3"\n', encoding="utf-8"
+        '[project]\nname = "instructor"\nversion = "1.2.3"\n'
+        '[project.urls]\nrepository = "https://github.com/567-labs/instructor"\n',
+        encoding="utf-8",
     )
     (root / "uv.lock").write_text(
         'version = 1\n[[package]]\nname = "instructor"\nversion = "1.2.3"\n',
@@ -118,3 +120,21 @@ def test_prepare_release_requires_comparison_link(tmp_path: Path) -> None:
 
     assert result.returncode == 2
     assert "missing the [1.2.3] comparison link" in result.stderr
+
+
+def test_prepare_release_rejects_stale_repository_url(tmp_path: Path) -> None:
+    _write_release_files(tmp_path, _changelog())
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        pyproject.read_text(encoding="utf-8").replace(
+            "https://github.com/567-labs/instructor",
+            "https://github.com/instructor-ai/instructor",
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 2
+    assert "repository URL mismatch" in result.stderr
+    assert "expected=https://github.com/567-labs/instructor" in result.stderr


### PR DESCRIPTION
## Summary

- update the wheel/sdist repository metadata from the former `instructor-ai` organization to `567-labs/instructor`
- make release preparation reject stale repository metadata before artifacts are built or published
- include the compact OpenAI-compatible multi-model gateway `base_url` example from #2504 while preserving contributor authorship
- document the package metadata correction in the `1.15.5` notes

The package metadata defect was found by inspecting the exact wheel produced by the non-publishing readiness run after #2503 merged.

## Included / superseded

- includes #2504 as the canonical compact docs update
- supersedes the broader DaoXE-specific docs PR #2436 with the generic eight-line example

Both source commits remain separately attributed on this branch.

## Validation

- release validator tests: 6 passed
- Ruff check and format: passed
- scoped test type check: passed
- release metadata validation for `1.15.5`: passed
- `uv lock --check`: passed
- pre-commit hooks: passed
- wheel and sdist build: passed
- Twine metadata checks: passed
- built wheel reports `Project-URL: repository, https://github.com/567-labs/instructor`
- DaoXE `api.daoxe.com/v1/models` and `daoxe.com/v1/models` endpoints both return the expected authenticated API response
- `git diff --check`: passed

## Skipped

- no runtime/provider implementation changes
- no dependency changes
- no tag, release, PyPI publication, or social post

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata, release script, docs, and tests only—no library runtime or dependency changes.
> 
> **Overview**
> Updates **published package metadata** so `project.urls.repository` points at `567-labs/instructor` instead of the old `instructor-ai` org, and records that fix in the **1.15.5** changelog.
> 
> **Release preparation** now reads that URL from `pyproject.toml` and fails fast with a repository URL mismatch if it still points at the wrong GitHub org, with a test covering the stale-URL case.
> 
> **Docs** add a short `from_provider` example for OpenAI-compatible gateways using `base_url` and a gateway API key (DaoXE as the sample endpoint).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff8c87647a213b022f1439622033dd7b5472db9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->