### PR TITLE
fix(bedrock): parse reasoning-prefixed JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Bedrock reasoning JSON**: Parse the final complete JSON value after reasoning text or `<think>` blocks, preserve JSON escape sequences, and keep caller-owned messages unchanged during Bedrock request preparation and retries. ([#2076](https://github.com/567-labs/instructor/issues/2076), [#2287](https://github.com/567-labs/instructor/pull/2287))
+
 ## [1.15.5] - 2026-08-07
 
 ### Fixed

--- a/instructor/v2/providers/bedrock/handlers.py
+++ b/instructor/v2/providers/bedrock/handlers.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import base64
 import json
 import mimetypes
-import re
 from textwrap import dedent
 from typing import Any, cast
 
@@ -18,6 +17,7 @@ from instructor.v2.core.errors import ConfigurationError, ResponseParsingError
 from instructor.v2.core.response_model import prepare_response_model
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.core.handler import ModeHandler
+from instructor.v2.core.json import extract_json_from_codeblock
 
 
 def generate_bedrock_schema(response_model: type[Any]) -> dict[str, Any]:
@@ -38,9 +38,10 @@ def reask_bedrock_json(
     kwargs: dict[str, Any],
     response: Any,
     exception: Exception,
-):
+) -> dict[str, Any]:
     """Handle reask for Bedrock JSON mode when validation fails."""
-    kwargs = kwargs.copy()
+    new_kwargs = kwargs.copy()
+    new_kwargs["messages"] = list(kwargs.get("messages", []))
     reask_msgs = [response["output"]["message"]]
     reask_msgs.append(
         {
@@ -55,17 +56,18 @@ def reask_bedrock_json(
             ],
         }
     )
-    kwargs["messages"].extend(reask_msgs)
-    return kwargs
+    new_kwargs["messages"].extend(reask_msgs)
+    return new_kwargs
 
 
 def reask_bedrock_tools(
     kwargs: dict[str, Any],
     response: Any,
     exception: Exception,
-):
+) -> dict[str, Any]:
     """Handle reask for Bedrock tools mode when validation fails."""
-    kwargs = kwargs.copy()
+    new_kwargs = kwargs.copy()
+    new_kwargs["messages"] = list(kwargs.get("messages", []))
 
     assistant_message = response["output"]["message"]
     reask_msgs = [assistant_message]
@@ -115,8 +117,8 @@ def reask_bedrock_tools(
             }
         )
 
-    kwargs["messages"].extend(reask_msgs)
-    return kwargs
+    new_kwargs["messages"].extend(reask_msgs)
+    return new_kwargs
 
 
 def _normalize_bedrock_image_format(mime_or_ext: str) -> str:
@@ -241,11 +243,9 @@ def _prepare_bedrock_converse_kwargs_internal(
             and "text" in system_content[0]
         ):
             system_text = system_content[0]["text"]
-            if "messages" not in call_kwargs:
-                call_kwargs["messages"] = []
-            call_kwargs["messages"].insert(
-                0, {"role": "system", "content": system_text}
-            )
+            messages = list(call_kwargs.get("messages", []))
+            messages.insert(0, {"role": "system", "content": system_text})
+            call_kwargs["messages"] = messages
 
     if "model" in call_kwargs and "modelId" not in call_kwargs:
         call_kwargs["modelId"] = call_kwargs.pop("model")
@@ -544,10 +544,7 @@ class BedrockMDJSONHandler(ModeHandler):
                 "Streaming is not supported for Bedrock in MD_JSON mode."
             )
         text = _extract_bedrock_text(response)
