### PR TITLE
fix: reject empty provider model names

### DIFF
--- a/instructor/v2/auto_client.py
+++ b/instructor/v2/auto_client.py
@@ -114,6 +114,14 @@ def from_provider(
             '(e.g. "openai/gpt-4" or "anthropic/claude-3-sonnet")'
         ) from None
 
+    if not provider or not model_name:
+        from instructor.v2.core.errors import ConfigurationError
+
+        raise ConfigurationError(
+            'Model string must be in format "provider/model-name" '
+            'with both parts non-empty (e.g. "openai/gpt-4")'
+        )
+
     provider_info = {"provider": provider, "operation": "initialize"}
     logger.info(
         "Initializing %s provider with model %s",

--- a/tests/v2/test_auto_client_deterministic.py
+++ b/tests/v2/test_auto_client_deterministic.py
@@ -19,6 +19,11 @@ def test_from_provider_requires_provider_prefix() -> None:
         auto_client.from_provider("gpt-5")
 
 
+def test_from_provider_rejects_empty_model_name() -> None:
+    with pytest.raises(ConfigurationError, match="Model string must be in format"):
+        auto_client.from_provider("openai/")
+
+
 def test_from_provider_rejects_unknown_provider() -> None:
     with pytest.raises(ConfigurationError, match="Unsupported provider: mystery"):
         auto_client.from_provider("mystery/model")


### PR DESCRIPTION
## Describe your changes

Reject provider strings with an empty provider or model component before constructing an SDK client.

Previously, `from_provider("openai/")` reached `openai.OpenAI` and failed on unrelated configuration such as a missing API key. The documented `provider/model-name` contract now produces the same actionable `ConfigurationError` used for strings without a provider prefix.

Adds a focused regression test for the empty-model case.

## Issue ticket number and link

Not applicable — this is a small, independently discovered validation fix, and no duplicate issue or PR was found.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation. (No documentation change: this enforces the existing documented format.)

Tests:

- `uv run pytest tests/v2/test_auto_client_deterministic.py -q`
- `uv run ruff check instructor/v2/auto_client.py tests/v2/test_auto_client_deterministic.py`
- `uv run ty check instructor/v2/auto_client.py tests/v2/test_auto_client_deterministic.py`
