### PR TITLE
feat(retry): add cumulative token budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+- **Validation retry budgets**: Add positive cumulative `token_budget` limits for structured non-streaming retries, immutable `completion:usage` snapshots, sync/async cutoff parity, and stable cumulative usage metadata. Valid responses still win after crossing the budget; retries fail closed before another provider call when usage is unavailable. ([#2391](https://github.com/567-labs/instructor/issues/2391), [#2392](https://github.com/567-labs/instructor/pull/2392))
+
 ## [1.15.5] - 2026-08-07
 
 ### Fixed

--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -13,11 +13,35 @@ Hooks let you intercept and handle events during the completion and parsing proc
 |-------|-------------|-------------------|
 | `completion:kwargs` | Arguments passed to completion | `def handler(*args, **kwargs)` |
 | `completion:response` | Raw API response received | `def handler(response)` |
+| `completion:usage` | Immutable snapshot of cumulative retry usage | `def handler(usage, *, attempt_number)` |
 | `completion:error` | Error during a retry attempt | `def handler(error, *, attempt_number, max_attempts, is_last_attempt)` |
 | `parse:error` | Pydantic validation failed | `def handler(error)` |
 | `completion:last_attempt` | Final retry attempt exhausted | `def handler(error, *, attempt_number, max_attempts, is_last_attempt)` |
 
-`completion:error` and `completion:last_attempt` handlers receive optional retry metadata as keyword arguments. Old-style handlers that only accept `error` continue to work — the metadata is silently dropped for backward compatibility.
+`completion:usage`, `completion:error`, and `completion:last_attempt` handlers receive retry metadata as keyword arguments. Old-style error handlers that only accept `error` continue to work because the metadata is silently dropped for backward compatibility.
+
+## Cumulative Usage
+
+`completion:usage` runs after each response that includes compatible usage
+metadata. Each event receives a separate cumulative snapshot, so retaining or
+changing one snapshot does not affect later events or Instructor's accounting.
+
+```python
+import instructor
+
+client = instructor.from_provider("openai/gpt-4.1-mini")
+
+
+def record_usage(usage, *, attempt_number: int):
+    print(f"Attempt {attempt_number}: {usage.total_tokens} total tokens")
+
+
+client.on("completion:usage", record_usage)
+```
+
+For a successful Pydantic model or list response, Instructor also attaches the
+final cumulative snapshot as `_total_usage`. Primitive response models should
+use the hook because they cannot carry response metadata.
 
 ## Registering and Removing Hooks
 

--- a/docs/concepts/retrying.md
+++ b/docs/concepts/retrying.md
@@ -7,6 +7,49 @@ description: "Learn how to implement retry logic with Tenacity for LLM applicati
 
 Tenacity is a Python library for adding retry logic to your applications. Combined with Instructor, it helps handle API failures, rate limits, and validation errors.
 
+## Limit Validation Retry Cost
+
+Use `token_budget` to stop validation retries after cumulative provider usage
+reaches a positive token limit:
+
+```python
+import instructor
+from instructor.core import TokenBudgetExceeded
+from pydantic import BaseModel
+
+client = instructor.from_provider("openai/gpt-4.1-mini")
+
+
+class UserInfo(BaseModel):
+    name: str
+    age: int
+
+
+try:
+    user = client.create(
+        response_model=UserInfo,
+        messages=[{"role": "user", "content": "Extract: Jason is 25"}],
+        max_retries=3,
+        token_budget=2_000,
+    )
+except TokenBudgetExceeded as error:
+    print(error.total_usage)
+```
+
+The budget is checked after a response fails validation and before Instructor
+prepares another request. Reaching the exact budget stops the retry. A response
+that validates successfully is returned even if that completed request takes
+the cumulative total over the budget.
+
+`token_budget` is a retry budget, not a hard per-request limit. The provider may
+use more than the remaining budget while completing the current request. Use
+the provider's output-token setting when you also need a per-request limit.
+
+Budgeted retries currently require a structured, non-streaming response and
+compatible provider usage metadata. Instructor raises
+`TokenUsageUnavailableError` instead of making another request when it cannot
+account for usage safely.
+
 ## Basic Retry with Exponential Backoff
 
 The most common pattern uses exponential backoff to delay retries:

--- a/instructor/core/__init__.py
+++ b/instructor/core/__init__.py
@@ -14,6 +14,9 @@ from .exceptions import (
     ResponseParsingError,
     MultimodalError,
     FailedAttempt,
+    TokenBudgetError,
+    TokenBudgetExceeded,
+    TokenUsageUnavailableError,
 )
 from .hooks import Hooks, HookName
 from .patch import patch, apatch
@@ -35,6 +38,9 @@ __all__ = [
     "ResponseParsingError",
     "MultimodalError",
     "FailedAttempt",
+    "TokenBudgetError",
+    "TokenBudgetExceeded",
+    "TokenUsageUnavailableError",
     "Hooks",
     "HookName",
     "patch",

--- a/instructor/exceptions.py
+++ b/instructor/exceptions.py
@@ -29,6 +29,9 @@ from .core.exceptions import (
     MultimodalError,
     ProviderError,
     ResponseParsingError,
+    TokenBudgetError,
+    TokenBudgetExceeded,
+    TokenUsageUnavailableError,
     ValidationError,
 )
 
@@ -44,5 +47,8 @@ __all__ = [
     "MultimodalError",
     "ProviderError",
     "ResponseParsingError",
+    "TokenBudgetError",
+    "TokenBudgetExceeded",
+    "TokenUsageUnavailableError",
     "ValidationError",
 ]

--- a/instructor/v2/core/client.py
+++ b/instructor/v2/core/client.py
@@ -65,6 +65,7 @@ class Response(_ResponseBase):
         max_retries: int | Retrying = 3,
         context: dict[str, Any] | None = None,
         strict: bool = True,
+        token_budget: int | None = None,
         **kwargs: Any,
     ) -> T: ...
 
@@ -76,6 +77,7 @@ class Response(_ResponseBase):
         max_retries: int | Retrying = 3,
         context: dict[str, Any] | None = None,
         strict: bool = True,
+        token_budget: None = None,
         **kwargs: Any,
     ) -> Any: ...
 
@@ -86,9 +88,12 @@ class Response(_ResponseBase):
         max_retries: int | Retrying = 3,
         context: dict[str, Any] | None = None,
         strict: bool = True,
+        token_budget: int | None = None,
         **kwargs,
     ) -> T | Any:
         messages = self._normalize_messages(messages, kwargs)
+        if token_budget is not None:
+            kwargs["token_budget"] = token_budget
 
         create = cast(Callable[..., Any], self.client.create)
         return create(
@@ -224,6 +229,7 @@ class AsyncResponse(_ResponseBase):
         max_retries: int | AsyncRetrying = 3,
         context: dict[str, Any] | None = None,
         strict: bool = True,
+        token_budget: int | None = None,
         **kwargs: Any,
     ) -> T: ...
 
