### PR TITLE
chore(release): prepare 1.16.0 candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-08-08
+
 ### Added
 - **Bedrock native structured outputs**: Add explicit `Mode.JSON_SCHEMA` and `Mode.TOOLS_STRICT` support through Converse `outputConfig.textFormat` and strict tool schemas, with recursive schema normalization and a boto3 `1.42.42` minimum. Model selection remains caller-controlled. ([#2084](https://github.com/567-labs/instructor/issues/2084), [#2086](https://github.com/567-labs/instructor/pull/2086))
 - **Validation retry budgets**: Add positive cumulative `token_budget` limits for structured non-streaming retries, immutable `completion:usage` snapshots, sync/async cutoff parity, and stable cumulative usage metadata. Valid responses still win after crossing the budget; retries fail closed before another provider call when usage is unavailable. ([#2391](https://github.com/567-labs/instructor/issues/2391), [#2392](https://github.com/567-labs/instructor/pull/2392))
@@ -287,5 +289,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 - Pydantic v2 deprecation warnings resolved by migrating from class `Config` to `ConfigDict` ([#1782](https://github.com/567-labs/instructor/pull/1782))
 
-[Unreleased]: https://github.com/567-labs/instructor/compare/v1.15.5...HEAD
+[Unreleased]: https://github.com/567-labs/instructor/compare/v1.16.0...HEAD
+[1.16.0]: https://github.com/567-labs/instructor/compare/v1.15.5...v1.16.0
 [1.15.5]: https://github.com/567-labs/instructor/compare/v1.15.4...v1.15.5

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -66,7 +66,7 @@ if TYPE_CHECKING:
         openai_moderation as openai_moderation,
     )
 
-__version__ = "1.15.5"
+__version__ = "1.16.0"
 
 __all__ = [
     "Instructor",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "regex>=2023.0.0,<2027.0.0",
 ]
 name = "instructor"
-version = "1.15.5"
+version = "1.16.0"
 description = "structured outputs for llm"
 readme = "README.md"
 

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import re
 import sys
 from pathlib import Path
@@ -31,6 +32,27 @@ def _project_version(root: Path) -> str:
 def _repository_url(root: Path) -> str:
     data = _load_toml(root / "pyproject.toml")
     return str(data["project"]["urls"]["repository"])
+
+
+def _runtime_version(root: Path) -> str:
+    init_path = root / "instructor" / "__init__.py"
+    tree = ast.parse(init_path.read_text(encoding="utf-8"), filename=str(init_path))
+    versions = [
+        node.value.value
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "__version__"
+            for target in node.targets
+        )
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    ]
+    if len(versions) != 1:
+        raise ValueError(
+            "instructor/__init__.py must contain exactly one string __version__"
+        )
+    return versions[0]
 
 
 def _lock_version(root: Path) -> str:
@@ -90,8 +112,14 @@ def prepare_release(
 ) -> str:
     """Validate version metadata and write the matching changelog section."""
     version = _project_version(root)
+    runtime_version = _runtime_version(root)
     lock_version = _lock_version(root)
     repository_url = _repository_url(root)
+    if runtime_version != version:
+        raise ValueError(
+            "version mismatch: "
+            f"pyproject.toml={version}, instructor.__version__={runtime_version}"
+        )
     if lock_version != version:
         raise ValueError(
             f"version mismatch: pyproject.toml={version}, uv.lock={lock_version}"

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -18,6 +18,9 @@ def _write_release_files(root: Path, changelog: str) -> None:
         'version = 1\n[[package]]\nname = "instructor"\nversion = "1.2.3"\n',
         encoding="utf-8",
     )
+    package = root / "instructor"
+    package.mkdir()
+    (package / "__init__.py").write_text('__version__ = "1.2.3"\n', encoding="utf-8")
     (root / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
 
 
@@ -107,6 +110,28 @@ def test_prepare_release_rejects_lockfile_version_drift(tmp_path: Path) -> None:
 
     assert result.returncode == 2
     assert "pyproject.toml=1.2.3, uv.lock=1.2.2" in result.stderr
+
+
+def test_prepare_release_rejects_runtime_version_drift(tmp_path: Path) -> None:
+    _write_release_files(tmp_path, _changelog())
+    (tmp_path / "instructor" / "__init__.py").write_text(
+        '__version__ = "1.2.2"\n', encoding="utf-8"
+    )
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 2
+    assert "pyproject.toml=1.2.3, instructor.__version__=1.2.2" in result.stderr
+
+
+def test_prepare_release_requires_single_runtime_version(tmp_path: Path) -> None:
+    _write_release_files(tmp_path, _changelog())
+    (tmp_path / "instructor" / "__init__.py").write_text("", encoding="utf-8")
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 2
+    assert "exactly one string __version__" in result.stderr
 
 
 def test_prepare_release_requires_comparison_link(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1805,7 +1805,7 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.15.5"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Purpose

Stacked release-candidate PR on top of draft integration PR #2517. **Do not merge or publish from this PR.** It validates the recommended release sequence in which 1.15.5 is published first and 1.16.0 follows.

## Changes

- declare `1.16.0` in `pyproject.toml`, `uv.lock`, and `instructor.__version__`
- move the integrated 1.16 notes into a dated `[1.16.0] - 2026-08-08` changelog section
- add the `v1.15.5...v1.16.0` comparison link
- strengthen `scripts/prepare_release.py` so runtime-version drift fails before artifact construction
- add regressions for mismatched and missing runtime versions

The additional validator was prompted by a clean-wheel smoke that correctly caught an initial candidate where distribution metadata was 1.16.0 but `instructor.__version__` was still 1.15.5.

## Local validation

- release metadata validation with `--expected-version 1.16.0`: pass
- release-validator tests: 8 passed
- exact release test lane: 2076 passed, 148 skipped
- release Ruff, format, strict source/test `ty`, lock/install/export checks, and all pre-commit hooks: pass
- wheel and sdist build as 1.16.0; Twine check: pass
- clean wheel installation, metadata, runtime version, schema, and Pydantic smokes: pass on Python 3.9 and Python 3.13

## Release gate

This stacked candidate assumes `v1.15.5` is published from exact commit `1454af92b4012e679d8156ff4d16953301714e2e` first. If the maintainer instead folds unpublished 1.15.5 into 1.16.0, the predecessor comparison and release notes must be revised before retargeting.

No merge, tag, GitHub release, PyPI publication, deployment, or social post is authorized by this PR.