### PR TITLE
fix(v2): parse PEP 604 unions in iterable streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Iterable streaming unions**: Parse PEP 604 unions (`create_iterable(response_model=Weather | GoogleSearch)`, `Iterable[Weather | GoogleSearch]`) member by member instead of raising `AttributeError: 'types.UnionType' object has no attribute 'model_validate_json'`, matching the existing `Union[Weather, GoogleSearch]` behaviour.
+
 ## [1.15.5] - 2026-08-02
 
 ### Fixed

--- a/instructor/v2/dsl/iterable.py
+++ b/instructor/v2/dsl/iterable.py
@@ -140,7 +140,11 @@ class IterableBase:
         **kwargs: Any,
     ):
         assert cls.task_type is not None
-        if get_origin(cls.task_type) is Union:
+        # ``Iterable[A | B]`` stores a ``types.UnionType`` task type, whose origin is
+        # ``types.UnionType`` rather than ``typing.Union`` on Python 3.10-3.13. Match on
+        # ``_UNION_ORIGINS`` so PEP 604 unions take the member-by-member branch instead of
+        # falling through to ``model_validate_json`` on the union object itself.
+        if get_origin(cls.task_type) in _UNION_ORIGINS:
             union_members = get_args(cls.task_type)
             for member in union_members:
                 try:

--- a/tests/v2/test_iterable_streaming.py
+++ b/tests/v2/test_iterable_streaming.py
@@ -1,15 +1,26 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from collections.abc import Iterable
+from typing import Any, Union, cast
 
+import pytest
 from pydantic import BaseModel
 
+from instructor.v2.core.response_model import prepare_response_model
 from instructor.v2.dsl.iterable import IterableBase, IterableModel
 
 
 class User(BaseModel):
     name: str
     bio: str
+
+
+class Weather(BaseModel):
+    location: str
+
+
+class GoogleSearch(BaseModel):
+    query: str
 
 
 def test_iterable_get_object_ignores_braces_inside_strings() -> None:
@@ -54,3 +65,62 @@ def test_iterable_tasks_from_chunks_handles_braces_inside_strings() -> None:
         User(name="Alice", bio="happy :}"),
         User(name="Bob", bio="plain"),
     ]
+
+
+UNION_CHUNKS = [
+    '{"tasks": [',
+    '{"location": "Toronto"}',
+    ', {"query": "super bowl winner"}',
+    "]}",
+]
+
+EXPECTED_UNION_TASKS = [
+    Weather(location="Toronto"),
+    GoogleSearch(query="super bowl winner"),
+]
+
+
+@pytest.mark.parametrize(
+    "task_type",
+    [
+        pytest.param(Union[Weather, GoogleSearch], id="typing-union"),
+        pytest.param(Weather | GoogleSearch, id="pep604-union"),
+    ],
+)
+def test_iterable_streaming_parses_both_union_spellings(task_type: Any) -> None:
+    """`A | B` must stream like `Union[A, B]`.
+
+    `IterableModel` already accepts PEP 604 unions when it builds the wrapper class, but
+    `extract_cls_task_type` used to match only `typing.Union`, so a `types.UnionType`
+    task type fell through to `model_validate_json` on the union object itself and raised
+    `AttributeError: 'types.UnionType' object has no attribute 'model_validate_json'`.
+    """
+    iterable_model = cast(Any, IterableModel(cast(type[BaseModel], task_type)))
+
+    assert list(iterable_model.tasks_from_chunks(UNION_CHUNKS)) == EXPECTED_UNION_TASKS
+
+
+@pytest.mark.parametrize(
+    "response_model",
+    [
+        pytest.param(Iterable[Union[Weather, GoogleSearch]], id="typing-union"),
+        pytest.param(Iterable[Weather | GoogleSearch], id="pep604-union"),
+    ],
+)
+def test_create_iterable_response_model_streams_union_members(
+    response_model: Any,
+) -> None:
+    """Covers the type `create_iterable` builds: it wraps `response_model` in `Iterable[...]`."""
+    prepared = cast(Any, prepare_response_model(response_model))
+
+    assert prepared.__name__ == "IterableWeatherOrGoogleSearch"
+    assert list(prepared.tasks_from_chunks(UNION_CHUNKS)) == EXPECTED_UNION_TASKS
+
+
+def test_iterable_pep604_union_reports_unmatched_payload_as_value_error() -> None:
+    iterable_model = cast(
+        Any, IterableModel(cast(type[BaseModel], Weather | GoogleSearch))
+    )
+
+    with pytest.raises(ValueError, match="Failed to extract task type"):
+        iterable_model.extract_cls_task_type('{"unrelated": true}')


### PR DESCRIPTION
## Problem

Streaming a union of models works with `Union[A, B]` but crashes with the PEP 604
spelling `A | B`:

```python
client.chat.completions.create_iterable(
    response_model=Weather | GoogleSearch,
    messages=[...],
)
```

```
AttributeError: 'types.UnionType' object has no attribute 'model_validate_json'
```

It raises on the first streamed item. `response_model=Union[Weather, GoogleSearch]`
— the spelling used in `docs/concepts/iterable.md` — works fine, so the two
spellings of the same type disagree.

## Cause

`create_iterable` wraps the model as `Iterable[Weather | GoogleSearch]`, so
`IterableBase.task_type` holds a `types.UnionType`. In
`instructor/v2/dsl/iterable.py`, `extract_cls_task_type` matched only
`typing.Union`:

```python
if get_origin(cls.task_type) is Union:
```

On Python 3.10-3.13 `get_origin(A | B)` is `types.UnionType`, so PEP 604 unions
skipped the member-by-member branch and called `model_validate_json` on the union
object itself.

The same file already defines `_UNION_ORIGINS = (Union, UnionType)` (lines 17-22)
and `IterableModel` uses it, so `Iterable[A | B]` builds a correct
`IterableWeatherOrGoogleSearch` wrapper and then fails to parse into it.
`dsl/parallel.py`, `dsl/partial.py` and `core/response_model.py` all already match
on `UnionType`; `extract_cls_task_type` was the only site left out.

## Fix

Match `_UNION_ORIGINS` in `extract_cls_task_type`. No new imports; `typing.Union`
behaviour is unchanged, and the Python 3.9 fallback (`_UNION_ORIGINS = (Union,)`)
is preserved.

One helper covers four streaming entry points — `tasks_from_chunks`,
`tasks_from_chunks_async`, `tasks_from_task_list_chunks`,
`tasks_from_task_list_chunks_async` — so sync, async and task-list streaming are
all fixed.

## Tests

`tests/v2/test_iterable_streaming.py` gains parametrised cases running both union
spellings through `IterableModel` and through the `Iterable[...]` type that
`create_iterable` builds, plus the unmatched-payload error path.

Without the fix: `3 failed, 6 passed` (only the `pep604-union` cases fail).
With the fix: `9 passed`.

Surrounding modules (`tests/v2/`, `tests/dsl/`, `tests/processing/`,
`tests/coverage/test_dsl_iter_parallel_coverage.py`) go from `7 failed, 1812
passed` on `main` to `7 failed, 1817 passed` — the same pre-existing failures
(missing optional provider deps locally), plus the 5 new cases.

Relates to the `|`-vs-`Union` streaming issues #661 / #1523 / #2088, which were
fixed in `dsl/partial.py`; this applies the same treatment to `dsl/iterable.py`.
It is a separate call site, not a duplicate of those fixes.
