### PR TITLE
docs(contributing): align setup with uv workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ By participating in this project, you agree to abide by our code of conduct: tre
 
 ### Environment Setup
 
-1. **Fork the Repository**: Click the "Fork" button at the top right of the [repository page](https://github.com/instructor-ai/instructor).
+1. **Fork the Repository**: Click the "Fork" button at the top right of the [repository page](https://github.com/567-labs/instructor).
 
 2. **Clone Your Fork**:
    ```bash
@@ -48,7 +48,7 @@ By participating in this project, you agree to abide by our code of conduct: tre
 
 3. **Set up Remote**:
    ```bash
-   git remote add upstream https://github.com/instructor-ai/instructor.git
+   git remote add upstream https://github.com/567-labs/instructor.git
    ```
 
 4. **Install UV** (recommended):
@@ -63,19 +63,18 @@ By participating in this project, you agree to abide by our code of conduct: tre
 5. **Install Dependencies**:
    ```bash
    # Using uv (recommended)
-   uv pip install -e ".[dev,docs,test-docs]"
+   uv sync --extra dev --extra docs --extra test-docs
    
    # Using poetry
    poetry install --with dev,docs,test-docs
    
    # For specific providers, add the provider name as an extra
-   # Example: uv pip install -e ".[dev,docs,test-docs,anthropic]"
+   # Example: uv sync --extra dev --extra docs --extra test-docs --extra anthropic
    ```
 
 6. **Set up Pre-commit**:
    ```bash
-   pip install pre-commit
-   pre-commit install
+   uv run pre-commit install
    ```
 
 ### Development Workflow
@@ -115,16 +114,19 @@ UV is a fast Python package installer and resolver. It's recommended for day-to-
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Install project and development dependencies
-uv pip install -e ".[dev,docs]"
+uv sync --extra dev --extra docs
 
-# Adding a new dependency (example)
-uv pip install new-package
+# Add a project dependency and update pyproject.toml plus uv.lock
+uv add new-package
 ```
 
 Key UV commands:
-- `uv pip install -e .` - Install the project in editable mode
-- `uv pip install -e ".[dev]"` - Install with development extras
-- `uv pip freeze > requirements.txt` - Generate requirements file
+- `uv sync` - Install the project and synchronize the environment with `uv.lock`
+- `uv sync --extra dev` - Install with a selected optional extra
+- `uv add package-name` - Add a project dependency and update the lockfile
+- `uv pip install package-name` - Install only into the current environment without changing project metadata
+- `uv pip compile pyproject.toml -o requirements.txt` - Regenerate the committed requirements export
+- `uv lock --check` - Verify that `uv.lock` matches `pyproject.toml`
 - `uv self update` - Update UV to the latest version
 
 #### Using Poetry
@@ -173,9 +175,9 @@ Instructor uses optional dependencies to support different LLM providers. Provid
 4. **Document Installation**: Update the documentation to include installation instructions:
    ```
    # Install with your provider support
-   uv pip install "instructor[my-provider]"
+   uv add "instructor[my-provider]"
    # or
-   poetry install --with my-provider
+   poetry add "instructor[my-provider]"
    ```
 
 5. **Create Provider Utilities and Handlers**:
@@ -198,7 +200,7 @@ Instructor uses optional dependencies to support different LLM providers. Provid
 
 ### Reporting Bugs
 
-If you find a bug, please create an issue on [our issue tracker](https://github.com/instructor-ai/instructor/issues) with:
+If you find a bug, please create an issue on [our issue tracker](https://github.com/567-labs/instructor/issues) with:
 
 1. A clear, descriptive title
 2. A detailed description including:
@@ -241,7 +243,7 @@ Documentation improvements are always welcome! Follow these guidelines:
 
 We encourage contributions to our evaluation tests:
 
-1. Explore existing evals in the [evals directory](https://github.com/instructor-ai/instructor/tree/main/tests/llm)
+1. Explore existing evals in the [evals directory](https://github.com/567-labs/instructor/tree/main/tests/llm)
 2. Contribute new evals as pytest tests
 3. Evals should test specific capabilities or edge cases of the library or models
 4. Follow the existing patterns for structuring eval tests
@@ -350,17 +352,17 @@ Run tests using pytest:
 
 ```bash
 # Run all tests
-pytest tests/
+uv run pytest tests/
 
 # Run specific test
-pytest tests/path_to_test.py::test_name
+uv run pytest tests/path_to_test.py::test_name
 
 # Skip LLM tests (faster for local development)
-pytest tests/ -k 'not llm and not openai'
+uv run pytest tests/ -k 'not llm and not openai'
 
 # Generate coverage report
-coverage run -m pytest tests/ -k "not docs"
-coverage report
+uv run coverage run -m pytest tests/ -k "not docs"
+uv run coverage report
 ```
 
 ## Branch and Release Process

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,7 +13,7 @@ We welcome contributions to Instructor! This page covers the different ways you 
 
 Evals help us monitor the quality of both the OpenAI models and the Instructor library. To contribute:
 
-1. **Explore Existing Evals**: Check out [our evals directory](https://github.com/instructor-ai/instructor/tree/main/tests/llm/test_openai/evals)
+1. **Explore Existing Evals**: Check out [our evals directory](https://github.com/567-labs/instructor/tree/main/tests/llm)
 2. **Create a New Eval**: Add new pytest tests that evaluate specific capabilities or edge cases
 3. **Follow the Pattern**: Structure your eval similar to existing ones
 4. **Submit a PR**: We'll review and incorporate your eval
@@ -22,7 +22,7 @@ Evals are run weekly, and results are tracked to monitor performance over time.
 
 ### Reporting Issues
 
-If you encounter a bug or problem, please [file an issue on GitHub](https://github.com/instructor-ai/instructor/issues) with:
+If you encounter a bug or problem, please [file an issue on GitHub](https://github.com/567-labs/instructor/issues) with:
 
 1. A clear, descriptive title
 2. Detailed information including:
@@ -38,8 +38,8 @@ If you encounter a bug or problem, please [file an issue on GitHub](https://gith
 We welcome pull requests! Here's the process:
 
 1. **For Small Changes**: Feel free to submit a PR directly
-2. **For Larger Changes**: [Start with an issue](https://github.com/instructor-ai/instructor/issues) to discuss approach
-3. **Looking for Ideas?** Check issues labeled [help wanted](https://github.com/instructor-ai/instructor/labels/help%20wanted) or [good first issue](https://github.com/instructor-ai/instructor/labels/good%20first%20issue)
+2. **For Larger Changes**: [Start with an issue](https://github.com/567-labs/instructor/issues) to discuss approach
+3. **Looking for Ideas?** Check issues labeled [help wanted](https://github.com/567-labs/instructor/labels/help%20wanted) or [good first issue](https://github.com/567-labs/instructor/labels/good%20first%20issue)
 
 ## Setting Up Your Development Environment
 
@@ -63,16 +63,16 @@ UV is a fast Python package installer and resolver that makes development easier
    cd instructor
 
    # Install with development dependencies
-   uv pip install -e ".[dev,docs]"
+   uv sync --extra dev --extra docs
    ```
 
 3. **Adding New Dependencies**:
    ```bash
-   # Add a regular dependency
-   uv pip install some-package
+   # Add a project dependency and update pyproject.toml plus uv.lock
+   uv add some-package
 
-   # Install a specific version
-   uv pip install "some-package>=1.0.0,<2.0.0"
+   # Install only into the current environment without changing project metadata
+   uv pip install some-package
    ```
 
 4. **Common UV Commands**:
@@ -80,8 +80,9 @@ UV is a fast Python package installer and resolver that makes development easier
    # Update UV itself
    uv self update
 
-   # Create a requirements file
-   uv pip freeze > requirements.txt
+   # Verify the lockfile and regenerate the committed requirements export
+   uv lock --check
+   uv pip compile pyproject.toml -o requirements.txt
    ```
 
 ### Using Poetry
@@ -142,9 +143,9 @@ Instructor uses optional dependencies to support different LLM providers. Provid
 4. **Document Installation**:
    ```bash
    # Installation command for your provider
-   uv pip install "instructor[my-provider]"
+   uv add "instructor[my-provider]"
    # or with poetry
-   poetry install --with my-provider
+   poetry add "instructor[my-provider]"
    ```
 
 5. **Create Provider Utilities and Handlers**:
@@ -171,7 +172,7 @@ Instructor uses optional dependencies to support different LLM providers. Provid
    ```bash
    git clone https://github.com/YOUR-USERNAME/instructor.git
    cd instructor
-   git remote add upstream https://github.com/instructor-ai/instructor.git
+   git remote add upstream https://github.com/567-labs/instructor.git
    ```
 3. **Create a Branch**:
    ```bash
@@ -180,7 +181,7 @@ Instructor uses optional dependencies to support different LLM providers. Provid
 4. **Make Changes, Test, and Commit**:
    ```bash
    # Run tests
-   pytest tests/ -k 'not llm and not openai'  # Skip LLM tests for faster local dev
+   uv run pytest tests/ -k 'not llm and not openai'  # Skip LLM tests for faster local dev
 
    # Commit changes
    git add .
@@ -300,8 +301,7 @@ We use the following tools to maintain code quality:
 
 ```bash
 # Install pre-commit hooks
-pip install pre-commit
-pre-commit install
+uv run pre-commit install
 ```
 
 Key style guidelines:
@@ -439,8 +439,8 @@ print(person.age)   # 25
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-<a href="https://github.com/instructor-ai/instructor/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=jxnl/instructor" />
+<a href="https://github.com/567-labs/instructor/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=567-labs/instructor" />
 </a>
 
 ## Documentation Resources


### PR DESCRIPTION
## Summary

- replace stale `instructor-ai/instructor` contributor links with `567-labs/instructor`
- use `uv sync` to create and synchronize the locked project environment
- distinguish `uv add` project-metadata changes from ad hoc `uv pip install` environment changes
- run repository tools through `uv run`, including pre-commit, pytest, and coverage
- document the requirements export command used by the repository's pre-commit hook
- align provider installation examples for uv and Poetry
- update the contributor image to the current organization

This is the current-main reconstruction of #2354 and preserves the documentation contribution from @Steeveyboy.

## Why a replacement

The older PR has 14 commits and mixes correct link updates with several unsafe or inconsistent commands: it redundantly creates a uv environment, uses `uv add` where only an environment install is intended, and installs pre-commit as a tool while invoking the project copy. This replacement keeps the useful intent while matching the current lockfile and hook behavior.

## Validation

- documented `uv sync --extra dev --extra docs --extra test-docs` resolution: pass
- documented `uv pip compile pyproject.toml` requirements export: pass
- all pre-commit hooks: pass
- clean MkDocs build: pass
- `git diff --check`: pass

MkDocs reports only the three pre-existing Griffe warnings and unrelated stale anchors.

## Skipped items

- #2468 remains separate: it is a 384-line product/provenance workflow with product-level `confidence` semantics, not a compact contributor-documentation correction
- no provider implementation, dependency, runtime, release, or deployment change
- no broad historical-link rewrite outside the contributor guides

## Release sequencing

This remains draft while exact commit `1454af92` is held as the unpublished `1.15.5` candidate. Even docs-only work should not move `main` past that exact candidate until `1.15.5` is published or the release-history decision is made explicitly.