### PR TITLE
fix: finalize 1.15.5 correctness consolidation

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -94,6 +94,7 @@ jobs:
           uv run --frozen pytest tests/ --asyncio-mode=auto -n auto \
             --ignore=tests/coverage \
             --ignore=tests/test_batch_processor_coverage.py \
+            -m 'not llm' \
             -k 'not test_core_providers and not test_openai and not test_anthropic and not test_gemini and not test_genai and not test_writer and not test_vertexai and not docs'
 
       - name: Build and validate distributions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,17 +30,12 @@ jobs:
           uv run --frozen pytest tests/ --asyncio-mode=auto -n auto
           --ignore=tests/coverage
           --ignore=tests/test_batch_processor_coverage.py
+          -m 'not llm'
           -k 'not test_core_providers and not test_openai and not test_anthropic
           and not test_gemini and not test_genai and not test_writer and not
           test_vertexai and not docs'
         env:
           INSTRUCTOR_ENV: CI
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
-          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
 
   # Offline coverage tests must not be filtered by provider names.
   offline-coverage-tests:
@@ -129,6 +124,7 @@ jobs:
           uv run --frozen coverage erase
           uv run --frozen coverage run --branch -m pytest tests/ \
             --asyncio-mode=auto --strict-config --strict-markers \
+            -m 'not llm' \
             -k 'not docs'
           uv run --frozen coverage report --show-missing --fail-under=99
           uv run --frozen coverage json -o "${RUNNER_TEMP}/coverage.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
-### Fixed
-- **Iterable streaming unions**: Parse PEP 604 unions (`create_iterable(response_model=Weather | GoogleSearch)`, `Iterable[Weather | GoogleSearch]`) member by member instead of raising `AttributeError: 'types.UnionType' object has no attribute 'model_validate_json'`, matching the existing `Union[Weather, GoogleSearch]` behaviour.
-
-## [1.15.5] - 2026-08-02
+## [1.15.5] - 2026-08-07
 
 ### Fixed
