### PR TITLE
chore(release): alternative folded 1.16.0 candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
-## [1.16.0] - 2026-08-08
+## [1.16.0] - 2026-08-09
 
 ### Added
-- **Bedrock native structured outputs**: Add explicit `Mode.JSON_SCHEMA` and `Mode.TOOLS_STRICT` support through Converse `outputConfig.textFormat` and strict tool schemas, with recursive schema normalization and a boto3 `1.42.42` minimum. Model selection remains caller-controlled. ([#2084](https://github.com/567-labs/instructor/issues/2084), [#2086](https://github.com/567-labs/instructor/pull/2086))
-- **Validation retry budgets**: Add positive cumulative `token_budget` limits for structured non-streaming retries, immutable `completion:usage` snapshots, sync/async cutoff parity, and stable cumulative usage metadata. Valid responses still win after crossing the budget; retries fail closed before another provider call when usage is unavailable. ([#2391](https://github.com/567-labs/instructor/issues/2391), [#2392](https://github.com/567-labs/instructor/pull/2392))
+- **Bedrock native structured outputs**: Add explicit `Mode.JSON_SCHEMA` and `Mode.TOOLS_STRICT` support through Converse `outputConfig.textFormat` and strict tool schemas, with recursive schema normalization and a boto3 `1.42.42` minimum. Model selection remains caller-controlled. ([#2515](https://github.com/567-labs/instructor/pull/2515), [#2084](https://github.com/567-labs/instructor/issues/2084), [#2086](https://github.com/567-labs/instructor/pull/2086))
+- **Validation retry budgets**: Add positive cumulative `token_budget` limits for structured non-streaming retries, immutable `completion:usage` snapshots, sync/async cutoff parity, and stable cumulative usage metadata. Valid responses still win after crossing the budget. When a budget is configured, a failed attempt with unavailable usage stops before another provider call. ([#2512](https://github.com/567-labs/instructor/pull/2512), [#2391](https://github.com/567-labs/instructor/issues/2391), [#2392](https://github.com/567-labs/instructor/pull/2392))
+
+### Changed
+- **Contributor workflow**: Align contributor setup and dependency management around locked `uv sync` environments, `uv run` commands, and `uv add` only for intentional project metadata changes. ([#2516](https://github.com/567-labs/instructor/pull/2516), [#2354](https://github.com/567-labs/instructor/pull/2354))
 
 ### Fixed
-- **Mistral SDK compatibility**: Support the `mistralai` 2.x client export on Python 3.10+ while retaining the compatible 1.x fallback required by Python 3.9. ([#2298](https://github.com/567-labs/instructor/pull/2298), [#2365](https://github.com/567-labs/instructor/issues/2365))
-- **Bedrock reasoning JSON**: Parse the final complete JSON value after reasoning text or `<think>` blocks, preserve JSON escape sequences, and keep caller-owned messages unchanged during Bedrock request preparation and retries. ([#2076](https://github.com/567-labs/instructor/issues/2076), [#2287](https://github.com/567-labs/instructor/pull/2287))
+- **Mistral SDK compatibility**: Support the `mistralai` 2.x client export on Python 3.10+ while retaining the compatible 1.x fallback required by Python 3.9. ([#2513](https://github.com/567-labs/instructor/pull/2513), [#2298](https://github.com/567-labs/instructor/pull/2298), [#2365](https://github.com/567-labs/instructor/issues/2365))
+- **Bedrock reasoning JSON**: Parse the final complete JSON value after reasoning text or `<think>` blocks, preserve JSON escape sequences, and keep caller-owned messages unchanged during Bedrock request preparation and retries. ([#2514](https://github.com/567-labs/instructor/pull/2514), [#2076](https://github.com/567-labs/instructor/issues/2076), [#2287](https://github.com/567-labs/instructor/pull/2287))
 - **Remote multimodal fetches**: Apply the existing 30-second request timeout to image, audio, and PDF downloads so an unresponsive URL cannot block a caller indefinitely. ([#2507](https://github.com/567-labs/instructor/pull/2507))
 - **OpenAI streaming retries**: Keep TOOLS, JSON, JSON_SCHEMA, and MD_JSON retries on the streaming parser after the one-shot model marker is consumed, allowing corrected streamed responses to validate successfully. ([#2508](https://github.com/567-labs/instructor/pull/2508))
 - **Iterable streaming unions**: Parse PEP 604 unions (`create_iterable(response_model=Weather | GoogleSearch)`, `Iterable[Weather | GoogleSearch]`) member by member instead of calling `model_validate_json` on `types.UnionType`. ([#2509](https://github.com/567-labs/instructor/pull/2509))
@@ -51,7 +54,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - **OpenAI Responses API**: Align `RESPONSES_TOOLS` `text.format` with the forced tool schema and add targeted retry guidance when tool calls return empty `{}` arguments. ([#2300](https://github.com/567-labs/instructor/issues/2300), [#2304](https://github.com/567-labs/instructor/pull/2304))
 
 ### Security
-- **LLM validator isolation**: Send validation rules and candidate values as structured JSON data under a fixed trusted instruction to reduce prompt-injection risk, and raise `ValueError` for rejected values instead of relying on optimization-sensitive assertions. ([#2056](https://github.com/567-labs/instructor/issues/2056), [#2307](https://github.com/567-labs/instructor/pull/2307))
+- **LLM validator isolation**: Send validation rules and candidate values as structured JSON data under a fixed trusted instruction to reduce prompt-injection risk, and raise `ValueError` for rejected values instead of relying on optimization-sensitive assertions. ([#2511](https://github.com/567-labs/instructor/pull/2511), [#2056](https://github.com/567-labs/instructor/issues/2056), [#2307](https://github.com/567-labs/instructor/pull/2307))
 
 ### Tests / CI
 - **Fork-safe contributor checks**: Mark auto-client network tests explicitly and exclude them from core, coverage, and release lanes so fork PRs without provider secrets do not fail with empty authorization headers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-08-08
+
 ### Added
 - **Bedrock native structured outputs**: Add explicit `Mode.JSON_SCHEMA` and `Mode.TOOLS_STRICT` support through Converse `outputConfig.textFormat` and strict tool schemas, with recursive schema normalization and a boto3 `1.42.42` minimum. Model selection remains caller-controlled. ([#2084](https://github.com/567-labs/instructor/issues/2084), [#2086](https://github.com/567-labs/instructor/pull/2086))
 - **Validation retry budgets**: Add positive cumulative `token_budget` limits for structured non-streaming retries, immutable `completion:usage` snapshots, sync/async cutoff parity, and stable cumulative usage metadata. Valid responses still win after crossing the budget; retries fail closed before another provider call when usage is unavailable. ([#2391](https://github.com/567-labs/instructor/issues/2391), [#2392](https://github.com/567-labs/instructor/pull/2392))
@@ -287,5 +289,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 - Pydantic v2 deprecation warnings resolved by migrating from class `Config` to `ConfigDict` ([#1782](https://github.com/567-labs/instructor/pull/1782))
 
-[Unreleased]: https://github.com/567-labs/instructor/compare/v1.15.5...HEAD
+[Unreleased]: https://github.com/567-labs/instructor/compare/v1.16.0...HEAD
+[1.16.0]: https://github.com/567-labs/instructor/compare/v1.15.5...v1.16.0
 [1.15.5]: https://github.com/567-labs/instructor/compare/v1.15.4...v1.15.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 - **Mistral SDK compatibility**: Support the `mistralai` 2.x client export on Python 3.10+ while retaining the compatible 1.x fallback required by Python 3.9. ([#2298](https://github.com/567-labs/instructor/pull/2298), [#2365](https://github.com/567-labs/instructor/issues/2365))
 - **Bedrock reasoning JSON**: Parse the final complete JSON value after reasoning text or `<think>` blocks, preserve JSON escape sequences, and keep caller-owned messages unchanged during Bedrock request preparation and retries. ([#2076](https://github.com/567-labs/instructor/issues/2076), [#2287](https://github.com/567-labs/instructor/pull/2287))
-
-### Security
-- **LLM validator isolation**: Send validation rules and candidate values as structured JSON data under a fixed trusted instruction to reduce prompt-injection risk, and raise `ValueError` for rejected values instead of relying on optimization-sensitive assertions. ([#2056](https://github.com/567-labs/instructor/issues/2056), [#2307](https://github.com/567-labs/instructor/pull/2307))
-
-## [1.15.5] - 2026-08-07
-
-### Fixed
 - **Remote multimodal fetches**: Apply the existing 30-second request timeout to image, audio, and PDF downloads so an unresponsive URL cannot block a caller indefinitely. ([#2507](https://github.com/567-labs/instructor/pull/2507))
 - **OpenAI streaming retries**: Keep TOOLS, JSON, JSON_SCHEMA, and MD_JSON retries on the streaming parser after the one-shot model marker is consumed, allowing corrected streamed responses to validate successfully. ([#2508](https://github.com/567-labs/instructor/pull/2508))
 - **Iterable streaming unions**: Parse PEP 604 unions (`create_iterable(response_model=Weather | GoogleSearch)`, `Iterable[Weather | GoogleSearch]`) member by member instead of calling `model_validate_json` on `types.UnionType`. ([#2509](https://github.com/567-labs/instructor/pull/2509))
@@ -56,6 +49,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - **v2 imports**: Defer OpenAI SDK imports from core v2 modules until an OpenAI-specific path actually needs them, reducing import side effects for non-OpenAI usage. ([#2390](https://github.com/567-labs/instructor/pull/2390))
 - **v2 response models**: Treat `list[A | B]` PEP 604 unions of Pydantic models as iterable response models, matching `list[Union[A, B]]` schema behavior. ([#2377](https://github.com/567-labs/instructor/pull/2377))
 - **OpenAI Responses API**: Align `RESPONSES_TOOLS` `text.format` with the forced tool schema and add targeted retry guidance when tool calls return empty `{}` arguments. ([#2300](https://github.com/567-labs/instructor/issues/2300), [#2304](https://github.com/567-labs/instructor/pull/2304))
+
+### Security
+- **LLM validator isolation**: Send validation rules and candidate values as structured JSON data under a fixed trusted instruction to reduce prompt-injection risk, and raise `ValueError` for rejected values instead of relying on optimization-sensitive assertions. ([#2056](https://github.com/567-labs/instructor/issues/2056), [#2307](https://github.com/567-labs/instructor/pull/2307))
 
 ### Tests / CI
 - **Fork-safe contributor checks**: Mark auto-client network tests explicitly and exclude them from core, coverage, and release lanes so fork PRs without provider secrets do not fail with empty authorization headers.
@@ -290,5 +286,4 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Pydantic v2 deprecation warnings resolved by migrating from class `Config` to `ConfigDict` ([#1782](https://github.com/567-labs/instructor/pull/1782))
 
 [Unreleased]: https://github.com/567-labs/instructor/compare/v1.16.0...HEAD
-[1.16.0]: https://github.com/567-labs/instructor/compare/v1.15.5...v1.16.0
-[1.15.5]: https://github.com/567-labs/instructor/compare/v1.15.4...v1.15.5
+[1.16.0]: https://github.com/567-labs/instructor/compare/v1.15.4...v1.16.0

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -66,7 +66,7 @@ if TYPE_CHECKING:
         openai_moderation as openai_moderation,
     )
 
-__version__ = "1.15.5"
+__version__ = "1.16.0"
 
 __all__ = [
     "Instructor",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "regex>=2023.0.0,<2027.0.0",
 ]
 name = "instructor"
-version = "1.15.5"
+version = "1.16.0"
 description = "structured outputs for llm"
 readme = "README.md"
 

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import re
 import sys
 from pathlib import Path
@@ -31,6 +32,27 @@ def _project_version(root: Path) -> str:
 def _repository_url(root: Path) -> str:
     data = _load_toml(root / "pyproject.toml")
     return str(data["project"]["urls"]["repository"])
+
+
+def _runtime_version(root: Path) -> str:
+    init_path = root / "instructor" / "__init__.py"
+    tree = ast.parse(init_path.read_text(encoding="utf-8"), filename=str(init_path))
+    versions = [
+        node.value.value
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "__version__"
+            for target in node.targets
+        )
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    ]
+    if len(versions) != 1:
+        raise ValueError(
+            "instructor/__init__.py must contain exactly one string __version__"
+        )
+    return versions[0]
 
 
 def _lock_version(root: Path) -> str:
@@ -90,8 +112,14 @@ def prepare_release(
 ) -> str:
     """Validate version metadata and write the matching changelog section."""
     version = _project_version(root)
+    runtime_version = _runtime_version(root)
     lock_version = _lock_version(root)
     repository_url = _repository_url(root)
+    if runtime_version != version:
+        raise ValueError(
+            "version mismatch: "
+            f"pyproject.toml={version}, instructor.__version__={runtime_version}"
+        )
     if lock_version != version:
         raise ValueError(
             f"version mismatch: pyproject.toml={version}, uv.lock={lock_version}"

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -18,6 +18,9 @@ def _write_release_files(root: Path, changelog: str) -> None:
         'version = 1\n[[package]]\nname = "instructor"\nversion = "1.2.3"\n',
         encoding="utf-8",
     )
+    package = root / "instructor"
+    package.mkdir()
+    (package / "__init__.py").write_text('__version__ = "1.2.3"\n', encoding="utf-8")
     (root / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
 
 
@@ -107,6 +110,28 @@ def test_prepare_release_rejects_lockfile_version_drift(tmp_path: Path) -> None:
 
     assert result.returncode == 2
     assert "pyproject.toml=1.2.3, uv.lock=1.2.2" in result.stderr
+
+
+def test_prepare_release_rejects_runtime_version_drift(tmp_path: Path) -> None:
+    _write_release_files(tmp_path, _changelog())
+    (tmp_path / "instructor" / "__init__.py").write_text(
+        '__version__ = "1.2.2"\n', encoding="utf-8"
+    )
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 2
+    assert "pyproject.toml=1.2.3, instructor.__version__=1.2.2" in result.stderr
+
+
+def test_prepare_release_requires_single_runtime_version(tmp_path: Path) -> None:
+    _write_release_files(tmp_path, _changelog())
+    (tmp_path / "instructor" / "__init__.py").write_text("", encoding="utf-8")
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 2
+    assert "exactly one string __version__" in result.stderr
 
 
 def test_prepare_release_requires_comparison_link(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1805,7 +1805,7 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.15.5"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Purpose

This is the approved folded release candidate for 1.16.0 against current `main`. Jason chose on 2026-08-09 to skip standalone 1.15.5 publication and fold that unpublished payload into 1.16.0.

Integration PR #2517 is now merged at `ad95a3d4`. Against that exact main tree, this PR contains only six release files: version source, runtime version, lock metadata, release validator and tests, and the audited changelog.

This PR does not publish, tag, release, deploy to PyPI, or post social copy.

## Included

- Version source, lock metadata, and runtime `instructor.__version__` set to `1.16.0`.
- Release validator checks the runtime version using AST in addition to source, lockfile, changelog, tag, and artifacts.
- Changelog contains the complete unpublished 1.15.5 payload plus the scoped 1.16 work under one `1.16.0` heading dated 2026-08-09.
- Canonical PRs #2511-#2516 and their source issues/PRs are attributed in the relevant entries.
- Contributor workflow documentation is represented explicitly.
- Compare link is `v1.15.4...v1.16.0`.

## Validation

Validated at `8a43993e576cb3f59432bcef4aadf8e4ba90f06a`:

- `uv lock --check`
- release validator for expected `1.16.0`
- 8 release-validator tests
- full pre-commit suite: Ruff, format, lock, dependency install, requirements export, and ty
- wheel and sdist build plus Twine 6.2.0 checks
- clean Python 3.9 and 3.13 wheel installs
- distribution metadata, runtime version, generated schema, and Pydantic validation smoke checks
- changelog audit against `v1.15.4..HEAD`: complete scope, no standalone 1.15.5 boundary, canonical attribution, current candidate date, and correct compare links
- [Test workflow](https://github.com/567-labs/instructor/actions/runs/31319380847): full coverage, core, Python 3.9-3.13, core-provider groups, Auto Client, and all configured providers passed
- [Release Readiness](https://github.com/567-labs/instructor/actions/runs/31319380844): metadata, release checks, build, Twine, artifact upload, and Python 3.9/3.13 wheel smokes passed; publication was skipped

## Related

- Merged integration: #2517
- Closed publish-first alternative: #2518

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release candidate: version bumps, changelog reorganization, and stricter pre-publish checks with no runtime library behavior changes in this diff.
> 
> **Overview**
> This PR **bumps the package to `1.16.0`** across `pyproject.toml`, `instructor.__version__`, and `uv.lock`, and **folds the unpublished 1.15.5 changelog** into a single dated **`1.16.0`** section (2026-08-09) with compare links **`v1.15.4...v1.16.0`**.
> 
> **Release tooling** now parses `instructor/__init__.py` with AST and **fails if `__version__` drifts** from the project version or is missing, with matching tests in the release-validator fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a43993e576cb3f59432bcef4aadf8e4ba90f06a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->