### PR TITLE
fix(mistral): support sdk v2 exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Mistral SDK compatibility**: Support the `mistralai` 2.x client export on Python 3.10+ while retaining the compatible 1.x fallback required by Python 3.9. ([#2298](https://github.com/567-labs/instructor/pull/2298), [#2365](https://github.com/567-labs/instructor/issues/2365))
+
 ## [1.15.5] - 2026-08-07
 
 ### Fixed

--- a/docs/blog/posts/open_source.md
+++ b/docs/blog/posts/open_source.md
@@ -232,13 +232,17 @@ For those interested in exploring the capabilities of Mistral Large with Instruc
 ```python
 import instructor
 from pydantic import BaseModel
-from mistralai.client import MistralClient
 
+try:
+    from mistralai.client import Mistral
+except ImportError:
+    from mistralai import Mistral
 
-client = MistralClient()
-
-patched_chat = instructor.from_openai(
-    create=client.chat, mode=instructor.Mode.TOOLS
+client = Mistral(api_key="your-api-key-here")
+patched_chat = instructor.from_mistral(
+    client=client,
+    model="mistral-large-latest",
+    mode=instructor.Mode.TOOLS,
 )
 
 
@@ -247,8 +251,7 @@ class UserDetails(BaseModel):
     age: int
 
 
-resp = patched_chat(
-    model="mistral-large-latest",
+resp = patched_chat.create(
     response_model=UserDetails,
     messages=[
         {

--- a/docs/integrations/mistral.md
+++ b/docs/integrations/mistral.md
@@ -28,9 +28,12 @@ pip install "instructor[mistral]"
 ⚠️ **Important**: You must set your Mistral API key by setting it explicitly on the client
 
 ```python
-import os
-from mistralai import Mistral
-client = Mistral(api_key='your-api-key-here')
+try:
+    from mistralai.client import Mistral  # mistralai 2.x
+except ImportError:
+    from mistralai import Mistral  # mistralai 1.x
+
+client = Mistral(api_key="your-api-key-here")
 ```
 
 ## Available Modes
@@ -43,22 +46,19 @@ Instructor provides two modes for working with Mistral:
 To set the mode for your mistral client, simply use the code snippet below
 
 ```python
-import os
-from pydantic import BaseModel
 import instructor
 
 
 # Initialize with API key
 instructor_client = instructor.from_provider(
     "mistral/mistral-large-latest",
-    mode=Mode.TOOLS,
+    mode=instructor.Mode.TOOLS,
 )
 ```
 
 ## Simple User Example (Sync)
 
 ```python
-import os
 from pydantic import BaseModel
 import instructor
 from instructor import Mode
@@ -88,10 +88,9 @@ print(user)
 
 ## Async Example
 
-For asynchronous operations, you can use the `use_async=True` parameter when creating the client:
+For asynchronous operations, use `async_client=True` with `from_provider()`:
 
 ```python
-import os
 import asyncio
 from pydantic import BaseModel
 import instructor
@@ -131,7 +130,6 @@ You can also work with nested models:
 ```python
 from pydantic import BaseModel
 from typing import List
-import os
 import instructor
 from instructor import Mode
 
@@ -185,17 +183,13 @@ Instructor now supports streaming capabilities with Mistral! You can use both `c
 ```python
 from pydantic import BaseModel
 import instructor
-from mistralai import Mistral
 from instructor.dsl.partial import Partial
 
 class UserExtract(BaseModel):
     name: str
     age: int
 
-# Initialize with API key
-client = Mistral(api_key=os.environ.get("MISTRAL_API_KEY"))
-
-# Enable instructor patches for Mistral client
+# Create an Instructor client for Mistral
 instructor_client = instructor.from_provider("mistral/mistral-small")
 
 # Stream partial responses
@@ -220,16 +214,12 @@ for partial_user in model:
 ```python
 from pydantic import BaseModel
 import instructor
-from mistralai import Mistral
 
 class UserExtract(BaseModel):
     name: str
     age: int
 
-# Initialize with API key
-client = Mistral(api_key=os.environ.get("MISTRAL_API_KEY"))
-
-# Enable instructor patches for Mistral client
+# Create an Instructor client for Mistral
 instructor_client = instructor.from_provider("mistral/mistral-small")
 
 # Stream iterable responses
@@ -255,16 +245,16 @@ You can also use async versions of both streaming approaches:
 import asyncio
 from pydantic import BaseModel
 import instructor
-from mistralai import Mistral
 from instructor.dsl.partial import Partial
 
 class UserExtract(BaseModel):
     name: str
     age: int
 
-# Initialize client with async support
-client = Mistral(api_key=os.environ.get("MISTRAL_API_KEY"))
-instructor_client = instructor.from_provider("mistral/mistral-small")
+instructor_client = instructor.from_provider(
+    "mistral/mistral-small",
+    async_client=True,
+)
 
 async def stream_partial():
     model = await instructor_client.create(
@@ -310,12 +300,10 @@ Instructor maintains compatibility with the latest Mistral API versions and mode
 
 Instructor makes it easy to analyse and extract semantic information from PDFs using Mistral's models. Let's see an example below with the sample PDF above where we'll load it in using our `from_url` method. Note that for now Mistral only supports document URLs.
 
-```
+```python
 from instructor.processing.multimodal import PDF
 from pydantic import BaseModel
 import instructor
-from mistralai import Mistral
-import os
 
 
 class Receipt(BaseModel):

--- a/examples/mistral/mistral.py
+++ b/examples/mistral/mistral.py
@@ -1,8 +1,13 @@
-from pydantic import BaseModel
-from mistralai.client import MistralClient
-from instructor import from_mistral
-from instructor.mode import Mode
 import os
+
+from pydantic import BaseModel
+
+from instructor import Mode, from_mistral
+
+try:
+    from mistralai.client import Mistral
+except ImportError:
+    from mistralai import Mistral
 
 
 class UserDetails(BaseModel):
@@ -11,7 +16,7 @@ class UserDetails(BaseModel):
 
 
 # enables `response_model` in chat call
-client = MistralClient(api_key=os.environ.get("MISTRAL_API_KEY"))
+client = Mistral(api_key=os.environ.get("MISTRAL_API_KEY"))
 instructor_client = from_mistral(
     client=client,
     model="mistral-large-latest",
@@ -19,7 +24,7 @@ instructor_client = from_mistral(
     max_tokens=1000,
 )
 
-resp = instructor_client.messages.create(
+resp = instructor_client.create(
     response_model=UserDetails,
     messages=[{"role": "user", "content": "Jason is 10"}],
     temperature=0,

--- a/instructor/v2/auto_client.py
+++ b/instructor/v2/auto_client.py
@@ -736,7 +736,12 @@ def _build_mistral(
     provider_info: dict[str, str],
 ) -> InstructorType:
     try:
-        from mistralai import Mistral
+        try:
+            mistral_module = cast(Any, importlib.import_module("mistralai.client"))
+            Mistral = mistral_module.Mistral
+        except (AttributeError, ImportError):
+            mistral_module = cast(Any, importlib.import_module("mistralai"))
+            Mistral = mistral_module.Mistral
         from instructor.v2.providers.mistral.client import from_mistral
         import os
 

--- a/instructor/v2/providers/mistral/client.py
+++ b/instructor/v2/providers/mistral/client.py
@@ -11,7 +11,8 @@ Mistral has a unique API structure:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, overload
+import importlib
+from typing import Any, Literal, Protocol, overload
 
 from instructor.v2.core.client import AsyncInstructor, Instructor
 from instructor.v2.core.mode import Mode
@@ -21,18 +22,30 @@ from instructor.v2.core.patch import patch_v2
 # Ensure handlers are registered (decorators auto-register on import)
 from instructor.v2.providers.mistral import handlers  # noqa: F401
 
-if TYPE_CHECKING:
-    from mistralai import Mistral
-else:
-    try:
-        from mistralai import Mistral
-    except ImportError:
-        Mistral = None
+
+class _MistralClient(Protocol):
+    chat: Any
+
+
+def _load_mistral_client_type() -> type[Any] | None:
+    """Load the client class from the Mistral 2.x or 1.x export."""
+    for module_name in ("mistralai.client", "mistralai"):
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        client_type = getattr(module, "Mistral", None)
+        if isinstance(client_type, type):
+            return client_type
+    return None
+
+
+Mistral = _load_mistral_client_type()
 
 
 @overload
 def from_mistral(
-    client: Mistral,
+    client: _MistralClient,
     mode: Mode = Mode.TOOLS,
     use_async: Literal[False] = False,
     model: str | None = None,
@@ -42,7 +55,7 @@ def from_mistral(
 
 @overload
 def from_mistral(
-    client: Mistral,
+    client: _MistralClient,
     mode: Mode = Mode.TOOLS,
     use_async: Literal[True] = True,
     model: str | None = None,
@@ -52,7 +65,7 @@ def from_mistral(
 
 @overload
 def from_mistral(
-    client: Mistral,
+    client: _MistralClient,
     mode: Mode = Mode.TOOLS,
     use_async: bool = False,
     model: str | None = None,
@@ -61,7 +74,7 @@ def from_mistral(
 
 
 def from_mistral(
-    client: Mistral,
+    client: _MistralClient,
     mode: Mode = Mode.TOOLS,
     use_async: bool = False,
     model: str | None = None,
@@ -87,7 +100,10 @@ def from_mistral(
         ClientError: If client is not a valid Mistral client instance or mistralai not installed
 
     Examples:
-        >>> from mistralai import Mistral
+        >>> try:
+        ...     from mistralai.client import Mistral  # mistralai 2.x
+        ... except ImportError:
+        ...     from mistralai import Mistral  # mistralai 1.x
         >>> from instructor import Mode
         >>> from instructor.v2.providers.mistral import from_mistral
         >>>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ test-docs = [
     "tabulate<1.0.0,>=0.9.0",
     "pydantic-extra-types<3.0.0,>=2.6.0",
     "litellm>=1.35.31,<=1.83.7",
-    "mistralai<2.0.0,>=1.5.1",
+    "mistralai<3.0.0,>=1.5.1",
 ]
 anthropic = ["anthropic==0.93.0", "xmltodict>=0.13,<1.1"]
 groq = ["groq>=0.4.2,<1.1.0"]
@@ -92,7 +92,7 @@ cerebras_cloud_sdk = ["cerebras-cloud-sdk<2.0.0,>=1.5.0"]
 fireworks-ai = ["fireworks-ai<1.0.0,>=0.15.4"]
 writer = ["writer-sdk<3.0.0,>=2.2.0"]
 bedrock = ["boto3<2.0.0,>=1.34.0"]
-mistral = ["mistralai<2.0.0,>=1.5.1"]
+mistral = ["mistralai<3.0.0,>=1.5.1"]
 perplexity = ["openai>=2.0.0,<3.0.0"]
 google-genai = ["google-genai>=1.5.0","jsonref<2.0.0,>=1.1.0"]
 litellm = ["litellm>=1.35.31,<=1.83.7"]

--- a/tests/coverage/test_auto_client_coverage.py
+++ b/tests/coverage/test_auto_client_coverage.py
@@ -309,6 +309,60 @@ def test_mistral_requires_key_and_accepts_environment_key(
     assert callable(client.create_fn)
 
 
+def test_mistral_builder_supports_sdk_v1_export(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import instructor.v2.providers.mistral.client as mistral_client
+
+    class LegacyMistral:
+        def __init__(self, api_key: str) -> None:
+            self.api_key = api_key
+
+    class LegacySDK:
+        Mistral = LegacyMistral
+
+    real_import_module = importlib.import_module
+
+    def import_module(name: str, package: str | None = None) -> Any:
+        if name == "mistralai.client":
+            return object()
+        if name == "mistralai":
+            return LegacySDK
+        return real_import_module(name, package)
+
+    captured: dict[str, Any] = {}
+
+    def from_mistral(client: object, **kwargs: Any) -> dict[str, Any]:
+        captured["client"] = client
+        captured["kwargs"] = kwargs
+        return kwargs
+
+    monkeypatch.setattr(importlib, "import_module", import_module)
+    monkeypatch.setattr(mistral_client, "from_mistral", from_mistral)
+
+    result = cast(
+        Any,
+        auto_client._build_mistral(
+            provider="mistral",
+            model_name="mistral-small",
+            async_client=True,
+            mode=None,
+            api_key="test-key",
+            kwargs={"temperature": 0.2},
+            provider_info={"provider": "mistral", "operation": "initialize"},
+        ),
+    )
+
+    assert isinstance(captured["client"], LegacyMistral)
+    assert captured["client"].api_key == "test-key"
+    assert captured["kwargs"] == {
+        "model": "mistral-small",
+        "use_async": True,
+        "temperature": 0.2,
+    }
+    assert result == captured["kwargs"]
+
+
 @pytest.mark.parametrize(
     "model,environment_key",
     [
@@ -437,6 +491,7 @@ def test_missing_provider_dependency_has_actionable_error(
     message: str,
 ) -> None:
     real_import = builtins.__import__
+    real_import_module = importlib.import_module
 
     def guarded_import(
         name: str,
@@ -452,6 +507,15 @@ def test_missing_provider_dependency_has_actionable_error(
         return real_import(name, globals_, locals_, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    def guarded_import_module(name: str, package: str | None = None) -> Any:
+        if name == blocked_import or name.startswith(f"{blocked_import}."):
+            raise ModuleNotFoundError(
+                f"No module named '{blocked_import}'", name=blocked_import
+            )
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", guarded_import_module)
     with pytest.raises(ConfigurationError, match=message):
         auto_client.from_provider(model, api_key="test-key")
 

--- a/tests/coverage/test_mistral_coverage.py
+++ b/tests/coverage/test_mistral_coverage.py
@@ -1,27 +1,32 @@
 from __future__ import annotations
 
 import builtins
+import importlib
 import runpy
 from collections.abc import Iterable
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Union, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from mistralai import Mistral
-from mistralai.models import (
-    AssistantMessage,
-    ChatCompletionChoice,
-    ChatCompletionResponse,
-    CompletionChunk,
-    CompletionEvent,
-    CompletionResponseStreamChoice,
-    DeltaMessage,
-    FunctionCall,
-    ToolCall,
-    UsageInfo,
-)
 from pydantic import BaseModel
+
+try:
+    mistral_models = cast(Any, importlib.import_module("mistralai.client.models"))
+except ImportError:
+    mistral_models = cast(Any, importlib.import_module("mistralai.models"))
+
+AssistantMessage = mistral_models.AssistantMessage
+ChatCompletionChoice = mistral_models.ChatCompletionChoice
+ChatCompletionResponse = mistral_models.ChatCompletionResponse
+CompletionChunk = mistral_models.CompletionChunk
+CompletionEvent = mistral_models.CompletionEvent
+CompletionResponseStreamChoice = mistral_models.CompletionResponseStreamChoice
+DeltaMessage = mistral_models.DeltaMessage
+FunctionCall = mistral_models.FunctionCall
+ToolCall = mistral_models.ToolCall
+UsageInfo = mistral_models.UsageInfo
 
 import instructor.v2.providers.mistral.client as mistral_client
 from instructor.v2.core.errors import ClientError, ModeError, ResponseParsingError
@@ -50,7 +55,7 @@ class Answer(BaseModel):
     answer: float
 
 
-def tool_call(name: str, arguments: dict[str, Any] | str, call_id: str) -> ToolCall:
+def tool_call(name: str, arguments: dict[str, Any] | str, call_id: str) -> Any:
     return ToolCall(
         id=call_id,
         type="function",
@@ -61,9 +66,9 @@ def tool_call(name: str, arguments: dict[str, Any] | str, call_id: str) -> ToolC
 def response(
     *,
     content: str | None = None,
-    tool_calls: list[ToolCall] | None = None,
+    tool_calls: list[Any] | None = None,
     finish_reason: str = "stop",
-) -> ChatCompletionResponse:
+) -> Any:
     return ChatCompletionResponse(
         id="mistral-response",
         object="chat.completion",
@@ -80,9 +85,7 @@ def response(
     )
 
 
-def event(
-    *, content: str | None = None, tool_calls: list[ToolCall] | None = None
-) -> CompletionEvent:
+def event(*, content: str | None = None, tool_calls: list[Any] | None = None) -> Any:
     return CompletionEvent(
         data=CompletionChunk(
             id="mistral-stream",
@@ -105,10 +108,53 @@ class FakeMistral:
         self.chat.stream_async = AsyncMock()
 
 
+def test_runtime_client_class_matches_installed_sdk() -> None:
+    assert mistral_client.Mistral is not None
+    assert mistral_client.Mistral.__name__ == "Mistral"
+
+
+def test_client_loader_prefers_sdk_v2_export(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class V2Mistral:
+        pass
+
+    def import_module(name: str, package: str | None = None) -> Any:
+        assert package is None
+        assert name == "mistralai.client"
+        return SimpleNamespace(Mistral=V2Mistral)
+
+    monkeypatch.setattr(importlib, "import_module", import_module)
+
+    assert mistral_client._load_mistral_client_type() is V2Mistral
+
+
+def test_client_loader_falls_back_to_sdk_v1_export(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class V1Mistral:
+        pass
+
+    imported_modules: list[str] = []
+
+    def import_module(name: str, package: str | None = None) -> Any:
+        assert package is None
+        imported_modules.append(name)
+        if name == "mistralai.client":
+            return SimpleNamespace()
+        return SimpleNamespace(Mistral=V1Mistral)
+
+    monkeypatch.setattr(importlib, "import_module", import_module)
+
+    assert mistral_client._load_mistral_client_type() is V1Mistral
+    assert imported_modules == ["mistralai.client", "mistralai"]
+
+
 def test_missing_mistral_sdk_has_clear_client_and_package_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     real_import = builtins.__import__
+    real_import_module = importlib.import_module
     client_path = Path(mistral_client.__file__)
     package_path = client_path.with_name("__init__.py")
 
@@ -119,11 +165,18 @@ def test_missing_mistral_sdk_has_clear_client_and_package_fallback(
         fromlist: tuple[str, ...] = (),
         level: int = 0,
     ) -> Any:
-        if name == "mistralai":
+        if name in {"mistralai", "mistralai.client"}:
             raise ImportError("mistralai is not installed")
         return real_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", without_sdk)
+
+    def without_sdk_module(name: str, package: str | None = None) -> Any:
+        if name in {"mistralai", "mistralai.client"}:
+            raise ImportError("mistralai is not installed")
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", without_sdk_module)
     unloaded_client = runpy.run_path(str(client_path))
 
     assert unloaded_client["Mistral"] is None
@@ -154,14 +207,12 @@ def test_from_mistral_rejects_bad_mode_and_client(
     monkeypatch.setattr(mistral_client, "Mistral", FakeMistral)
 
     with pytest.raises(ModeError) as mode_error:
-        mistral_client.from_mistral(
-            cast(Mistral, FakeMistral()), mode=Mode.ANTHROPIC_JSON
-        )
+        mistral_client.from_mistral(cast(Any, FakeMistral()), mode=Mode.ANTHROPIC_JSON)
     assert "anthropic_json" in str(mode_error.value)
     assert Provider.MISTRAL.value in str(mode_error.value)
 
     with pytest.raises(ClientError, match="Got: object"):
-        mistral_client.from_mistral(cast(Mistral, object()), mode=Mode.TOOLS)
+        mistral_client.from_mistral(cast(Any, object()), mode=Mode.TOOLS)
 
 
 def test_from_mistral_warns_for_deprecated_tools_mode(
@@ -171,7 +222,7 @@ def test_from_mistral_warns_for_deprecated_tools_mode(
 
     with pytest.warns(DeprecationWarning, match="Use Mode.TOOLS instead"):
         client = mistral_client.from_mistral(
-            cast(Mistral, FakeMistral()), mode=Mode.MISTRAL_TOOLS
+            cast(Any, FakeMistral()), mode=Mode.MISTRAL_TOOLS
         )
 
     assert client.mode is Mode.TOOLS
@@ -198,7 +249,7 @@ def test_sync_client_routes_completion_retry_and_stream(
     ]
 
     client = mistral_client.from_mistral(
-        cast(Mistral, sdk),
+        cast(Any, sdk),
         mode=Mode.TOOLS,
         model="mistral-small-latest",
         temperature=0.2,
@@ -259,7 +310,7 @@ async def test_async_client_routes_completion_retry_and_stream(
     )
 
     client = mistral_client.from_mistral(
-        cast(Mistral, sdk),
+        cast(Any, sdk),
         mode=Mode.TOOLS,
         use_async=True,
         model="mistral-small-latest",

--- a/tests/llm/test_new_client.py
+++ b/tests/llm/test_new_client.py
@@ -354,10 +354,12 @@ async def test_client_cohere_async():
 
 @pytest.mark.skip(reason="Skip for now")
 def test_client_from_mistral_with_response():
-    import mistralai.client as mistralaicli
+    from instructor.v2.providers.mistral.client import Mistral
+
+    assert Mistral is not None
 
     client = instructor.from_mistral(
-        mistralaicli.MistralClient(),
+        Mistral(api_key=os.environ.get("MISTRAL_API_KEY")),
         max_tokens=1000,
         model="mistral-large-latest",
     )
@@ -373,9 +375,11 @@ def test_client_from_mistral_with_response():
 
 @pytest.mark.skip(reason="Skip for now")
 def test_client_mistral_response():
-    import mistralai.client as mistralaicli
+    from instructor.v2.providers.mistral.client import Mistral
 
-    client = mistralaicli.MistralClient()
+    assert Mistral is not None
+
+    client = Mistral(api_key=os.environ.get("MISTRAL_API_KEY"))
     instructor_client = instructor.from_mistral(
         client, max_tokens=1000, model="mistral-large-latest"
     )

--- a/tests/typing/test_public_surface.py
+++ b/tests/typing/test_public_surface.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Generator
 from types import CoroutineType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from typing_extensions import assert_type
 
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
     from botocore.client import BaseClient
     from cerebras.cloud.sdk import AsyncCerebras, Cerebras
     from fireworks.client import Fireworks
-    from mistralai import Mistral
     from writerai import AsyncWriter, Writer
     from xai_sdk.sync.client import Client as SyncXAIClient
 
@@ -63,6 +62,10 @@ if TYPE_CHECKING:
 
 class User(BaseModel):
     name: str
+
+
+class MistralClient(Protocol):
+    chat: Any
 
 
 def check_response_helpers(
@@ -200,7 +203,7 @@ def check_litellm_factory() -> None:
 def check_bool_selected_factories(
     gemini_model: legacy_genai.GenerativeModel,
     vertex_model: gm.GenerativeModel,
-    mistral_client: Mistral,
+    mistral_client: MistralClient,
 ) -> None:
     assert_type(from_gemini(gemini_model), Instructor)
     assert_type(from_gemini(gemini_model, use_async=True), AsyncInstructor)

--- a/uv.lock
+++ b/uv.lock
@@ -1841,7 +1841,8 @@ litellm = [
     { name = "litellm" },
 ]
 mistral = [
-    { name = "mistralai" },
+    { name = "mistralai", version = "1.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "mistralai", version = "2.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 perplexity = [
     { name = "openai" },
@@ -1859,7 +1860,8 @@ test-docs = [
     { name = "diskcache" },
     { name = "fastapi" },
     { name = "litellm" },
-    { name = "mistralai" },
+    { name = "mistralai", version = "1.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "mistralai", version = "2.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pandas" },
     { name = "pydantic-extra-types" },
     { name = "redis" },
@@ -1906,8 +1908,8 @@ requires-dist = [
     { name = "jsonref", marker = "extra == 'vertexai'", specifier = ">=1.1.0,<2.0.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.35.31,<=1.83.7" },
     { name = "litellm", marker = "extra == 'test-docs'", specifier = ">=1.35.31,<=1.83.7" },
-    { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.5.1,<2.0.0" },
-    { name = "mistralai", marker = "extra == 'test-docs'", specifier = ">=1.5.1,<2.0.0" },
+    { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.5.1,<3.0.0" },
+    { name = "mistralai", marker = "extra == 'test-docs'", specifier = ">=1.5.1,<3.0.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.1,<2.0.0" },
     { name = "mkdocs-jupyter", marker = "extra == 'docs'", specifier = ">=0.24.6,<0.27.0" },
     { name = "mkdocs-llmstxt", marker = "python_full_version >= '3.10' and extra == 'docs'", specifier = ">=0.5.0,<0.6.0" },
@@ -2197,6 +2199,15 @@ name = "jsmin"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/73/e01e4c5e11ad0494f4407a3f623ad4d87714909f50b17a06ed121034ff6e/jsmin-3.0.1.tar.gz", hash = "sha256:c0959a121ef94542e807a674142606f7e90214a2b3d1eb17300244bbb5cc2bfc", size = 13925, upload-time = "2022-01-16T20:35:59.13Z" }
+
+[[package]]
+name = "jsonpath-python"
+version = "1.1.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/18/4ca8742534a5993ff383f7602e325ce2d5d7cc93d72ac5e1cdedbea8a458/jsonpath_python-1.1.6.tar.gz", hash = "sha256:dded9932b4ec41fb8726e09c83afa4e6be618f938c2db287cc2a81723c639671", size = 88178, upload-time = "2026-05-07T01:26:34.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/8a/1270a6803bd821cbfcdda387eaa13cb41a7b1f7b9bd145979b3bfb9d6cb7/jsonpath_python-1.1.6-py3-none-any.whl", hash = "sha256:a1c50afd8d3fbbaf47a4873bc890dcb3c15da96f5c020327977d844d8731a2d4", size = 14453, upload-time = "2026-05-07T01:26:33.306Z" },
+]
 
 [[package]]
 name = "jsonref"
@@ -2639,20 +2650,52 @@ wheels = [
 
 [[package]]
 name = "mistralai"
-version = "1.9.9"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "eval-type-backport" },
-    { name = "httpx" },
-    { name = "invoke" },
-    { name = "pydantic" },
-    { name = "python-dateutil" },
-    { name = "pyyaml" },
-    { name = "typing-inspection" },
+resolution-markers = [
+    "python_full_version < '3.10'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/02/fb484098d29f10e1f55f0c88c15262990d253304b94a5ecedd89e6a68d06/mistralai-1.9.9.tar.gz", hash = "sha256:025ae6f45dba8b7585642bc6fa214316138546a0cac692c6ec8e1187424da54a", size = 204678, upload-time = "2025-08-26T17:41:08.378Z" }
+dependencies = [
+    { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
+    { name = "httpx", marker = "python_full_version < '3.10'" },
+    { name = "invoke", marker = "python_full_version < '3.10'" },
+    { name = "opentelemetry-api", version = "1.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "python_full_version < '3.10'" },
+    { name = "opentelemetry-sdk", version = "1.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.59b0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", marker = "python_full_version < '3.10'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.10'" },
+    { name = "pyyaml", marker = "python_full_version < '3.10'" },
+    { name = "typing-inspection", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/b6/ab0f6ca229be1c78a2918327da5c0efc964d006e9e4d94689798ac42249f/mistralai-1.10.0.tar.gz", hash = "sha256:c92e9a5ec7057577b326d47a4b1c186f42660bccbe95167fc25c686fe658ad23", size = 219585, upload-time = "2025-12-17T09:34:50.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/2c/7c62e67c221a10bfd94b219fe115211109a83e72a996fa343d72b4fa9f84/mistralai-1.9.9-py3-none-any.whl", hash = "sha256:6742fdbf4a277b605287538761e2665b6fb025328676a024868734ffe78ef72f", size = 439470, upload-time = "2025-08-26T17:41:07.05Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/49/ff78671bbd0a678ce0a4d0b0a8f86b0a63c7489d6288cc7636ad14bd1f28/mistralai-1.10.0-py3-none-any.whl", hash = "sha256:fd37d15f077375f77cbfbbb57abed6b2c6ae0a3db39cf4815400742441b3b60a", size = 460994, upload-time = "2025-12-17T09:34:49.214Z" },
+]
+
+[[package]]
+name = "mistralai"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "eval-type-backport", marker = "python_full_version >= '3.10'" },
+    { name = "httpx", marker = "python_full_version >= '3.10'" },
+    { name = "jsonpath-python", marker = "python_full_version >= '3.10'" },
+    { name = "opentelemetry-api", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.60b1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", marker = "python_full_version >= '3.10'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/e0/9d3e8bcfa73357f997ea297148d16ac243d1a228838334179a9199b713ff/mistralai-2.9.1.tar.gz", hash = "sha256:5b3983c6fddc81b898f1dd5a61a96a59a0e18069c54940cac9b5220dd6b66486", size = 534224, upload-time = "2026-08-04T16:23:45.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/6e/11d537beb67fd7dc0f1028c4a9f4f8230c6328abf6e2f2c9d0447ea0e4a4/mistralai-2.9.1-py3-none-any.whl", hash = "sha256:6f83177b8c4fdffdd2a054cf9d96fc7c0d7a474e856ecd1f0b7070344128516b", size = 1270991, upload-time = "2026-08-04T16:23:43.001Z" },
 ]
 
 [[package]]
@@ -3377,42 +3420,151 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.36.0"
+version = "1.38.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/d8/0f354c375628e048bd0570645b310797299754730079853095bf000fba69/opentelemetry_api-1.38.0.tar.gz", hash = "sha256:f4c193b5e8acb0912b06ac5b16321908dd0843d75049c091487322284a3eea12", size = 65242, upload-time = "2025-10-16T08:35:50.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a2/d86e01c28300bd41bab8f18afd613676e2bd63515417b77636fc1add426f/opentelemetry_api-1.38.0-py3-none-any.whl", hash = "sha256:2891b0197f47124454ab9f0cf58f3be33faca394457ac3e09daba13ff50aa582", size = 65947, upload-time = "2025-10-16T08:35:30.23Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
 dependencies = [
     { name = "importlib-metadata", marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/d2/c782c88b8afbf961d6972428821c302bd1e9e7bc361352172f0ca31296e2/opentelemetry_api-1.36.0.tar.gz", hash = "sha256:9a72572b9c416d004d492cbc6e61962c0501eaf945ece9b5a0f56597d8348aa0", size = 64780, upload-time = "2025-07-29T15:12:06.02Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/ee/6b08dde0a022c463b88f55ae81149584b125a42183407dc1045c486cc870/opentelemetry_api-1.36.0-py3-none-any.whl", hash = "sha256:02f20bcacf666e1333b6b1f04e647dc1d5111f86b8e510238fcc56d7762cda8c", size = 65564, upload-time = "2025-07-29T15:11:47.998Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356, upload-time = "2025-12-11T13:32:17.304Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/83/dd4660f2956ff88ed071e9e0e36e830df14b8c5dc06722dbde1841accbe8/opentelemetry_exporter_otlp_proto_common-1.38.0.tar.gz", hash = "sha256:e333278afab4695aa8114eeb7bf4e44e65c6607d54968271a249c180b2cb605c", size = 20431, upload-time = "2025-10-16T08:35:53.285Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/9e/55a41c9601191e8cd8eb626b54ee6827b9c9d4a46d736f32abc80d8039fc/opentelemetry_exporter_otlp_proto_common-1.38.0-py3-none-any.whl", hash = "sha256:03cb76ab213300fe4f4c62b7d8f17d97fcfd21b89f0b5ce38ea156327ddda74a", size = 18359, upload-time = "2025-10-16T08:35:34.099Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos", marker = "python_full_version < '3.10'" },
+    { name = "opentelemetry-api", version = "1.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "opentelemetry-exporter-otlp-proto-common", marker = "python_full_version < '3.10'" },
+    { name = "opentelemetry-proto", marker = "python_full_version < '3.10'" },
+    { name = "opentelemetry-sdk", version = "1.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "requests", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0a/debcdfb029fbd1ccd1563f7c287b89a6f7bef3b2902ade56797bfd020854/opentelemetry_exporter_otlp_proto_http-1.38.0.tar.gz", hash = "sha256:f16bd44baf15cbe07633c5112ffc68229d0edbeac7b37610be0b2def4e21e90b", size = 17282, upload-time = "2025-10-16T08:35:54.422Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/77/154004c99fb9f291f74aa0822a2f5bbf565a72d8126b3a1b63ed8e5f83c7/opentelemetry_exporter_otlp_proto_http-1.38.0-py3-none-any.whl", hash = "sha256:84b937305edfc563f08ec69b9cb2298be8188371217e867c1854d77198d0825b", size = 19579, upload-time = "2025-10-16T08:35:36.269Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/14/f0c4f0f6371b9cb7f9fa9ee8918bfd59ac7040c7791f1e6da32a1839780d/opentelemetry_proto-1.38.0.tar.gz", hash = "sha256:88b161e89d9d372ce723da289b7da74c3a8354a8e5359992be813942969ed468", size = 46152, upload-time = "2025-10-16T08:36:01.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/6a/82b68b14efca5150b2632f3692d627afa76b77378c4999f2648979409528/opentelemetry_proto-1.38.0-py3-none-any.whl", hash = "sha256:b6ebe54d3217c42e45462e2a1ae28c3e2bf2ec5a5645236a490f55f45f1a0a18", size = 72535, upload-time = "2025-10-16T08:35:45.749Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.36.0"
+version = "1.38.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
 dependencies = [
-    { name = "opentelemetry-api", marker = "python_full_version >= '3.10'" },
-    { name = "opentelemetry-semantic-conventions", marker = "python_full_version >= '3.10'" },
+    { name = "opentelemetry-api", version = "1.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.59b0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/cb/f0eee1445161faf4c9af3ba7b848cc22a50a3d3e2515051ad8628c35ff80/opentelemetry_sdk-1.38.0.tar.gz", hash = "sha256:93df5d4d871ed09cb4272305be4d996236eedb232253e3ab864c8620f051cebe", size = 171942, upload-time = "2025-10-16T08:36:02.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/2e/e93777a95d7d9c40d270a371392b6d6f1ff170c2a3cb32d6176741b5b723/opentelemetry_sdk-1.38.0-py3-none-any.whl", hash = "sha256:1c66af6564ecc1553d72d811a01df063ff097cdc82ce188da9951f93b8d10f6b", size = 132349, upload-time = "2025-10-16T08:35:46.995Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "opentelemetry-api", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.60b1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/85/8567a966b85a2d3f971c4d42f781c305b2b91c043724fa08fd37d158e9dc/opentelemetry_sdk-1.36.0.tar.gz", hash = "sha256:19c8c81599f51b71670661ff7495c905d8fdf6976e41622d5245b791b06fa581", size = 162557, upload-time = "2025-07-29T15:12:16.76Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/59/7bed362ad1137ba5886dac8439e84cd2df6d087be7c09574ece47ae9b22c/opentelemetry_sdk-1.36.0-py3-none-any.whl", hash = "sha256:19fe048b42e98c5c1ffe85b569b7073576ad4ce0bcb6e9b4c6a39e890a6c45fb", size = 119995, upload-time = "2025-07-29T15:12:03.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.57b0"
+version = "0.59b0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
 dependencies = [
-    { name = "opentelemetry-api", marker = "python_full_version >= '3.10'" },
+    { name = "opentelemetry-api", version = "1.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/bc/8b9ad3802cd8ac6583a4eb7de7e5d7db004e89cb7efe7008f9c8a537ee75/opentelemetry_semantic_conventions-0.59b0.tar.gz", hash = "sha256:7a6db3f30d70202d5bf9fa4b69bc866ca6a30437287de6c510fb594878aed6b0", size = 129861, upload-time = "2025-10-16T08:36:03.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/7d/c88d7b15ba8fe5c6b8f93be50fc11795e9fc05386c44afaf6b76fe191f9b/opentelemetry_semantic_conventions-0.59b0-py3-none-any.whl", hash = "sha256:35d3b8833ef97d614136e253c1da9342b4c3c083bbaf29ce31d572a1c3825eed", size = 207954, upload-time = "2025-10-16T08:35:48.054Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "opentelemetry-api", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/31/67dfa252ee88476a29200b0255bda8dfc2cf07b56ad66dc9a6221f7dc787/opentelemetry_semantic_conventions-0.57b0.tar.gz", hash = "sha256:609a4a79c7891b4620d64c7aac6898f872d790d75f22019913a660756f27ff32", size = 124225, upload-time = "2025-07-29T15:12:17.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/75/7d591371c6c39c73de5ce5da5a2cc7b72d1d1cd3f8f4638f553c01c37b11/opentelemetry_semantic_conventions-0.57b0-py3-none-any.whl", hash = "sha256:757f7e76293294f124c827e514c2a3144f191ef175b069ce8d1211e1e38e9e78", size = 201627, upload-time = "2025-07-29T15:12:04.174Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
 ]
 
 [[package]]
@@ -5480,7 +5632,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp", marker = "python_full_version >= '3.10'" },
     { name = "grpcio", marker = "python_full_version >= '3.10'" },
-    { name = "opentelemetry-sdk", marker = "python_full_version >= '3.10'" },
+    { name = "opentelemetry-sdk", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "packaging", marker = "python_full_version >= '3.10'" },
     { name = "protobuf", marker = "python_full_version >= '3.10'" },
     { name = "pydantic", marker = "python_full_version >= '3.10'" },


### PR DESCRIPTION
## Summary

- support both Mistral SDK export layouts: `mistralai.client.Mistral` on 2.x and `mistralai.Mistral` on 1.x
- widen the optional dependency to `mistralai>=1.5.1,<3`; the frozen lock selects 1.10.0 for Python 3.9 and 2.9.1 for Python 3.10+
- keep direct factories and `from_provider()` aligned behind the same v2-first, v1-fallback behavior
- update deterministic tests, public typing coverage, examples, integration docs, and the changelog
- repair stale Mistral examples that used the removed `MistralClient` class or the nonexistent Instructor `.messages.create` path

## Consolidates

- rebuilds #2298 by @Ian321 against current `main`, preserving the contributor's SDK v2 intent while avoiding unrelated lockfile churn
- addresses #2365
- keep both linked items open until this behavior reaches `main`; after merge, #2298 can close as superseded and #2365 as fixed

## Validation

- clean Python 3.9 environment: `mistralai==1.10.0`, `mistralai.sdk.Mistral`, focused suite **59 passed, 1 skipped**
- clean Python 3.11 environment: `mistralai==2.9.1`, `mistralai.client.sdk.Mistral`, focused suite **59 passed, 1 skipped**
- synced all-extras SDK 2.x environment: complete focused suite **121 passed, 1 skipped**
- exact GitHub core-test command: **2020 passed, 144 skipped**
- exact offline coverage lane: **763 passed**, **93%** total coverage; changed Mistral client at **100%**
- maintained Ruff and format scopes, full and release-strict source/test `ty`, `uv lock --check`, all pre-commit hooks, and `git diff --check`: passed
- clean MkDocs build: passed; only three pre-existing Griffe warnings and unrelated stale anchors remain

GitHub Actions is still required as the authoritative Linux and supported-Python matrix. No live Mistral API call was made locally.

## Release sequencing

This remains a draft because exact `main` at `1454af92` is the validated but unpublished 1.15.5 candidate. Do not merge this runtime/dependency change until 1.15.5 is published or the maintainer explicitly chooses to fold that history into 1.16.0.

## Skipped

- no provider additions, architecture changes, automatic routing policy, or broad dependency batch
- no unrelated OpenTelemetry update was selected manually; lockfile telemetry/JSONPath entries are transitive requirements of the two resolved Mistral SDK branches
- no tag, release, PyPI publication, deployment, or social post