+- **Remote multimodal fetches**: Apply the existing 30-second request timeout to image, audio, and PDF downloads so an unresponsive URL cannot block a caller indefinitely. ([#2507](https://github.com/567-labs/instructor/pull/2507))
+- **OpenAI streaming retries**: Keep TOOLS, JSON, JSON_SCHEMA, and MD_JSON retries on the streaming parser after the one-shot model marker is consumed, allowing corrected streamed responses to validate successfully. ([#2508](https://github.com/567-labs/instructor/pull/2508))
+- **Iterable streaming unions**: Parse PEP 604 unions (`create_iterable(response_model=Weather | GoogleSearch)`, `Iterable[Weather | GoogleSearch]`) member by member instead of calling `model_validate_json` on `types.UnionType`. ([#2509](https://github.com/567-labs/instructor/pull/2509))
 - **Package metadata**: Point the published distribution's repository URL at the current `567-labs/instructor` organization and validate it before release.
 - **Retry usage accounting**: Accumulate nested and newly added numeric usage fields across OpenAI and Anthropic retries, including prediction, cache-write, cache-creation, and server-tool counters, without treating boolean metadata as billable usage. ([#2493](https://github.com/567-labs/instructor/issues/2493), [#2500](https://github.com/567-labs/instructor/pull/2500))
 - **OpenAI Responses reask**: Add a fallback correction message when a `RESPONSES_TOOLS` response contains no tool calls (e.g. reasoning-only output), so retries carry validation feedback instead of resending the identical request. ([#2498](https://github.com/567-labs/instructor/pull/2498))
@@ -45,6 +45,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - **OpenAI Responses API**: Align `RESPONSES_TOOLS` `text.format` with the forced tool schema and add targeted retry guidance when tool calls return empty `{}` arguments. ([#2300](https://github.com/567-labs/instructor/issues/2300), [#2304](https://github.com/567-labs/instructor/pull/2304))
 
 ### Tests / CI
+- **Fork-safe contributor checks**: Mark auto-client network tests explicitly and exclude them from core, coverage, and release lanes so fork PRs without provider secrets do not fail with empty authorization headers.
 - **Coverage and test quality**: Run the complete offline suite on Python 3.9-3.13, enforce fork-safe statement and branch coverage plus supported-version type checks in pull-request CI, add strict resource and thread warning checks, and provide a manual retry-mutation workflow. Consolidate typed response, stream, and SDK fixtures; remove duplicate tests and unreachable provider paths; and replace coverage-only stubs with meaningful edge-case and transport-backed provider checks.
 - **Release safety**: Validate the declared source, lockfile, changelog, tag, and built artifacts before any publication step; require an explicit version confirmation and publish opt-in; and publish the exact tested assets instead of rebuilding from a moving branch.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Iterable streaming unions**: Parse PEP 604 unions (`create_iterable(response_model=Weather | GoogleSearch)`, `Iterable[Weather | GoogleSearch]`) member by member instead of raising `AttributeError: 'types.UnionType' object has no attribute 'model_validate_json'`, matching the existing `Union[Weather, GoogleSearch]` behaviour.
+
 ## [1.15.5] - 2026-08-02
 
 ### Fixed

--- a/instructor/v2/core/multimodal.py
+++ b/instructor/v2/core/multimodal.py
@@ -203,7 +203,7 @@ class Image(BaseModel):
 
         if not media_type:
             try:
-                response = requests.head(url, allow_redirects=True)
+                response = requests.head(url, allow_redirects=True, timeout=30)
                 media_type = response.headers.get("Content-Type")
             except requests.RequestException as e:
                 raise ValueError(f"Failed to fetch image from URL") from e
@@ -233,7 +233,7 @@ class Image(BaseModel):
     @lru_cache
     def url_to_base64(url: str) -> str:
         """Cachable helper method for getting image url and encoding to base64."""
-        response = requests.get(url)
+        response = requests.get(url, timeout=30)
         response.raise_for_status()
         return base64.b64encode(response.content).decode("utf-8")
 
@@ -324,7 +324,7 @@ class Audio(BaseModel):
         """Create an Audio instance from a URL."""
         if url.startswith("gs://"):
             return cls.from_gs_url(url)
-        response = requests.get(url)
+        response = requests.get(url, timeout=30)
         content_type = response.headers.get("content-type")
         if content_type not in VALID_AUDIO_MIME_TYPES:
             raise ValueError(
@@ -591,7 +591,7 @@ class PDF(BaseModel):
 
         if not media_type:
             try:
-                response = requests.head(url, allow_redirects=True)
+                response = requests.head(url, allow_redirects=True, timeout=30)
                 media_type = response.headers.get("Content-Type")
             except requests.RequestException as e:
                 raise ValueError("Failed to fetch PDF from URL") from e

--- a/instructor/v2/dsl/iterable.py
+++ b/instructor/v2/dsl/iterable.py
@@ -140,7 +140,11 @@ class IterableBase:
         **kwargs: Any,
     ):
         assert cls.task_type is not None
-        if get_origin(cls.task_type) is Union:
+        # ``Iterable[A | B]`` stores a ``types.UnionType`` task type, whose origin is
+        # ``types.UnionType`` rather than ``typing.Union`` on Python 3.10-3.13. Match on
+        # ``_UNION_ORIGINS`` so PEP 604 unions take the member-by-member branch instead of
+        # falling through to ``model_validate_json`` on the union object itself.
+        if get_origin(cls.task_type) in _UNION_ORIGINS:
             union_members = get_args(cls.task_type)
             for member in union_members:
                 try:

--- a/instructor/v2/dsl/iterable.py
+++ b/instructor/v2/dsl/iterable.py
@@ -140,10 +140,7 @@ class IterableBase:
         **kwargs: Any,
     ):
         assert cls.task_type is not None
-        # ``Iterable[A | B]`` stores a ``types.UnionType`` task type, whose origin is
-        # ``types.UnionType`` rather than ``typing.Union`` on Python 3.10-3.13. Match on
-        # ``_UNION_ORIGINS`` so PEP 604 unions take the member-by-member branch instead of
-        # falling through to ``model_validate_json`` on the union object itself.
+        # PEP 604 unions use types.UnionType rather than typing.Union as their origin.
         if get_origin(cls.task_type) in _UNION_ORIGINS:
             union_members = get_args(cls.task_type)
             for member in union_members:

--- a/instructor/v2/providers/anthropic/multimodal.py
+++ b/instructor/v2/providers/anthropic/multimodal.py
@@ -33,7 +33,7 @@ def pdf_to_anthropic(pdf: Any) -> dict[str, Any]:
     ):
         return {"type": "document", "source": {"type": "url", "url": pdf.source}}
     if not pdf.data:
-        pdf.data = requests.get(str(pdf.source)).content
+        pdf.data = requests.get(str(pdf.source), timeout=30).content
         pdf.data = base64.b64encode(pdf.data).decode("utf-8")
     return {
         "type": "document",

--- a/instructor/v2/providers/genai/multimodal.py
+++ b/instructor/v2/providers/genai/multimodal.py
@@ -28,7 +28,7 @@ def image_to_genai(image: Any) -> Any:
         ("http://", "https://")
     ):
         return types.Part.from_bytes(
-            data=requests.get(image.source).content,
+            data=requests.get(image.source, timeout=30).content,
             mime_type=image.media_type,
         )
     if image.data or image.is_base64(str(image.source)):
@@ -55,7 +55,7 @@ def pdf_to_genai(pdf: Any) -> Any:
         and pdf.source.startswith(("http://", "https://"))
         and not pdf.data
     ):
-        data = requests.get(pdf.source).content
+        data = requests.get(pdf.source, timeout=30).content
         encoded = base64.b64encode(data).decode("utf-8")
         return types.Part.from_bytes(
             data=base64.b64decode(encoded),

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -414,6 +414,19 @@ class OpenAIHandlerBase(ModeHandler):
             return True
         return False
 
+    def _should_parse_streaming(
+        self,
+        response_model: type[BaseModel] | ParallelBase | None,
+        stream: bool,
+    ) -> bool:
+        """Return whether a response needs DSL streaming parsing."""
+        registered = self._consume_streaming_flag(response_model)
+        return bool(
+            inspect.isclass(response_model)
+            and issubclass(response_model, (IterableBase, PartialBase))
+            and (stream or registered)
+        )
+
     def extract_streaming_json(
         self, completion: TypingIterable[Any]
     ) -> Generator[str, None, None]:
@@ -713,16 +726,12 @@ class OpenAIToolsHandler(OpenAIHandlerBase):
         response_model: type[BaseModel],
         validation_context: dict[str, Any] | None = None,
         strict: bool | None = None,
-        stream: bool = False,  # noqa: ARG002
+        stream: bool = False,
         is_async: bool = False,  # noqa: ARG002
     ) -> Any:
         """Parse tool call response."""
         # Check for streaming
-        if (
-            isinstance(response_model, type)
-            and (stream or self._consume_streaming_flag(response_model))
-            and issubclass(response_model, (IterableBase, PartialBase))
-        ):
+        if self._should_parse_streaming(response_model, stream):
             return self._parse_streaming_response(
                 response_model,
                 response,
@@ -811,16 +820,12 @@ class OpenAIJSONSchemaHandler(OpenAIHandlerBase):
         response_model: type[BaseModel],
         validation_context: dict[str, Any] | None = None,
         strict: bool | None = None,
-        stream: bool = False,  # noqa: ARG002
+        stream: bool = False,
         is_async: bool = False,  # noqa: ARG002
     ) -> Any:
         """Parse JSON schema response."""
         # Check for streaming
-        if (
-            isinstance(response_model, type)
-            and (stream or self._consume_streaming_flag(response_model))
-            and issubclass(response_model, (IterableBase, PartialBase))
-        ):
+        if self._should_parse_streaming(response_model, stream):
             return self._parse_streaming_response(
                 response_model,
                 response,
@@ -903,14 +908,10 @@ class OpenAIJSONHandler(OpenAIHandlerBase):
         response_model: type[BaseModel],
         validation_context: dict[str, Any] | None = None,
         strict: bool | None = None,
-        stream: bool = False,  # noqa: ARG002
+        stream: bool = False,
         is_async: bool = False,  # noqa: ARG002
     ) -> Any:
-        if (
-            isinstance(response_model, type)
-            and (stream or self._consume_streaming_flag(response_model))
-            and issubclass(response_model, (IterableBase, PartialBase))
-        ):
+        if self._should_parse_streaming(response_model, stream):
             return self._parse_streaming_response(
                 response_model,
                 response,
@@ -1005,16 +1006,12 @@ class OpenAIMDJSONHandler(OpenAIHandlerBase):
         response_model: type[BaseModel],
         validation_context: dict[str, Any] | None = None,
         strict: bool | None = None,
-        stream: bool = False,  # noqa: ARG002
+        stream: bool = False,
         is_async: bool = False,  # noqa: ARG002
     ) -> Any:
         """Parse JSON from markdown code block in response."""
         # Check for streaming
-        if (
-            isinstance(response_model, type)
-            and (stream or self._consume_streaming_flag(response_model))
-            and issubclass(response_model, (IterableBase, PartialBase))
-        ):
+        if self._should_parse_streaming(response_model, stream):
             return self._parse_streaming_response(
                 response_model,
                 response,

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -718,10 +718,11 @@ class OpenAIToolsHandler(OpenAIHandlerBase):
     ) -> Any:
         """Parse tool call response."""
         # Check for streaming
-        consume_streaming = isinstance(
-            response_model, type
-        ) and self._consume_streaming_flag(response_model)
-        if consume_streaming:
+        if (
+            isinstance(response_model, type)
+            and (stream or self._consume_streaming_flag(response_model))
+            and issubclass(response_model, (IterableBase, PartialBase))
+        ):
             return self._parse_streaming_response(
                 response_model,
                 response,
@@ -905,8 +906,10 @@ class OpenAIJSONHandler(OpenAIHandlerBase):
         stream: bool = False,  # noqa: ARG002
         is_async: bool = False,  # noqa: ARG002
     ) -> Any:
-        if isinstance(response_model, type) and self._consume_streaming_flag(
-            response_model
+        if (
+            isinstance(response_model, type)
+            and (stream or self._consume_streaming_flag(response_model))
+            and issubclass(response_model, (IterableBase, PartialBase))
         ):
             return self._parse_streaming_response(
                 response_model,
@@ -1007,8 +1010,10 @@ class OpenAIMDJSONHandler(OpenAIHandlerBase):
     ) -> Any:
         """Parse JSON from markdown code block in response."""
         # Check for streaming
-        if isinstance(response_model, type) and self._consume_streaming_flag(
-            response_model
+        if (
+            isinstance(response_model, type)
+            and (stream or self._consume_streaming_flag(response_model))
+            and issubclass(response_model, (IterableBase, PartialBase))
         ):
             return self._parse_streaming_response(
                 response_model,

--- a/instructor/v2/providers/openai/multimodal.py
+++ b/instructor/v2/providers/openai/multimodal.py
@@ -72,7 +72,7 @@ def pdf_to_openai(pdf: Any, mode: Mode) -> dict[str, Any]:
         and pdf.source.startswith(("http://", "https://"))
         and not pdf.data
     ):
-        response = requests.get(pdf.source)
+        response = requests.get(pdf.source, timeout=30)
         data = base64.b64encode(response.content).decode("utf-8")
         if mode in RESPONSES_MODES:
             return {

--- a/tests/coverage/test_anthropic_support_coverage.py
+++ b/tests/coverage/test_anthropic_support_coverage.py
@@ -184,10 +184,10 @@ def test_anthropic_multimodal_encodes_remote_image_and_local_pdf(
     assert image_calls == ["https://example.test/diagram.png"]
     assert image.data == "aW1hZ2U="
 
-    requests: list[str] = []
+    requests: list[tuple[str, int]] = []
 
-    def fake_get(url: str) -> Any:
-        requests.append(url)
+    def fake_get(url: str, *, timeout: int) -> Any:
+        requests.append((url, timeout))
         return SimpleNamespace(content=b"%PDF-1.7\nexample")
 
     monkeypatch.setattr(multimodal.requests, "get", fake_get)
@@ -203,7 +203,7 @@ def test_anthropic_multimodal_encodes_remote_image_and_local_pdf(
             "data": expected,
         },
     }
-    assert requests == ["/tmp/example.pdf"]
+    assert requests == [("/tmp/example.pdf", 30)]
     assert pdf.data == expected
 
 

--- a/tests/coverage/test_core_multimodal_coverage.py
+++ b/tests/coverage/test_core_multimodal_coverage.py
@@ -143,10 +143,10 @@ def test_image_raw_base64_rejects_non_webp_riff_data() -> None:
 
 
 def test_image_url_to_base64_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[str] = []
+    calls: list[tuple[str, int]] = []
 
-    def get(url: str) -> requests.Response:
-        calls.append(url)
+    def get(url: str, *, timeout: int) -> requests.Response:
+        calls.append((url, timeout))
         return response(b"image-bytes", "image/png")
 
     monkeypatch.setattr(requests, "get", get)
@@ -154,7 +154,7 @@ def test_image_url_to_base64_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
     second = Image.url_to_base64("https://example.test/photo.png")
 
     assert first == second == base64.b64encode(b"image-bytes").decode()
-    assert calls == ["https://example.test/photo.png"]
+    assert calls == [("https://example.test/photo.png", 30)]
 
 
 def test_audio_autodetects_url_gcs_string_path_and_path(
@@ -260,10 +260,12 @@ def test_pdf_autodetects_gcs_path_and_raw_base64(
 def test_pdf_autodetects_url_from_response_media_type(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls: list[tuple[str, bool]] = []
+    calls: list[tuple[str, bool, int]] = []
 
-    def head(url: str, allow_redirects: bool = False) -> requests.Response:
-        calls.append((url, allow_redirects))
+    def head(
+        url: str, allow_redirects: bool = False, *, timeout: int
+    ) -> requests.Response:
+        calls.append((url, allow_redirects, timeout))
         return response(b"", "application/pdf")
 
     monkeypatch.setattr(requests, "head", head)
@@ -273,7 +275,7 @@ def test_pdf_autodetects_url_from_response_media_type(
     assert pdf.source == "https://example.test/reports/latest"
     assert pdf.media_type == "application/pdf"
     assert pdf.data is None
-    assert calls == [("https://example.test/reports/latest", True)]
+    assert calls == [("https://example.test/reports/latest", True, 30)]
 
 
 def test_pdf_rejects_raw_base64_with_non_pdf_content() -> None:

--- a/tests/coverage/test_openai_support_coverage.py
+++ b/tests/coverage/test_openai_support_coverage.py
@@ -237,10 +237,10 @@ def test_openai_multimodal_encoders_cover_response_and_error_paths(
     with pytest.raises(ValueError, match="Responses doesn't support audio"):
         audio_to_openai(audio, Mode.RESPONSES_TOOLS_WITH_INBUILT_TOOLS)
 
-    requested: list[str] = []
+    requested: list[tuple[str, int]] = []
 
-    def fetch(url: str) -> requests.Response:
-        requested.append(url)
+    def fetch(url: str, *, timeout: int) -> requests.Response:
+        requested.append((url, timeout))
         response = requests.Response()
         response.status_code = 200
         response._content = b"%PDF-1.7\ncoverage"  # real response body, no network call
@@ -261,8 +261,8 @@ def test_openai_multimodal_encoders_cover_response_and_error_paths(
         },
     }
     assert requested == [
-        "https://cdn.example.invalid/report.pdf",
-        "https://cdn.example.invalid/report.pdf",
+        ("https://cdn.example.invalid/report.pdf", 30),
+        ("https://cdn.example.invalid/report.pdf", 30),
     ]
 
     pdf_data = PDF.from_base64("data:application/pdf;base64,cGRm")

--- a/tests/multimodal/test_multimodal.py
+++ b/tests/multimodal/test_multimodal.py
@@ -751,3 +751,35 @@ def test_pdf_to_bedrock_missing_data_no_source():
         match="PDF data is missing. Provide base64-encoded data or use an s3:// source.",
     ):
         pdf.to_bedrock()
+
+
+def test_url_to_base64_passes_timeout():
+    """Remote fetches must pass a request timeout so a slow or unresponsive host
+    cannot hang the caller indefinitely (uncontrolled resource consumption, CWE-400)."""
+    with patch("instructor.v2.core.multimodal.requests") as mock_requests:
+        mock_response = MagicMock()
+        mock_response.content = b"fake image bytes"
+        mock_requests.get.return_value = mock_response
+
+        Image.url_to_base64("https://example.com/timeout-regression.jpg")
+
+        mock_requests.get.assert_called_once()
+        _, kwargs = mock_requests.get.call_args
+        assert kwargs.get("timeout") is not None
+
+
+def test_image_from_url_head_passes_timeout():
+    """The HEAD probe used to sniff an extensionless URL's content type must also
+    pass a timeout so it cannot hang the caller indefinitely (CWE-400)."""
+    with patch("instructor.v2.core.multimodal.requests") as mock_requests:
+        mock_requests.RequestException = Exception
+        mock_response = MagicMock()
+        mock_response.headers = {"Content-Type": "image/jpeg"}
+        mock_requests.head.return_value = mock_response
+
+        # URL has no file extension, forcing the HEAD content-type probe.
+        Image.from_url("https://example.com/no-extension")
+
+        mock_requests.head.assert_called_once()
+        _, kwargs = mock_requests.head.call_args
+        assert kwargs.get("timeout") is not None

--- a/tests/multimodal/test_multimodal.py
+++ b/tests/multimodal/test_multimodal.py
@@ -765,7 +765,7 @@ def test_url_to_base64_passes_timeout():
 
         mock_requests.get.assert_called_once()
         _, kwargs = mock_requests.get.call_args
-        assert kwargs.get("timeout") is not None
+        assert kwargs["timeout"] == 30
 
 
 def test_image_from_url_head_passes_timeout():
@@ -782,4 +782,4 @@ def test_image_from_url_head_passes_timeout():
 
         mock_requests.head.assert_called_once()
         _, kwargs = mock_requests.head.call_args
-        assert kwargs.get("timeout") is not None
+        assert kwargs["timeout"] == 30

--- a/tests/providers/test_auto_client.py
+++ b/tests/providers/test_auto_client.py
@@ -173,6 +173,7 @@ def test_validation_error_with_api_key_is_not_skipped() -> None:
 
 
 @pytest.mark.parametrize("provider_string", PROVIDERS)
+@pytest.mark.llm
 def test_user_extraction_sync(provider_string):
     """Test user extraction for each provider (sync)."""
 
@@ -200,6 +201,7 @@ def test_user_extraction_sync(provider_string):
 
 @pytest.mark.parametrize("provider_string", PROVIDERS)
 @pytest.mark.asyncio
+@pytest.mark.llm
 async def test_user_extraction_async(provider_string):
     """Test user extraction for each provider (async)."""
 
@@ -270,6 +272,7 @@ def test_provider_dispatch_uses_registered_builder(monkeypatch):
     ]
 
 
+@pytest.mark.llm
 def test_additional_kwargs_passed():
     """Test that additional kwargs are passed to provider."""
     import instructor

--- a/tests/v2/test_genai_multimodal_runtime.py
+++ b/tests/v2/test_genai_multimodal_runtime.py
@@ -29,11 +29,13 @@ def _install_fake_genai(
 def test_image_to_genai_fetches_url_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_genai(monkeypatch)
     multimodal = importlib.import_module("instructor.v2.providers.genai.multimodal")
-    monkeypatch.setattr(
-        multimodal.requests,
-        "get",
-        lambda url: SimpleNamespace(content=f"fetched:{url}".encode()),
-    )
+    requests: list[tuple[str, int]] = []
+
+    def get(url: str, *, timeout: int) -> Any:
+        requests.append((url, timeout))
+        return SimpleNamespace(content=f"fetched:{url}".encode())
+
+    monkeypatch.setattr(multimodal.requests, "get", get)
 
     image = Image(
         source="https://example.com/image.png",
@@ -45,6 +47,7 @@ def test_image_to_genai_fetches_url_bytes(monkeypatch: pytest.MonkeyPatch) -> No
 
     assert part.data == b"fetched:https://example.com/image.png"
     assert part.mime_type == "image/png"
+    assert requests == [("https://example.com/image.png", 30)]
 
 
 def test_image_to_genai_decodes_inline_data(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -80,11 +83,13 @@ def test_pdf_to_genai_handles_remote_and_inline_data(
 ) -> None:
     _install_fake_genai(monkeypatch)
     multimodal = importlib.import_module("instructor.v2.providers.genai.multimodal")
-    monkeypatch.setattr(
-        multimodal.requests,
-        "get",
-        lambda _url: SimpleNamespace(content=b"remote-pdf"),
-    )
+    requests: list[tuple[str, int]] = []
+
+    def get(url: str, *, timeout: int) -> Any:
+        requests.append((url, timeout))
+        return SimpleNamespace(content=b"remote-pdf")
+
+    monkeypatch.setattr(multimodal.requests, "get", get)
 
     remote_pdf = PDF(
         source="https://example.com/file.pdf",
@@ -102,6 +107,7 @@ def test_pdf_to_genai_handles_remote_and_inline_data(
 
     assert remote_part.data == b"remote-pdf"
     assert inline_part.data == b"A"
+    assert requests == [("https://example.com/file.pdf", 30)]
 
 
 def test_pdf_to_genai_raises_for_unsupported_pdf(

--- a/tests/v2/test_iterable_streaming.py
+++ b/tests/v2/test_iterable_streaming.py
@@ -1,15 +1,26 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from collections.abc import Iterable
+from typing import Any, Union, cast
 
+import pytest
 from pydantic import BaseModel
 
+from instructor.v2.core.response_model import prepare_response_model
 from instructor.v2.dsl.iterable import IterableBase, IterableModel
 
 
 class User(BaseModel):
     name: str
     bio: str
+
+
+class Weather(BaseModel):
+    location: str
+
+
+class GoogleSearch(BaseModel):
+    query: str
 
 
 def test_iterable_get_object_ignores_braces_inside_strings() -> None:
@@ -54,3 +65,62 @@ def test_iterable_tasks_from_chunks_handles_braces_inside_strings() -> None:
         User(name="Alice", bio="happy :}"),
         User(name="Bob", bio="plain"),
     ]
+
+
+UNION_CHUNKS = [
+    '{"tasks": [',
+    '{"location": "Toronto"}',
+    ', {"query": "super bowl winner"}',
+    "]}",
+]
+
+EXPECTED_UNION_TASKS = [
+    Weather(location="Toronto"),
+    GoogleSearch(query="super bowl winner"),
+]
+
+
+@pytest.mark.parametrize(
+    "task_type",
+    [
+        pytest.param(Union[Weather, GoogleSearch], id="typing-union"),
+        pytest.param(Weather | GoogleSearch, id="pep604-union"),
+    ],
+)
+def test_iterable_streaming_parses_both_union_spellings(task_type: Any) -> None:
+    """`A | B` must stream like `Union[A, B]`.
+
+    `IterableModel` already accepts PEP 604 unions when it builds the wrapper class, but
+    `extract_cls_task_type` used to match only `typing.Union`, so a `types.UnionType`
+    task type fell through to `model_validate_json` on the union object itself and raised
+    `AttributeError: 'types.UnionType' object has no attribute 'model_validate_json'`.
+    """
+    iterable_model = cast(Any, IterableModel(cast(type[BaseModel], task_type)))
+
+    assert list(iterable_model.tasks_from_chunks(UNION_CHUNKS)) == EXPECTED_UNION_TASKS
+
+
+@pytest.mark.parametrize(
+    "response_model",
+    [
+        pytest.param(Iterable[Union[Weather, GoogleSearch]], id="typing-union"),
+        pytest.param(Iterable[Weather | GoogleSearch], id="pep604-union"),
+    ],
+)
+def test_create_iterable_response_model_streams_union_members(
+    response_model: Any,
+) -> None:
+    """Covers the type `create_iterable` builds: it wraps `response_model` in `Iterable[...]`."""
+    prepared = cast(Any, prepare_response_model(response_model))
+
+    assert prepared.__name__ == "IterableWeatherOrGoogleSearch"
+    assert list(prepared.tasks_from_chunks(UNION_CHUNKS)) == EXPECTED_UNION_TASKS
+
+
+def test_iterable_pep604_union_reports_unmatched_payload_as_value_error() -> None:
+    iterable_model = cast(
+        Any, IterableModel(cast(type[BaseModel], Weather | GoogleSearch))
+    )
+
+    with pytest.raises(ValueError, match="Failed to extract task type"):
+        iterable_model.extract_cls_task_type('{"unrelated": true}')

--- a/tests/v2/test_iterable_streaming.py
+++ b/tests/v2/test_iterable_streaming.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+import sys
 from typing import Any, Union, cast
 
 import pytest
@@ -79,22 +80,23 @@ EXPECTED_UNION_TASKS = [
     GoogleSearch(query="super bowl winner"),
 ]
 
+TASK_TYPE_CASES = [pytest.param(Union[Weather, GoogleSearch], id="typing-union")]
+RESPONSE_MODEL_CASES = [
+    pytest.param(Iterable[Union[Weather, GoogleSearch]], id="typing-union")
+]
+if sys.version_info >= (3, 10):
+    TASK_TYPE_CASES.append(pytest.param(Weather | GoogleSearch, id="pep604-union"))
+    RESPONSE_MODEL_CASES.append(
+        pytest.param(Iterable[Weather | GoogleSearch], id="pep604-union")
+    )
+
 
 @pytest.mark.parametrize(
     "task_type",
-    [
-        pytest.param(Union[Weather, GoogleSearch], id="typing-union"),
-        pytest.param(Weather | GoogleSearch, id="pep604-union"),
-    ],
+    TASK_TYPE_CASES,
 )
 def test_iterable_streaming_parses_both_union_spellings(task_type: Any) -> None:
-    """`A | B` must stream like `Union[A, B]`.
-
-    `IterableModel` already accepts PEP 604 unions when it builds the wrapper class, but
-    `extract_cls_task_type` used to match only `typing.Union`, so a `types.UnionType`
-    task type fell through to `model_validate_json` on the union object itself and raised
-    `AttributeError: 'types.UnionType' object has no attribute 'model_validate_json'`.
-    """
+    """`A | B` must stream like `Union[A, B]`."""
     iterable_model = cast(Any, IterableModel(cast(type[BaseModel], task_type)))
 
     assert list(iterable_model.tasks_from_chunks(UNION_CHUNKS)) == EXPECTED_UNION_TASKS
@@ -102,21 +104,18 @@ def test_iterable_streaming_parses_both_union_spellings(task_type: Any) -> None:
 
 @pytest.mark.parametrize(
     "response_model",
-    [
-        pytest.param(Iterable[Union[Weather, GoogleSearch]], id="typing-union"),
-        pytest.param(Iterable[Weather | GoogleSearch], id="pep604-union"),
-    ],
+    RESPONSE_MODEL_CASES,
 )
 def test_create_iterable_response_model_streams_union_members(
     response_model: Any,
 ) -> None:
-    """Covers the type `create_iterable` builds: it wraps `response_model` in `Iterable[...]`."""
     prepared = cast(Any, prepare_response_model(response_model))
 
     assert prepared.__name__ == "IterableWeatherOrGoogleSearch"
     assert list(prepared.tasks_from_chunks(UNION_CHUNKS)) == EXPECTED_UNION_TASKS
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP 604 requires Python 3.10")
 def test_iterable_pep604_union_reports_unmatched_payload_as_value_error() -> None:
     iterable_model = cast(
         Any, IterableModel(cast(type[BaseModel], Weather | GoogleSearch))

--- a/tests/v2/test_openai_streaming.py
+++ b/tests/v2/test_openai_streaming.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Callable
 
 import pytest
 from pydantic import BaseModel, ValidationError, field_validator
 
 from instructor.v2.dsl.partial import Partial
-from instructor.v2.providers.openai.handlers import OpenAIToolsHandler
+from instructor.v2.providers.openai.handlers import (
+    OpenAIHandlerBase,
+    OpenAIJSONHandler,
+    OpenAIJSONSchemaHandler,
+    OpenAIMDJSONHandler,
+    OpenAIToolsHandler,
+)
 
 
 class User(BaseModel):
@@ -56,18 +62,39 @@ def _tool_stream(payload: str) -> Any:
     return iter([chunk])
 
 
-def test_streaming_retry_recovers_after_flag_consumed() -> None:
+def _text_stream(payload: str) -> Any:
+    delta = SimpleNamespace(content=payload, tool_calls=None)
+    return iter([SimpleNamespace(choices=[SimpleNamespace(delta=delta)])])
+
+
+def _markdown_stream(payload: str) -> Any:
+    return _text_stream(f"```json\n{payload}\n```")
+
+
+@pytest.mark.parametrize(
+    ("handler", "stream_factory"),
+    [
+        pytest.param(OpenAIToolsHandler(), _tool_stream, id="tools"),
+        pytest.param(OpenAIJSONSchemaHandler(), _text_stream, id="json-schema"),
+        pytest.param(OpenAIJSONHandler(), _text_stream, id="json"),
+        pytest.param(OpenAIMDJSONHandler(), _markdown_stream, id="md-json"),
+    ],
+)
+def test_streaming_retry_recovers_after_flag_consumed(
+    handler: OpenAIHandlerBase,
+    stream_factory: Callable[[str], Any],
+) -> None:
     response_model = Partial[_Foo]
-    handler = OpenAIToolsHandler()
     handler.mark_streaming_model(response_model, True)
 
     with pytest.raises(ValidationError):
         handler.parse_response(
-            _tool_stream('{"name": "Jane"}'), response_model, stream=True
+            stream_factory('{"name": "Jane"}'), response_model, stream=True
         )
+    assert handler._consume_streaming_flag(response_model) is False
 
     result = handler.parse_response(
-        _tool_stream('{"name": "Jane Doe"}'), response_model, stream=True
+        stream_factory('{"name": "Jane Doe"}'), response_model, stream=True
     )
     assert isinstance(result, list)
     assert result[-1].name == "Jane Doe"

--- a/tests/v2/test_openai_streaming.py
+++ b/tests/v2/test_openai_streaming.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from types import SimpleNamespace
+from typing import Any
 
-from pydantic import BaseModel
+import pytest
+from pydantic import BaseModel, ValidationError, field_validator
 
+from instructor.v2.dsl.partial import Partial
 from instructor.v2.providers.openai.handlers import OpenAIToolsHandler
 
 
@@ -20,3 +24,50 @@ def test_openai_tools_streaming_iterable_not_parallel():
 
     assert kwargs["tool_choice"] != "auto"
     assert handler._consume_streaming_flag(response_model)
+
+
+class _Foo(BaseModel):
+    name: str
+
+    @field_validator("name")
+    @classmethod
+    def _must_have_space(cls, value: str) -> str:
+        if " " not in value:
+            raise ValueError("must contain a space")
+        return value
+
+
+def _tool_stream(payload: str) -> Any:
+    delta = SimpleNamespace(
+        content=None,
+        tool_calls=[
+            SimpleNamespace(
+                index=0,
+                id="call-0",
+                function=SimpleNamespace(name="_Foo", arguments=payload),
+            )
+        ],
+    )
+    chunk = SimpleNamespace(
+        choices=[
+            SimpleNamespace(delta=delta, finish_reason="stop"),
+        ]
+    )
+    return iter([chunk])
+
+
+def test_streaming_retry_recovers_after_flag_consumed() -> None:
+    response_model = Partial[_Foo]
+    handler = OpenAIToolsHandler()
+    handler.mark_streaming_model(response_model, True)
+
+    with pytest.raises(ValidationError):
+        handler.parse_response(
+            _tool_stream('{"name": "Jane"}'), response_model, stream=True
+        )
+
+    result = handler.parse_response(
+        _tool_stream('{"name": "Jane Doe"}'), response_model, stream=True
+    )
+    assert isinstance(result, list)
+    assert result[-1].name == "Jane Doe"


### PR DESCRIPTION
## Included fixes

- Consolidates #2507: adds the existing 30-second timeout to all remaining remote image, audio, and PDF fetches, with assertions for every changed request path.
- Consolidates #2508: keeps OpenAI TOOLS, JSON, JSON_SCHEMA, and MD_JSON retries on the streaming parser while consuming the one-shot model marker correctly.
- Consolidates #2509: parses PEP 604 iterable unions member by member and keeps the regression suite collectable on Python 3.9.
- Makes contributor CI fork-safe by marking auto-client network tests and excluding `llm` tests from core, coverage, and release lanes.
- Moves these unreleased fixes into the still-unpublished `1.15.5` changelog section.

## Superseded PRs/issues

- Supersedes #2507, #2508, and #2509 while preserving each contributor commit and authorship.
- #2506 was closed separately as already consolidated by merged #2505.

## Validation

- Focused regression suite: `224 passed, 1 skipped, 27 deselected`
- Python 3.9 streaming compatibility: `11 passed, 1 skipped`
- Exact guarded-release offline selection: `2020 passed, 144 skipped`
- Release validator: `6 passed` and generated `1.15.5` notes successfully
- Ruff check/format, source and test `ty`, `uv lock --check`, workflow YAML parse, pre-commit hooks, and `git diff --check`: passed

## Skipped items

- Provider additions/upgrades, broad architecture/features, the 38-package dependency batch, security/product decisions, and substantial examples/docs remain open for dedicated review.
- No tag, GitHub release, PyPI publication, deployment, merge, or social post is performed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect multimodal HTTP behavior, OpenAI streaming retry parsing, and iterable union validation on common response paths; risk is moderated by focused regression tests but still touches production parsing and network I/O.
> 
> **Overview**
> This PR bundles unreleased **1.15.5** fixes: remote multimodal safety, OpenAI streaming retry parsing, iterable union streaming, and contributor CI that does not require provider secrets on fork PRs.
> 
> **Remote multimodal fetches** now pass a **30-second** `timeout` on every `requests.get` / `requests.head` used to download or sniff image, audio, and PDF URLs across v2 core and OpenAI, Anthropic, and GenAI provider encoders, so hung hosts cannot block callers indefinitely.
> 
> **OpenAI streaming retries** route TOOLS, JSON, JSON_SCHEMA, and MD_JSON through a shared `_should_parse_streaming` check that still uses the streaming DSL parser when `stream=True`, even after the one-shot streaming model marker is consumed—so a corrected streamed retry can validate instead of falling back to one-shot parsing.
> 
> **Iterable streaming** treats PEP 604 unions (`Weather | GoogleSearch`, `Iterable[Weather | GoogleSearch]`) like `typing.Union` by validating each union member in `extract_cls_task_type`, with new streaming and `prepare_response_model` tests.
> 
> **CI / changelog**: Auto-client live network tests are marked `llm` and excluded from core, full coverage, and release pytest runs (`-m 'not llm'`); core tests no longer inject provider API keys into the environment. Changelog documents these items under **1.15.5** (dated 2026-08-07).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e92e3d6d9ac5dff59f63aa5ce8833e503f0027c2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->