-        match = re.search(r"```?json(.*?)```?", text, re.DOTALL)
-        if match:
-            text = match.group(1).strip()
-        text = re.sub(r"```?json|\\n", "", text).strip()
+        text = extract_json_from_codeblock(text)
         return response_model.model_validate_json(
             text,
             context=validation_context,

--- a/tests/v2/test_bedrock_handlers.py
+++ b/tests/v2/test_bedrock_handlers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
 
 import pytest
@@ -22,6 +23,12 @@ class User(BaseModel):
 
     name: str
     age: int
+
+
+class Message(BaseModel):
+    """Text payload used to verify JSON escape preservation."""
+
+    text: str
 
 
 def _bedrock_tool_response(
@@ -95,6 +102,7 @@ class TestBedrockToolsHandler:
     def test_handle_reask_adds_messages(self, handler):
         """handle_reask adds tool error messages."""
         kwargs = {"messages": [{"role": "user", "content": "Original"}]}
+        original = deepcopy(kwargs)
         response = _bedrock_tool_response({"answer": "bad"})
         exception = ValueError("Validation failed")
 
@@ -102,6 +110,7 @@ class TestBedrockToolsHandler:
 
         assert "messages" in result
         assert len(result["messages"]) > 1
+        assert kwargs == original
 
 
 class TestBedrockMDJSONHandler:
@@ -144,9 +153,60 @@ class TestBedrockMDJSONHandler:
         assert isinstance(result, Answer)
         assert result.answer == 3.0
 
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            (
+                '<think>I first considered {"answer": 99}.</think>\n{"answer": 4}',
+                4.0,
+            ),
+            (
+                "<think>Reasoning with {not valid JSON} across\nmultiple lines.</think>\n"
+                '```json\n{"answer": 5}\n```',
+                5.0,
+            ),
+        ],
+    )
+    def test_parse_response_uses_final_json_after_reasoning(
+        self, handler, text: str, expected: float
+    ) -> None:
+        """Reasoning content cannot replace or corrupt the final JSON value."""
+        result = handler.response_parser(_bedrock_text_response(text), Answer)
+
+        assert isinstance(result, Answer)
+        assert result.answer == expected
+
+    def test_parse_response_preserves_escaped_newlines(self, handler) -> None:
+        """JSON escape sequences remain part of the parsed payload."""
+        response = _bedrock_text_response('{"text": "first\\nsecond"}')
+
+        result = handler.response_parser(response, Message)
+
+        assert isinstance(result, Message)
+        assert result.text == "first\nsecond"
+
+    def test_prepare_request_does_not_mutate_native_system_messages(
+        self, handler
+    ) -> None:
+        """Converting native Bedrock system content treats caller input as read-only."""
+        kwargs = {
+            "system": [{"text": "Existing instruction"}],
+            "messages": [{"role": "user", "content": "Extract user"}],
+        }
+        original = deepcopy(kwargs)
+
+        _, result_kwargs = handler.request_handler(User, kwargs)
+
+        assert kwargs == original
+        assert result_kwargs["system"][0] == {"text": "Existing instruction"}
+        assert result_kwargs["messages"] == [
+            {"role": "user", "content": [{"text": "Extract user"}]}
+        ]
+
     def test_handle_reask_adds_messages(self, handler):
         """handle_reask adds user correction message."""
         kwargs = {"messages": [{"role": "user", "content": "Original"}]}
+        original = deepcopy(kwargs)
         response = _bedrock_text_response("Invalid response")
         exception = ValueError("Validation failed")
 
@@ -154,3 +214,4 @@ class TestBedrockMDJSONHandler:
 
         assert "messages" in result
         assert len(result["messages"]) > 1
+        assert kwargs == original


### PR DESCRIPTION
## Summary

- parse the final complete JSON object or array from Bedrock `MD_JSON` responses using the shared v2 extractor
- handle reasoning prose and `<think>...</think>` blocks even when they contain valid or malformed brace spans
- preserve escaped JSON content instead of deleting literal `\\n` sequences
- copy message lists before native-system conversion and Bedrock reasks so caller-owned input remains unchanged

This is the current-main canonical replacement for #2287 and preserves the intent and attribution of @octo-patch. It fixes #2076 once merged.

## Validation

- focused Bedrock and shared JSON tests: `66 passed`
- exact GitHub core-test scope: `2024 passed, 144 skipped`
- exact offline coverage scope: `760 passed`, `93%`
- focused branch coverage exercises every changed Bedrock handler statement
- maintained Ruff and format scopes: passed
- strict source and test `ty`: passed
- all pre-commit hooks, lock validation, and `git diff --check`: passed

## Intentionally separate

- #2086 / #2084 native Bedrock structured outputs: useful but needs a separate current-v2 reconstruction without hard-coded model routing
- #2409 / #2408 bearer-token authentication: held because the existing patch mutates process-global credential state

## Merge sequencing

This PR is draft while the already validated `1.15.5` candidate remains unpublished. It should not merge past `1454af92` until that release is published or the maintainer explicitly folds the version history into `1.16.0`.