### PR TITLE
fix(openai): route streaming retries through the streaming parser in TOOLS/JSON/MD_JSON

### DIFF
--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -718,10 +718,11 @@ class OpenAIToolsHandler(OpenAIHandlerBase):
     ) -> Any:
         """Parse tool call response."""
         # Check for streaming
-        consume_streaming = isinstance(
-            response_model, type
-        ) and self._consume_streaming_flag(response_model)
-        if consume_streaming:
+        if (
+            isinstance(response_model, type)
+            and (stream or self._consume_streaming_flag(response_model))
+            and issubclass(response_model, (IterableBase, PartialBase))
+        ):
             return self._parse_streaming_response(
                 response_model,
                 response,
@@ -905,8 +906,10 @@ class OpenAIJSONHandler(OpenAIHandlerBase):
         stream: bool = False,  # noqa: ARG002
         is_async: bool = False,  # noqa: ARG002
     ) -> Any:
-        if isinstance(response_model, type) and self._consume_streaming_flag(
-            response_model
+        if (
+            isinstance(response_model, type)
+            and (stream or self._consume_streaming_flag(response_model))
+            and issubclass(response_model, (IterableBase, PartialBase))
         ):
             return self._parse_streaming_response(
                 response_model,
@@ -1007,8 +1010,10 @@ class OpenAIMDJSONHandler(OpenAIHandlerBase):
     ) -> Any:
         """Parse JSON from markdown code block in response."""
         # Check for streaming
-        if isinstance(response_model, type) and self._consume_streaming_flag(
-            response_model
+        if (
+            isinstance(response_model, type)
+            and (stream or self._consume_streaming_flag(response_model))
+            and issubclass(response_model, (IterableBase, PartialBase))
         ):
             return self._parse_streaming_response(
                 response_model,

--- a/tests/v2/test_openai_streaming.py
+++ b/tests/v2/test_openai_streaming.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from types import SimpleNamespace
+from typing import Any
 
-from pydantic import BaseModel
+import pytest
+from pydantic import BaseModel, ValidationError, field_validator
 
+from instructor.v2.dsl.partial import Partial
 from instructor.v2.providers.openai.handlers import OpenAIToolsHandler
 
 
@@ -20,3 +24,50 @@ def test_openai_tools_streaming_iterable_not_parallel():
 
     assert kwargs["tool_choice"] != "auto"
     assert handler._consume_streaming_flag(response_model)
+
+
+class _Foo(BaseModel):
+    name: str
+
+    @field_validator("name")
+    @classmethod
+    def _must_have_space(cls, value: str) -> str:
+        if " " not in value:
+            raise ValueError("must contain a space")
+        return value
+
+
+def _tool_stream(payload: str) -> Any:
+    delta = SimpleNamespace(
+        content=None,
+        tool_calls=[
+            SimpleNamespace(
+                index=0,
+                id="call-0",
+                function=SimpleNamespace(name="_Foo", arguments=payload),
+            )
+        ],
+    )
+    chunk = SimpleNamespace(
+        choices=[
+            SimpleNamespace(delta=delta, finish_reason="stop"),
+        ]
+    )
+    return iter([chunk])
+
+
+def test_streaming_retry_recovers_after_flag_consumed() -> None:
+    response_model = Partial[_Foo]
+    handler = OpenAIToolsHandler()
+    handler.mark_streaming_model(response_model, True)
+
+    with pytest.raises(ValidationError):
+        handler.parse_response(
+            _tool_stream('{"name": "Jane"}'), response_model, stream=True
+        )
+
+    result = handler.parse_response(
+        _tool_stream('{"name": "Jane Doe"}'), response_model, stream=True
+    )
+    assert isinstance(result, list)
+    assert result[-1].name == "Jane Doe"


### PR DESCRIPTION
## Summary

`create_partial`/`create_iterable` with OpenAI TOOLS/JSON/MD_JSON modes fails on retry: the per-model streaming flag is consumed on the first attempt, and on retry the handler falls through to the non-streaming parser (but the response is still a `Stream`, producing `ResponseParsingError("No choices in OpenAI response")` instead of the real validation error). Even when the model self-corrects on retry, the corrected stream is discarded.

The JSON_SCHEMA and RESPONSES_TOOLS handlers already gate correctly the streaming path but the other 3 handlers were missing the `stream or` condition.

## Fix

Add `stream or` to the gate in all three handlers, mirroring the JSON_SCHEMA sibling.