@@ -235,6 +241,7 @@ class AsyncResponse(_ResponseBase):
         max_retries: int | AsyncRetrying = 3,
         context: dict[str, Any] | None = None,
         strict: bool = True,
+        token_budget: None = None,
         **kwargs: Any,
     ) -> Any: ...
 
@@ -245,9 +252,12 @@ class AsyncResponse(_ResponseBase):
         max_retries: int | AsyncRetrying = 3,
         context: dict[str, Any] | None = None,
         strict: bool = True,
+        token_budget: int | None = None,
         **kwargs,
     ) -> T | Any:
         messages = self._normalize_messages(messages, kwargs)
+        if token_budget is not None:
+            kwargs["token_budget"] = token_budget
 
         create = cast(Callable[..., Awaitable[Any]], self.client.create)
         return await create(
@@ -419,6 +429,7 @@ class Instructor:
                 "completion:response",
                 "completion:error",
                 "completion:last_attempt",
+                "completion:usage",
                 "parse:error",
             ]
         ),
@@ -435,6 +446,7 @@ class Instructor:
                 "completion:response",
                 "completion:error",
                 "completion:last_attempt",
+                "completion:usage",
                 "parse:error",
             ]
         ),
@@ -451,6 +463,7 @@ class Instructor:
                 "completion:response",
                 "completion:error",
                 "completion:last_attempt",
+                "completion:usage",
                 "parse:error",
             ]
         )
@@ -479,6 +492,7 @@ class Instructor:
         context: dict[str, Any] | None = None,  # {{ edit_1 }}
         strict: bool = True,
         hooks: Hooks | None = None,
+        token_budget: int | None = None,
         **kwargs: Any,
     ) -> Awaitable[T]: ...
 
@@ -491,6 +505,7 @@ class Instructor:
         context: dict[str, Any] | None = None,  # {{ edit_1 }}
         strict: bool = True,
         hooks: Hooks | None = None,
+        token_budget: int | None = None,
         **kwargs: Any,
     ) -> T: ...
 
@@ -503,6 +518,7 @@ class Instructor:
         context: dict[str, Any] | None = None,  # {{ edit_1 }}
         strict: bool = True,
         hooks: Hooks | None = None,
+        token_budget: None = None,
         **kwargs: Any,
     ) -> Awaitable[Any]: ...
 
@@ -515,6 +531,7 @@ class Instructor:
         context: dict[str, Any] | None = None,  # {{ edit_1 }}
         strict: bool = True,
         hooks: Hooks | None = None,
+        token_budget: None = None,
         **kwargs: Any,
     ) -> Any: ...
 
@@ -526,9 +543,12 @@ class Instructor:
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        token_budget: int | None = None,
         **kwargs: Any,
     ) -> T | Any | Awaitable[T] | Awaitable[Any]:
         kwargs = self.handle_kwargs(kwargs)
+        if token_budget is not None:
+            kwargs["token_budget"] = token_budget
 
         # Combine client hooks with per-call hooks
         combined_hooks = self.hooks
@@ -766,9 +786,12 @@ class AsyncInstructor(Instructor):
         context: dict[str, Any] | None = None,
         strict: bool = True,
         hooks: Hooks | None = None,
+        token_budget: int | None = None,
         **kwargs: Any,
     ) -> T | Any:
         kwargs = self.handle_kwargs(kwargs)
+        if token_budget is not None:
+            kwargs["token_budget"] = token_budget
 
         # Combine client hooks with per-call hooks
         combined_hooks = self.hooks

--- a/instructor/v2/core/errors.py
+++ b/instructor/v2/core/errors.py
@@ -242,7 +242,7 @@ class InstructorRetryException(InstructorError):
         last_completion: Any | None = None,
         messages: list[Any] | None = None,
         n_attempts: int,
-        total_usage: int,
+        total_usage: Any,
         create_kwargs: dict[str, Any] | None = None,
         failed_attempts: list[FailedAttempt] | None = None,
         **kwargs: Any,
@@ -253,6 +253,42 @@ class InstructorRetryException(InstructorError):
         self.total_usage = total_usage
         self.create_kwargs = create_kwargs
         super().__init__(*args, failed_attempts=failed_attempts, **kwargs)
+
+
+class TokenBudgetError(InstructorRetryException):
+    """Base class for retry termination caused by a token budget."""
+
+    def __init__(
+        self,
+        *args: Any,
+        budget: int,
+        last_completion: Any | None = None,
+        messages: list[Any] | None = None,
+        n_attempts: int,
+        total_usage: Any,
+        create_kwargs: dict[str, Any] | None = None,
+        failed_attempts: list[FailedAttempt] | None = None,
+        **kwargs: Any,
+    ):
+        self.budget = budget
+        super().__init__(
+            *args,
+            last_completion=last_completion,
+            messages=messages,
+            n_attempts=n_attempts,
+            total_usage=total_usage,
+            create_kwargs=create_kwargs,
+            failed_attempts=failed_attempts,
+            **kwargs,
+        )
+
+
+class TokenBudgetExceeded(TokenBudgetError):
+    """Raised before a retry that would continue at an exhausted token budget."""
+
+
+class TokenUsageUnavailableError(TokenBudgetError):
+    """Raised when a retry budget cannot be enforced without usage metadata."""
 
 
 class ValidationError(InstructorError):

--- a/instructor/v2/core/hooks.py
+++ b/instructor/v2/core/hooks.py
@@ -15,6 +15,7 @@ class HookName(Enum):
     COMPLETION_RESPONSE = "completion:response"
     COMPLETION_ERROR = "completion:error"
     COMPLETION_LAST_ATTEMPT = "completion:last_attempt"
+    COMPLETION_USAGE = "completion:usage"
     PARSE_ERROR = "parse:error"
 
 
@@ -44,6 +45,17 @@ class CompletionErrorHandler(Protocol):
     ) -> None: ...
 
 
+class CompletionUsageHandler(Protocol):
+    """Protocol for cumulative completion-usage handlers."""
+
+    def __call__(
+        self,
+        usage: Any,
+        *,
+        attempt_number: int = ...,
+    ) -> None: ...
+
+
 class ParseErrorHandler(Protocol):
     """Protocol for parse error handlers."""
 
@@ -58,6 +70,7 @@ HookNameType = Union[
         "completion:response",
         "completion:error",
         "completion:last_attempt",
+        "completion:usage",
         "parse:error",
     ],
 ]
@@ -67,6 +80,7 @@ HandlerType = Union[
     CompletionKwargsHandler,
     CompletionResponseHandler,
     CompletionErrorHandler,
+    CompletionUsageHandler,
     ParseErrorHandler,
 ]
 
