### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/concepts/from_provider.md
+++ b/docs/concepts/from_provider.md
@@ -181,6 +181,14 @@ client = instructor.from_provider(
     "openai/gpt-4o-mini", organization="org-your-org-id", timeout=30.0
 )
 
+# OpenAI-compatible multi-model gateways (same client pattern via base_url)
+# Example: DaoXE (https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=instructor&utm_content=from_provider) at https://api.daoxe.com/v1
+client = instructor.from_provider(
+    "openai/gpt-4o-mini",
+    api_key="YOUR_GATEWAY_KEY",
+    base_url="https://api.daoxe.com/v1",
+)
+
 # For Anthropic
 client = instructor.from_provider("anthropic/claude-3-5-sonnet", max_tokens=4096)
 


### PR DESCRIPTION
## Summary

`from_provider` already forwards `base_url` to the OpenAI client. Document that the same pattern works with OpenAI-compatible multi-model gateways, using [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=instructor&utm_content=from_provider) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Docs render correctly
- [ ] Existing `from_provider` examples unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>