### PR TITLE
fix: add request timeouts to multimodal URL fetches

### DIFF
--- a/instructor/v2/core/multimodal.py
+++ b/instructor/v2/core/multimodal.py
@@ -203,7 +203,7 @@ class Image(BaseModel):
 
         if not media_type:
             try:
-                response = requests.head(url, allow_redirects=True)
+                response = requests.head(url, allow_redirects=True, timeout=30)
                 media_type = response.headers.get("Content-Type")
             except requests.RequestException as e:
                 raise ValueError(f"Failed to fetch image from URL") from e
@@ -233,7 +233,7 @@ class Image(BaseModel):
     @lru_cache
     def url_to_base64(url: str) -> str:
         """Cachable helper method for getting image url and encoding to base64."""
-        response = requests.get(url)
+        response = requests.get(url, timeout=30)
         response.raise_for_status()
         return base64.b64encode(response.content).decode("utf-8")
 
@@ -324,7 +324,7 @@ class Audio(BaseModel):
         """Create an Audio instance from a URL."""
         if url.startswith("gs://"):
             return cls.from_gs_url(url)
-        response = requests.get(url)
+        response = requests.get(url, timeout=30)
         content_type = response.headers.get("content-type")
         if content_type not in VALID_AUDIO_MIME_TYPES:
             raise ValueError(
@@ -591,7 +591,7 @@ class PDF(BaseModel):
 
         if not media_type:
             try:
-                response = requests.head(url, allow_redirects=True)
+                response = requests.head(url, allow_redirects=True, timeout=30)
                 media_type = response.headers.get("Content-Type")
             except requests.RequestException as e:
                 raise ValueError("Failed to fetch PDF from URL") from e

--- a/instructor/v2/providers/anthropic/multimodal.py
+++ b/instructor/v2/providers/anthropic/multimodal.py
@@ -33,7 +33,7 @@ def pdf_to_anthropic(pdf: Any) -> dict[str, Any]:
     ):
         return {"type": "document", "source": {"type": "url", "url": pdf.source}}
     if not pdf.data:
-        pdf.data = requests.get(str(pdf.source)).content
+        pdf.data = requests.get(str(pdf.source), timeout=30).content
         pdf.data = base64.b64encode(pdf.data).decode("utf-8")
     return {
         "type": "document",

--- a/instructor/v2/providers/genai/multimodal.py
+++ b/instructor/v2/providers/genai/multimodal.py
@@ -28,7 +28,7 @@ def image_to_genai(image: Any) -> Any:
         ("http://", "https://")
     ):
         return types.Part.from_bytes(
-            data=requests.get(image.source).content,
+            data=requests.get(image.source, timeout=30).content,
             mime_type=image.media_type,
         )
     if image.data or image.is_base64(str(image.source)):
@@ -55,7 +55,7 @@ def pdf_to_genai(pdf: Any) -> Any:
         and pdf.source.startswith(("http://", "https://"))
         and not pdf.data
     ):
-        data = requests.get(pdf.source).content
+        data = requests.get(pdf.source, timeout=30).content
         encoded = base64.b64encode(data).decode("utf-8")
         return types.Part.from_bytes(
             data=base64.b64decode(encoded),

--- a/instructor/v2/providers/openai/multimodal.py
+++ b/instructor/v2/providers/openai/multimodal.py
@@ -72,7 +72,7 @@ def pdf_to_openai(pdf: Any, mode: Mode) -> dict[str, Any]:
         and pdf.source.startswith(("http://", "https://"))
         and not pdf.data
     ):
-        response = requests.get(pdf.source)
+        response = requests.get(pdf.source, timeout=30)
         data = base64.b64encode(response.content).decode("utf-8")
         if mode in RESPONSES_MODES:
             return {

--- a/tests/multimodal/test_multimodal.py
+++ b/tests/multimodal/test_multimodal.py
@@ -751,3 +751,35 @@ def test_pdf_to_bedrock_missing_data_no_source():
         match="PDF data is missing. Provide base64-encoded data or use an s3:// source.",
     ):
         pdf.to_bedrock()
+
+
+def test_url_to_base64_passes_timeout():
+    """Remote fetches must pass a request timeout so a slow or unresponsive host
+    cannot hang the caller indefinitely (uncontrolled resource consumption, CWE-400)."""
+    with patch("instructor.v2.core.multimodal.requests") as mock_requests:
+        mock_response = MagicMock()
+        mock_response.content = b"fake image bytes"
+        mock_requests.get.return_value = mock_response
+
+        Image.url_to_base64("https://example.com/timeout-regression.jpg")
+
+        mock_requests.get.assert_called_once()
+        _, kwargs = mock_requests.get.call_args
+        assert kwargs.get("timeout") is not None
+
+
+def test_image_from_url_head_passes_timeout():
+    """The HEAD probe used to sniff an extensionless URL's content type must also
+    pass a timeout so it cannot hang the caller indefinitely (CWE-400)."""
+    with patch("instructor.v2.core.multimodal.requests") as mock_requests:
+        mock_requests.RequestException = Exception
+        mock_response = MagicMock()
+        mock_response.headers = {"Content-Type": "image/jpeg"}
+        mock_requests.head.return_value = mock_response
+
+        # URL has no file extension, forcing the HEAD content-type probe.
+        Image.from_url("https://example.com/no-extension")
+
+        mock_requests.head.assert_called_once()
+        _, kwargs = mock_requests.head.call_args
+        assert kwargs.get("timeout") is not None


### PR DESCRIPTION
## Problem

Several `requests.get` / `requests.head` calls in the multimodal helpers download image, audio, and PDF content from remote URLs **without passing a timeout**. Because Python's `requests` has no default timeout, a slow or unresponsive host can hang the calling thread indefinitely (uncontrolled resource consumption, CWE-400). This is a denial-of-service hardening gap: a single unreachable media URL can stall a request pipeline forever.

The GCS helpers in the same module (`from_gs_url`) already use a 30s timeout, and `bedrock/handlers.py` uses `timeout=30` too, so the codebase already treats 30s as the convention. This PR simply extends that same default to the remaining fetches.

## Fixed call sites

- `instructor/v2/core/multimodal.py` - `Image.from_url` (HEAD probe), `Image.url_to_base64`, `Audio.from_url`, `PDF.from_url` (HEAD probe)
- `instructor/v2/providers/anthropic/multimodal.py` - `pdf_to_anthropic`
- `instructor/v2/providers/genai/multimodal.py` - `image_to_genai`, `pdf_to_genai`
- `instructor/v2/providers/openai/multimodal.py` - `pdf_to_openai`

## Change

Each remote fetch now passes `timeout=30`, matching the existing convention. No behavior change for healthy hosts; unresponsive hosts now fail fast instead of hanging.

## Tests

Added two regression tests in `tests/multimodal/test_multimodal.py` asserting a timeout is passed on both the `requests.get` and `requests.head` paths. Full multimodal suite passes: 62 passed, 1 skipped.