@@ -197,6 +211,10 @@ class Hooks:
             **kwargs: Optional metadata (attempt_number, max_attempts, is_last_attempt)
         """
         self.emit(HookName.COMPLETION_LAST_ATTEMPT, error, **kwargs)
+
+    def emit_completion_usage(self, usage: Any, **kwargs: Any) -> None:
+        """Emit an immutable snapshot of cumulative completion usage."""
+        self.emit(HookName.COMPLETION_USAGE, usage, **kwargs)
 
     def emit_parse_error(self, error: Exception, **kwargs: Any) -> None:
         """

--- a/instructor/v2/core/patch.py
+++ b/instructor/v2/core/patch.py
@@ -22,7 +22,11 @@ from instructor.v2.core.exceptions import RegistryValidationMixin
 from instructor.v2.core.registry import mode_registry
 from instructor.v2.core.messages import isolate_retry_kwargs
 from instructor.v2.core.response_model import prepare_response_model
-from instructor.v2.core.retry import retry_async_v2, retry_sync_v2
+from instructor.v2.core.retry import (
+    _validate_token_budget,
+    retry_async_v2,
+    retry_sync_v2,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -193,10 +197,16 @@ def _create_sync_wrapper(
         max_retries: int | Retrying = 1,
         strict: bool = True,
         hooks: Hooks | None = None,
+        token_budget: int | None = None,
         *args: Any,
         **kwargs: Any,
     ) -> T_Model:
         """Patched synchronous create function."""
+        _validate_token_budget(
+            token_budget,
+            response_model=response_model,
+            kwargs=kwargs,
+        )
         autodetect_images = bool(kwargs.get("autodetect_images", False))
         cache = kwargs.pop("cache", None)
         cache_ttl_raw = kwargs.pop("cache_ttl", None)
@@ -264,6 +274,7 @@ def _create_sync_wrapper(
             kwargs=isolate_retry_kwargs(new_kwargs),
             strict=strict,
             hooks=hooks,
+            token_budget=token_budget,
         )
 
         # Store in cache after successful call
@@ -309,10 +320,16 @@ def _create_async_wrapper(
         max_retries: int | AsyncRetrying = 1,
         strict: bool = True,
         hooks: Hooks | None = None,
+        token_budget: int | None = None,
         *args: Any,
         **kwargs: Any,
     ) -> T_Model:
         """Patched asynchronous create function."""
+        _validate_token_budget(
+            token_budget,
+            response_model=response_model,
+            kwargs=kwargs,
+        )
         autodetect_images = bool(kwargs.get("autodetect_images", False))
         cache = kwargs.pop("cache", None)
         cache_ttl_raw = kwargs.pop("cache_ttl", None)
@@ -380,6 +397,7 @@ def _create_async_wrapper(
             kwargs=isolate_retry_kwargs(new_kwargs),
             strict=strict,
             hooks=hooks,
+            token_budget=token_budget,
         )
 
         # Store in cache after successful call

--- a/instructor/v2/core/retry.py
+++ b/instructor/v2/core/retry.py
@@ -6,8 +6,10 @@ instead of v1's process_response.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
+from numbers import Real
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from pydantic import BaseModel, ValidationError
@@ -27,12 +29,15 @@ from instructor.v2.core.errors import (
     IncompleteOutputException,
     InstructorRetryException,
     ResponseParsingError,
+    TokenBudgetError,
+    TokenBudgetExceeded,
+    TokenUsageUnavailableError,
 )
 from instructor.v2.dsl.iterable import IterableBase
 from instructor.v2.dsl.response_list import ListResponse
 from instructor.v2.dsl.simple_type import AdapterBase
 from instructor.v2.core.messages import extract_messages
-from instructor.v2.core.usage import update_total_usage
+from instructor.v2.core.usage import has_compatible_usage, update_total_usage
 from instructor.v2.core.exceptions import RegistryValidationMixin
 from instructor.v2.core.registry import mode_registry
 
@@ -69,16 +74,119 @@ def _attempt_metadata(
     }
 
 
-def _finalize_parsed_response(parsed: Any, response: Any) -> Any:
+def _usage_snapshot(total_usage: Any) -> Any:
+    if isinstance(total_usage, BaseModel):
+        return total_usage.model_copy(deep=True)
+    return copy.deepcopy(total_usage)
+
+
+def _usage_total_tokens(total_usage: Any) -> int | None:
+    direct_total = getattr(total_usage, "total_tokens", None)
+    if isinstance(direct_total, Real) and not isinstance(direct_total, bool):
+        return int(direct_total)
+
+    token_fields = (
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+    )
+    values = [getattr(total_usage, field, None) for field in token_fields]
+    numeric_values = [
+        int(value)
+        for value in values
+        if isinstance(value, Real) and not isinstance(value, bool)
+    ]
+    return sum(numeric_values) if numeric_values else None
+
+
+def _validate_token_budget(
+    token_budget: int | None,
+    *,
+    response_model: object,
+    kwargs: dict[str, Any],
+) -> None:
+    if token_budget is None:
+        return
+    if isinstance(token_budget, bool) or not isinstance(token_budget, int):
+        raise TypeError("token_budget must be a positive integer or None")
+    if token_budget <= 0:
+        raise ValueError("token_budget must be greater than zero")
+    if response_model is None:
+        raise ValueError("token_budget requires a structured response_model")
+    if kwargs.get("stream"):
+        raise ValueError("token_budget is not supported for streaming responses")
+
+
+def _finalize_parsed_response(
+    parsed: Any,
+    response: Any,
+    total_usage: Any | None = None,
+) -> Any:
+    usage = _usage_snapshot(total_usage) if total_usage is not None else None
     if isinstance(parsed, IterableBase):
         parsed = [task for task in parsed.tasks]
     if isinstance(parsed, AdapterBase):
         return parsed.content
     if isinstance(parsed, list) and not isinstance(parsed, ListResponse):
-        return ListResponse.from_list(parsed, raw_response=response)
+        return ListResponse.from_list(
+            parsed,
+            raw_response=response,
+            total_usage=usage,
+        )
+    if isinstance(parsed, ListResponse):
+        parsed._raw_response = response
+        parsed._total_usage = usage
+        return parsed
     if isinstance(parsed, BaseModel):
         parsed._raw_response = response  # type: ignore[attr-defined]
+        if usage is not None:
+            parsed._total_usage = usage  # type: ignore[attr-defined]
     return parsed
+
+
+def _budget_error(
+    *,
+    token_budget: int | None,
+    usage_available: bool,
+    total_usage: Any,
+    attempt_number: int,
+    response: Any,
+    kwargs: dict[str, Any],
+    failed_attempts: list[FailedAttempt],
+) -> TokenBudgetError | None:
+    if token_budget is None:
+        return None
+
+    error_kwargs = {
+        "budget": token_budget,
+        "last_completion": response,
+        "messages": extract_messages(kwargs),
+        "n_attempts": attempt_number,
+        "total_usage": _usage_snapshot(total_usage),
+        "create_kwargs": kwargs,
+        "failed_attempts": failed_attempts,
+    }
+    if not usage_available:
+        return TokenUsageUnavailableError(
+            "Token budget cannot be enforced because the provider response did "
+            "not include compatible usage metadata",
+            **error_kwargs,
+        )
+
+    used_tokens = _usage_total_tokens(total_usage)
+    if used_tokens is None:
+        return TokenUsageUnavailableError(
+            "Token budget cannot be enforced because total token usage is unavailable",
+            **error_kwargs,
+        )
+    if used_tokens >= token_budget:
+        return TokenBudgetExceeded(
+            f"Token budget exhausted after {used_tokens} tokens across "
+            f"{attempt_number} attempts (budget: {token_budget})",
+            **error_kwargs,
+        )
+    return None
 
 
 def _initialize_usage(provider: Provider | Mode) -> Any:
@@ -121,6 +229,7 @@ def retry_sync_v2(
     kwargs: dict[str, Any],
     strict: bool,
     hooks: Hooks | None = None,
+    token_budget: int | None = None,
 ) -> T_Model:
     """Sync retry logic using v2 registry handlers.
 
@@ -135,13 +244,21 @@ def retry_sync_v2(
         kwargs: Keyword args for func
         strict: Strict validation mode
         hooks: Optional hooks
+        token_budget: Positive cumulative token budget for validation retries
 
     Returns:
         Validated Pydantic model instance
 
     Raises:
         InstructorRetryException: If max retries exceeded
+        TokenBudgetExceeded: If a failed attempt exhausts the retry budget
+        TokenUsageUnavailableError: If a retry budget cannot be enforced
     """
+    _validate_token_budget(
+        token_budget,
+        response_model=response_model,
+        kwargs=kwargs,
+    )
     if response_model is None:
         # No structured output, just call the API
         return func(*args, **kwargs)
@@ -169,6 +286,7 @@ def retry_sync_v2(
     last_exception: Exception | None = None
     last_attempt_number = 0
     total_usage = _initialize_usage(provider)
+    usage_complete = True
 
     try:
         for attempt in max_retries_instance:
@@ -205,7 +323,14 @@ def retry_sync_v2(
                 if hooks:
                     hooks.emit_completion_response(response)
 
+                usage_available = has_compatible_usage(response, total_usage)
+                usage_complete = usage_complete and usage_available
                 update_total_usage(response=response, total_usage=total_usage)
+                if hooks and usage_complete:
+                    hooks.emit_completion_usage(
+                        _usage_snapshot(total_usage),
+                        attempt_number=attempt_number,
+                    )
 
                 # Parse response using registry
                 try:
@@ -222,7 +347,11 @@ def retry_sync_v2(
                         f"Successfully parsed response on attempt "
                         f"{attempt.retry_state.attempt_number}"
                     )
-                    return _finalize_parsed_response(parsed, response)
+                    return _finalize_parsed_response(
+                        parsed,
+                        response,
+                        total_usage=total_usage if usage_complete else None,
+                    )
 
                 except IncompleteOutputException:
                     raise
@@ -237,15 +366,38 @@ def retry_sync_v2(
                     )
                     last_exception = e
 
+                    budget_error = _budget_error(
+                        token_budget=token_budget,
+                        usage_available=usage_complete,
+                        total_usage=total_usage,
+                        attempt_number=attempt_number,
+                        response=response,
+                        kwargs=kwargs,
+                        failed_attempts=failed_attempts,
+                    )
                     if hooks:
                         hooks.emit_parse_error(
                             e,
                             **_attempt_metadata(
                                 attempt_number=attempt_number,
                                 max_attempts=max_attempts,
-                                is_last_attempt=max_attempts == attempt_number,
+                                is_last_attempt=(
+                                    max_attempts == attempt_number
+                                    or budget_error is not None
+                                ),
                             ),
                         )
+                    if budget_error is not None:
+                        if hooks:
+                            hooks.emit_completion_last_attempt(
+                                budget_error,
+                                **_attempt_metadata(
+                                    attempt_number=attempt_number,
+                                    max_attempts=max_attempts,
+                                    is_last_attempt=True,
+                                ),
+                            )
+                        raise budget_error from e
                     # Prepare reask using registry
                     kwargs = handlers.reask_handler(
                         kwargs=kwargs,
@@ -256,7 +408,7 @@ def retry_sync_v2(
                     # Will retry with modified kwargs
                     raise
 
-    except IncompleteOutputException:
+    except (IncompleteOutputException, TokenBudgetError):
         raise
     except Exception as e:
         # Max retries exceeded or non-validation error occurred
@@ -310,6 +462,7 @@ def retry_sync(
     mode: Mode = Mode.TOOLS,
     provider: Provider = Provider.OPENAI,
     hooks: Hooks | None = None,
+    token_budget: int | None = None,
 ) -> T_Model | None:
     """Compatibility wrapper for the public retry API."""
     strict_value = True if strict is None else strict
@@ -324,6 +477,7 @@ def retry_sync(
         kwargs=dict(kwargs),
         strict=strict_value,
         hooks=hooks,
+        token_budget=token_budget,
     )
 
 
@@ -338,6 +492,7 @@ async def retry_async(
     mode: Mode = Mode.TOOLS,
     provider: Provider = Provider.OPENAI,
     hooks: Hooks | None = None,
+    token_budget: int | None = None,
 ) -> T_Model | None:
     """Compatibility wrapper for the public retry API."""
     strict_value = True if strict is None else strict
@@ -352,6 +507,7 @@ async def retry_async(
         kwargs=dict(kwargs),
         strict=strict_value,
         hooks=hooks,
+        token_budget=token_budget,
     )
 
 
@@ -366,6 +522,7 @@ async def retry_async_v2(
     kwargs: dict[str, Any],
     strict: bool,
     hooks: Hooks | None = None,
+    token_budget: int | None = None,
 ) -> T_Model:
     """Async retry logic using v2 registry handlers.
 
@@ -380,13 +537,21 @@ async def retry_async_v2(
         kwargs: Keyword args for func
         strict: Strict validation mode
         hooks: Optional hooks
+        token_budget: Positive cumulative token budget for validation retries
 
     Returns:
         Validated Pydantic model instance
 
     Raises:
         InstructorRetryException: If max retries exceeded
+        TokenBudgetExceeded: If a failed attempt exhausts the retry budget
+        TokenUsageUnavailableError: If a retry budget cannot be enforced
     """
+    _validate_token_budget(
+        token_budget,
+        response_model=response_model,
+        kwargs=kwargs,
+    )
     if response_model is None:
         # No structured output, just call the API
         return await func(*args, **kwargs)
@@ -414,6 +579,7 @@ async def retry_async_v2(
     last_exception: Exception | None = None
     last_attempt_number = 0
     total_usage = _initialize_usage(provider)
+    usage_complete = True
 
     try:
         async for attempt in max_retries_instance:
@@ -450,7 +616,14 @@ async def retry_async_v2(
                 if hooks:
                     hooks.emit_completion_response(response)
 
+                usage_available = has_compatible_usage(response, total_usage)
+                usage_complete = usage_complete and usage_available
                 update_total_usage(response=response, total_usage=total_usage)
+                if hooks and usage_complete:
+                    hooks.emit_completion_usage(
+                        _usage_snapshot(total_usage),
+                        attempt_number=attempt_number,
+                    )
 
                 # Parse response using registry
                 try:
@@ -467,7 +640,11 @@ async def retry_async_v2(
                         f"Successfully parsed response on attempt "
                         f"{attempt.retry_state.attempt_number}"
                     )
-                    return _finalize_parsed_response(parsed, response)
+                    return _finalize_parsed_response(
+                        parsed,
+                        response,
+                        total_usage=total_usage if usage_complete else None,
+                    )
 
                 except IncompleteOutputException:
                     raise
@@ -482,15 +659,38 @@ async def retry_async_v2(
                     )
                     last_exception = e
 
+                    budget_error = _budget_error(
+                        token_budget=token_budget,
+                        usage_available=usage_complete,
+                        total_usage=total_usage,
+                        attempt_number=attempt_number,
+                        response=response,
+                        kwargs=kwargs,
+                        failed_attempts=failed_attempts,
+                    )
                     if hooks:
                         hooks.emit_parse_error(
                             e,
                             **_attempt_metadata(
                                 attempt_number=attempt_number,
                                 max_attempts=max_attempts,
-                                is_last_attempt=max_attempts == attempt_number,
+                                is_last_attempt=(
+                                    max_attempts == attempt_number
+                                    or budget_error is not None
+                                ),
                             ),
                         )
+                    if budget_error is not None:
+                        if hooks:
+                            hooks.emit_completion_last_attempt(
+                                budget_error,
+                                **_attempt_metadata(
+                                    attempt_number=attempt_number,
+                                    max_attempts=max_attempts,
+                                    is_last_attempt=True,
+                                ),
+                            )
+                        raise budget_error from e
                     # Prepare reask using registry
                     kwargs = handlers.reask_handler(
                         kwargs=kwargs,
@@ -501,7 +701,7 @@ async def retry_async_v2(
                     # Will retry with modified kwargs
                     raise
 
-    except IncompleteOutputException:
+    except (IncompleteOutputException, TokenBudgetError):
         raise
     except Exception as e:
         # Max retries exceeded or non-validation error occurred

--- a/instructor/v2/core/usage.py
+++ b/instructor/v2/core/usage.py
@@ -66,6 +66,27 @@ def _accumulate_models(response: BaseModel, total: BaseModel) -> None:
             setattr(response, field_name, total_value)
 
 
+def has_compatible_usage(response: object, total_usage: object) -> bool:
+    """Return whether a response exposes usage supported by the accumulator."""
+    response_usage = getattr(response, "usage", None)
+
+    from openai.types import CompletionUsage as _OpenAIUsage
+
+    if isinstance(response_usage, _OpenAIUsage) and isinstance(
+        total_usage, _OpenAIUsage
+    ):
+        return True
+
+    try:
+        from anthropic.types import Usage as _AnthropicUsage
+
+        return isinstance(response_usage, _AnthropicUsage) and isinstance(
+            total_usage, _AnthropicUsage
+        )
+    except ImportError:
+        return False
+
+
 def update_total_usage(
     response: T_Response | None,
     total_usage: OpenAIUsage | AnthropicUsage,

--- a/instructor/v2/dsl/response_list.py
+++ b/instructor/v2/dsl/response_list.py
@@ -6,6 +6,7 @@ attach the provider's raw response so `create_with_completion()` can return it.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any, Generic, TypeVar
 
 T = TypeVar("T")
@@ -20,22 +21,46 @@ class ListResponse(list[T], Generic[T]):
     """
 
     _raw_response: Any | None
+    _total_usage: Any | None
 
-    def __init__(self, iterable=(), _raw_response: Any | None = None):  # type: ignore[no-untyped-def]
+    def __init__(
+        self,
+        iterable: Iterable[T] = (),
+        _raw_response: Any | None = None,
+        _total_usage: Any | None = None,
+    ) -> None:
         super().__init__(iterable)
         self._raw_response = _raw_response
+        self._total_usage = _total_usage
 
     @classmethod
-    def from_list(cls, items: list[T], *, raw_response: Any | None) -> ListResponse[T]:
-        return cls(items, _raw_response=raw_response)
+    def from_list(
+        cls,
+        items: list[T],
+        *,
+        raw_response: Any | None,
+        total_usage: Any | None = None,
+    ) -> ListResponse[T]:
+        return cls(
+            items,
+            _raw_response=raw_response,
+            _total_usage=total_usage,
+        )
 
     def get_raw_response(self) -> Any | None:
         return self._raw_response
 
+    def get_total_usage(self) -> Any | None:
+        return self._total_usage
+
     def __getitem__(self, key):  # type: ignore[no-untyped-def]
         value = super().__getitem__(key)
         if isinstance(key, slice):
-            return type(self)(value, _raw_response=self._raw_response)
+            return type(self)(
+                value,
+                _raw_response=self._raw_response,
+                _total_usage=self._total_usage,
+            )
         return value
 
 

--- a/instructor/v2/providers/xai/client.py
+++ b/instructor/v2/providers/xai/client.py
@@ -269,6 +269,8 @@ def from_xai(
         call_kwargs.pop("validation_context", None)
         call_kwargs.pop("context", None)
         call_kwargs.pop("hooks", None)
+        if call_kwargs.pop("token_budget", None) is not None:
+            raise ValueError("token_budget is not supported for xAI requests")
         is_stream = call_kwargs.pop("stream", False)
 
         prepared_model = response_model
@@ -429,6 +431,8 @@ def from_xai(
         call_kwargs.pop("validation_context", None)
         call_kwargs.pop("context", None)
         call_kwargs.pop("hooks", None)
+        if call_kwargs.pop("token_budget", None) is not None:
+            raise ValueError("token_budget is not supported for xAI requests")
         is_stream = call_kwargs.pop("stream", False)
 
         prepared_model = response_model

--- a/tests/coverage/test_xai_client_coverage.py
+++ b/tests/coverage/test_xai_client_coverage.py
@@ -306,6 +306,15 @@ def test_sync_unstructured_request_converts_messages_and_filters_instructor_args
         }
     ]
 
+    with pytest.raises(ValueError, match="not supported for xAI"):
+        wrapped.create(
+            response_model=Answer,
+            messages=MESSAGES,
+            model="grok-test",
+            token_budget=100,
+        )
+    assert len(factory.calls) == 1
+
 
 @pytest.mark.asyncio
 async def test_async_unstructured_request_converts_messages_and_filters_instructor_args() -> (
@@ -338,6 +347,15 @@ async def test_async_unstructured_request_converts_messages_and_filters_instruct
             "temperature": 0.25,
         }
     ]
+
+    with pytest.raises(ValueError, match="not supported for xAI"):
+        await wrapped.create(
+            response_model=Answer,
+            messages=MESSAGES,
+            model="grok-test",
+            token_budget=100,
+        )
+    assert len(factory.calls) == 1
 
 
 def test_sync_json_schema_parse_attaches_raw_response() -> None:

--- a/tests/typing/test_public_surface.py
+++ b/tests/typing/test_public_surface.py
@@ -69,6 +69,7 @@ def check_response_helpers(
     sync_response: Response, async_response: AsyncResponse
 ) -> None:
     assert_type(sync_response.create(response_model=User), User)
+    assert_type(sync_response.create(response_model=User, token_budget=1_000), User)
     assert_type(sync_response.create(response_model=None), Any)
     assert_type(
         sync_response.create_with_completion(response_model=User),
@@ -92,7 +93,7 @@ def check_response_helpers(
         sync_response.create_partial(response_model=None), Generator[Any, None, None]
     )
 
-    create_coro = async_response.create(response_model=User)
+    create_coro = async_response.create(response_model=User, token_budget=1_000)
     create_any_coro = async_response.create(response_model=None)
     completion_coro = async_response.create_with_completion(response_model=User)
     completion_any_coro = async_response.create_with_completion(response_model=None)

--- a/tests/v2/test_retry_budget.py
+++ b/tests/v2/test_retry_budget.py
@@ -1,0 +1,528 @@
+from __future__ import annotations
+
+import builtins
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from openai.types import CompletionUsage
+from pydantic import BaseModel, ValidationError
+
+from instructor import Mode, Provider
+from instructor.v2.core.client import (
+    AsyncInstructor,
+    AsyncResponse,
+    Instructor,
+    Response,
+)
+from instructor.v2.core.errors import (
+    InstructorRetryException,
+    TokenBudgetExceeded,
+    TokenUsageUnavailableError,
+)
+from instructor.v2.core.hooks import Hooks
+from instructor.v2.core.patch import patch_v2
+from instructor.v2.core.retry import (
+    _budget_error,
+    _finalize_parsed_response,
+    _usage_snapshot,
+    _usage_total_tokens,
+    retry_async_v2,
+    retry_sync_v2,
+)
+from instructor.v2.core.usage import has_compatible_usage
+from instructor.v2.dsl.response_list import ListResponse
+
+
+class Answer(BaseModel):
+    value: int
+
+
+def _validation_error() -> ValidationError:
+    with pytest.raises(ValidationError) as exc_info:
+        Answer.model_validate({"value": "invalid"})
+    return exc_info.value
+
+
+def _response(tokens: int, *, value: int | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        value=value,
+        usage=CompletionUsage(
+            completion_tokens=tokens,
+            prompt_tokens=0,
+            total_tokens=tokens,
+        ),
+    )
+
+
+def _install_handlers(
+    monkeypatch: pytest.MonkeyPatch,
+    parser: Callable[..., Answer],
+    reask: Callable[..., dict[str, Any]],
+) -> None:
+    monkeypatch.setattr(
+        "instructor.v2.core.retry.RegistryValidationMixin.validate_mode_registration",
+        lambda _provider, _mode: None,
+    )
+    monkeypatch.setattr(
+        "instructor.v2.core.retry.mode_registry.get_handlers",
+        lambda _provider, _mode: SimpleNamespace(
+            response_parser=parser,
+            reask_handler=reask,
+        ),
+    )
+
+
+def test_retry_budget_stops_before_sync_reask_at_exact_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider_calls = 0
+    reask_calls = 0
+    response = _response(100, value=None)
+    parse_events: list[dict[str, Any]] = []
+    last_attempts: list[tuple[Exception, dict[str, Any]]] = []
+
+    def create(*_args: Any, **_kwargs: Any) -> SimpleNamespace:
+        nonlocal provider_calls
+        provider_calls += 1
+        return response
+
+    def parse(**_kwargs: Any) -> Answer:
+        raise _validation_error()
+
+    def reask(**call: Any) -> dict[str, Any]:
+        nonlocal reask_calls
+        reask_calls += 1
+        return cast(dict[str, Any], call["kwargs"])
+
+    _install_handlers(monkeypatch, parse, reask)
+    hooks = Hooks()
+    hooks.on(
+        "parse:error",
+        lambda _error, **metadata: parse_events.append(metadata),
+    )
+    hooks.on(
+        "completion:last_attempt",
+        lambda error, **metadata: last_attempts.append((error, metadata)),
+    )
+
+    with pytest.raises(TokenBudgetExceeded) as exc_info:
+        retry_sync_v2(
+            func=create,
+            response_model=Answer,
+            provider=Provider.OPENAI,
+            mode=Mode.JSON,
+            context=None,
+            max_retries=3,
+            args=(),
+            kwargs={},
+            strict=True,
+            hooks=hooks,
+            token_budget=100,
+        )
+
+    error = exc_info.value
+    assert isinstance(error, InstructorRetryException)
+    assert error.budget == 100
+    assert error.n_attempts == 1
+    assert error.last_completion is response
+    assert error.total_usage.total_tokens == 100
+    assert len(error.failed_attempts or []) == 1
+    assert provider_calls == 1
+    assert reask_calls == 0
+    assert parse_events == [
+        {"attempt_number": 1, "max_attempts": 4, "is_last_attempt": True}
+    ]
+    assert last_attempts == [
+        (
+            error,
+            {"attempt_number": 1, "max_attempts": 4, "is_last_attempt": True},
+        )
+    ]
+
+
+def test_retry_budget_returns_valid_response_that_crosses_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = [_response(60, value=None), _response(60, value=7)]
+    provider_calls = 0
+    snapshots: list[tuple[CompletionUsage, int]] = []
+
+    def create(*_args: Any, **_kwargs: Any) -> SimpleNamespace:
+        nonlocal provider_calls
+        response = responses[provider_calls]
+        provider_calls += 1
+        return response
+
+    def parse(*, response: SimpleNamespace, **_kwargs: Any) -> Answer:
+        if response.value is None:
+            raise _validation_error()
+        return Answer(value=response.value)
+
+    _install_handlers(
+        monkeypatch,
+        parse,
+        lambda **call: cast(dict[str, Any], call["kwargs"]),
+    )
+    hooks = Hooks()
+
+    def record_usage(usage: Any, *, attempt_number: int) -> None:
+        snapshots.append((cast(CompletionUsage, usage), attempt_number))
+
+    hooks.on("completion:usage", record_usage)
+
+    result = retry_sync_v2(
+        func=create,
+        response_model=Answer,
+        provider=Provider.OPENAI,
+        mode=Mode.JSON,
+        context=None,
+        max_retries=3,
+        args=(),
+        kwargs={},
+        strict=True,
+        hooks=hooks,
+        token_budget=100,
+    )
+
+    assert result == Answer(value=7)
+    assert provider_calls == 2
+    assert [usage.total_tokens for usage, _ in snapshots] == [60, 120]
+    assert [attempt for _, attempt in snapshots] == [1, 2]
+    assert snapshots[0][0] is not snapshots[1][0]
+    assert snapshots[0][0].total_tokens == 60
+    assert cast(Any, result)._total_usage.total_tokens == 120
+
+
+def test_retry_budget_fails_closed_when_usage_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider_calls = 0
+    reask_calls = 0
+
+    def create(*_args: Any, **_kwargs: Any) -> SimpleNamespace:
+        nonlocal provider_calls
+        provider_calls += 1
+        return SimpleNamespace(value=None)
+
+    def parse(**_kwargs: Any) -> Answer:
+        raise _validation_error()
+
+    def reask(**call: Any) -> dict[str, Any]:
+        nonlocal reask_calls
+        reask_calls += 1
+        return cast(dict[str, Any], call["kwargs"])
+
+    _install_handlers(monkeypatch, parse, reask)
+
+    with pytest.raises(TokenUsageUnavailableError) as exc_info:
+        retry_sync_v2(
+            func=create,
+            response_model=Answer,
+            provider=Provider.OPENAI,
+            mode=Mode.JSON,
+            context=None,
+            max_retries=3,
+            args=(),
+            kwargs={},
+            strict=True,
+            token_budget=100,
+        )
+
+    assert exc_info.value.n_attempts == 1
+    assert provider_calls == 1
+    assert reask_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_budget_stops_before_async_reask_at_exact_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider_calls = 0
+    reask_calls = 0
+    usage_events: list[tuple[CompletionUsage, int]] = []
+    last_attempts: list[TokenBudgetExceeded] = []
+
+    async def create(*_args: Any, **_kwargs: Any) -> SimpleNamespace:
+        nonlocal provider_calls
+        provider_calls += 1
+        return _response(75, value=None)
+
+    def parse(**_kwargs: Any) -> Answer:
+        raise _validation_error()
+
+    def reask(**call: Any) -> dict[str, Any]:
+        nonlocal reask_calls
+        reask_calls += 1
+        return cast(dict[str, Any], call["kwargs"])
+
+    _install_handlers(monkeypatch, parse, reask)
+    hooks = Hooks()
+    hooks.on(
+        "completion:usage",
+        lambda usage, *, attempt_number: usage_events.append(
+            (cast(CompletionUsage, usage), attempt_number)
+        ),
+    )
+    hooks.on(
+        "completion:last_attempt",
+        lambda error, **_metadata: last_attempts.append(
+            cast(TokenBudgetExceeded, error)
+        ),
+    )
+
+    with pytest.raises(TokenBudgetExceeded) as exc_info:
+        await retry_async_v2(
+            func=create,
+            response_model=Answer,
+            provider=Provider.OPENAI,
+            mode=Mode.JSON,
+            context=None,
+            max_retries=3,
+            args=(),
+            kwargs={},
+            strict=True,
+            hooks=hooks,
+            token_budget=75,
+        )
+
+    assert exc_info.value.total_usage.total_tokens == 75
+    assert provider_calls == 1
+    assert reask_calls == 0
+    assert [(usage.total_tokens, attempt) for usage, attempt in usage_events] == [
+        (75, 1)
+    ]
+    assert last_attempts == [exc_info.value]
+
+    with pytest.raises(TokenBudgetExceeded):
+        await retry_async_v2(
+            func=create,
+            response_model=Answer,
+            provider=Provider.OPENAI,
+            mode=Mode.JSON,
+            context=None,
+            max_retries=3,
+            args=(),
+            kwargs={},
+            strict=True,
+            token_budget=75,
+        )
+
+    assert provider_calls == 2
+    assert reask_calls == 0
+
+
+@pytest.mark.parametrize(
+    ("token_budget", "response_model", "kwargs", "error_type"),
+    [
+        (0, Answer, {}, ValueError),
+        (-1, Answer, {}, ValueError),
+        (True, Answer, {}, TypeError),
+        (1.5, Answer, {}, TypeError),
+        (100, None, {}, ValueError),
+        (100, Answer, {"stream": True}, ValueError),
+    ],
+)
+def test_retry_budget_rejects_unenforceable_configuration_before_provider_call(
+    token_budget: Any,
+    response_model: type[Answer] | None,
+    kwargs: dict[str, Any],
+    error_type: type[Exception],
+) -> None:
+    provider_calls = 0
+
+    def create(*_args: Any, **_kwargs: Any) -> None:
+        nonlocal provider_calls
+        provider_calls += 1
+
+    with pytest.raises(error_type):
+        retry_sync_v2(
+            func=create,
+            response_model=response_model,
+            provider=Provider.OPENAI,
+            mode=Mode.JSON,
+            context=None,
+            max_retries=3,
+            args=(),
+            kwargs=kwargs,
+            strict=True,
+            token_budget=token_budget,
+        )
+
+    assert provider_calls == 0
+
+
+def test_list_response_preserves_usage_snapshot_across_slices() -> None:
+    raw_response = object()
+    usage = CompletionUsage(
+        completion_tokens=25,
+        prompt_tokens=75,
+        total_tokens=100,
+    )
+
+    result = _finalize_parsed_response(
+        [Answer(value=1), Answer(value=2)],
+        raw_response,
+        total_usage=usage,
+    )
+
+    assert isinstance(result, ListResponse)
+    assert result.get_total_usage() is not usage
+    assert result.get_total_usage().total_tokens == 100
+    assert result[:1].get_raw_response() is raw_response
+    assert result[:1].get_total_usage().total_tokens == 100
+
+
+def test_finalize_updates_existing_list_response_metadata() -> None:
+    raw_response = object()
+    usage = CompletionUsage(
+        completion_tokens=25,
+        prompt_tokens=75,
+        total_tokens=100,
+    )
+    result = ListResponse([Answer(value=1)])
+
+    finalized = _finalize_parsed_response(
+        result,
+        raw_response,
+        total_usage=usage,
+    )
+
+    assert finalized is result
+    assert result[0] == Answer(value=1)
+    assert result.get_raw_response() is raw_response
+    assert result.get_total_usage().total_tokens == 100
+    assert _finalize_parsed_response("plain", raw_response) == "plain"
+
+
+def test_anthropic_total_includes_cache_token_fields() -> None:
+    usage = SimpleNamespace(
+        input_tokens=10,
+        output_tokens=20,
+        cache_creation_input_tokens=30,
+        cache_read_input_tokens=40,
+    )
+
+    assert _usage_total_tokens(usage) == 100
+
+
+def test_budget_error_rejects_usage_without_a_token_total() -> None:
+    usage = SimpleNamespace(label="unsupported")
+
+    error = _budget_error(
+        token_budget=100,
+        usage_available=True,
+        total_usage=usage,
+        attempt_number=1,
+        response=object(),
+        kwargs={},
+        failed_attempts=[],
+    )
+
+    assert isinstance(error, TokenUsageUnavailableError)
+    assert error.total_usage is not usage
+    assert error.total_usage.label == "unsupported"
+    assert _usage_snapshot(usage) is not usage
+
+
+def test_usage_compatibility_handles_missing_anthropic_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def import_without_anthropic_types(
+        name: str,
+        globals: dict[str, Any] | None = None,
+        locals: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        if name == "anthropic.types":
+            raise ImportError("anthropic is not installed")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_anthropic_types)
+
+    assert not has_compatible_usage(SimpleNamespace(), SimpleNamespace())
+
+
+def test_patched_create_validates_budget_before_request_processing() -> None:
+    provider_calls = 0
+
+    def create(*_args: Any, **_kwargs: Any) -> None:
+        nonlocal provider_calls
+        provider_calls += 1
+
+    patched_create = patch_v2(
+        func=create,
+        provider=Provider.OPENAI,
+        mode=Mode.JSON,
+    )
+
+    with pytest.raises(ValueError, match="greater than zero"):
+        patched_create(response_model=Answer, token_budget=0)
+
+    assert provider_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_patched_async_create_validates_budget_before_request_processing() -> (
+    None
+):
+    provider_calls = 0
+
+    async def create(*_args: Any, **_kwargs: Any) -> None:
+        nonlocal provider_calls
+        provider_calls += 1
+
+    patched_create = patch_v2(
+        func=create,
+        provider=Provider.OPENAI,
+        mode=Mode.JSON,
+    )
+
+    with pytest.raises(ValueError, match="greater than zero"):
+        await patched_create(response_model=Answer, token_budget=0)
+
+    assert provider_calls == 0
+
+
+def test_sync_client_surfaces_forward_explicit_budget() -> None:
+    received: list[dict[str, Any]] = []
+
+    def create(**kwargs: Any) -> Answer:
+        received.append(kwargs)
+        return Answer(value=1)
+
+    response = Response(cast(Any, SimpleNamespace(create=create)))
+    instructor = Instructor(client=None, create=create)
+
+    assert (
+        response.create(messages=[], response_model=Answer, token_budget=10).value == 1
+    )
+    assert (
+        instructor.create(messages=[], response_model=Answer, token_budget=20).value
+        == 1
+    )
+    assert [call["token_budget"] for call in received] == [10, 20]
+
+
+@pytest.mark.asyncio
+async def test_async_client_surfaces_forward_explicit_budget() -> None:
+    received: list[dict[str, Any]] = []
+
+    async def create(**kwargs: Any) -> Answer:
+        received.append(kwargs)
+        return Answer(value=1)
+
+    response = AsyncResponse(cast(Any, SimpleNamespace(create=create)))
+    instructor = AsyncInstructor(client=None, create=create)
+
+    assert (
+        await response.create(messages=[], response_model=Answer, token_budget=10)
+    ).value == 1
+    assert (
+        await instructor.create(messages=[], response_model=Answer, token_budget=20)
+    ).value == 1
+    assert [call["token_budget"] for call in received] == [10, 20]


### PR DESCRIPTION
## Summary

- add a positive cumulative `token_budget` for structured, non-streaming validation retries
- parse each completed response before enforcing the budget, so valid responses are never discarded after their tokens have already been spent
- stop before reask or another provider request when cumulative usage is greater than or equal to the budget
- expose deep-copied cumulative usage through `completion:usage` and successful model/list metadata
- fail closed before another request when compatible usage metadata is unavailable
- preserve sync/async behavior, public typing, exception compatibility, list slicing metadata, and xAI's custom no-retry contract

## Linked work

- addresses #2391
- addresses the retry-amplification portion of #2056; the validator-injection portion is handled separately by #2511
- reconstructs and improves #2392 by @mimran-khan against current main
- supersedes #2392 after this PR merges

The contributor patch had the right product direction. This rebuild changes the cutoff order and boundary, makes usage events immutable, defines unsupported behavior, preserves public/client/provider contracts, and replaces mock-heavy coverage with deterministic provider-call assertions.

## Semantics

`token_budget` is a validation-retry budget, not a guaranteed hard cap on an in-flight provider request. A completed request can take the cumulative total over the limit. If that response validates, it is returned. If it fails validation, Instructor raises before constructing a reask or making another request.

Budgeted calls require a structured, non-streaming response and compatible usage metadata. Unsupported xAI custom requests are rejected explicitly.

## Validation

- focused retry-budget contract suite: `19 passed`
- changed-runtime, hook, provider, and exception suite: `175 passed`
- exact GitHub core-test command: passed
- exact offline coverage lane: `760 passed`, `93%` statement coverage (gate: `90%`)
- xAI compatibility plus retry-budget suite: `65 passed`
- maintained Ruff scope: passed
- maintained format check: passed
- full `ty check`: passed
- `uv lock --check`: passed
- pre-commit hooks: passed
- normal MkDocs build: passed
- `git diff --check`: passed

The local all-in-one branch-coverage process terminates abruptly during the provider-heavy suite on macOS without producing a report. The exact core and offline-coverage lanes pass independently; GitHub's Linux full-coverage job is authoritative for this PR.

## Release sequencing

This is intentionally a draft while exact main at `1454af92` remains the validated, unpublished `1.15.5` candidate. The PR can complete review and CI now, but should not merge until `1.15.5` is published or the maintainer explicitly chooses to fold that release into `1.16.0`.

## Intentionally skipped

- validator prompt isolation (#2511)
- Mistral v2 compatibility (#2298/#2365)
- Bedrock structured outputs, reasoning parsing, and bearer authentication (#2086/#2287/#2409)
- provider additions, provider architecture, dependency batches, and product-policy work
