### PR TITLE
fix(cache): include hoisted system prompt in the cache key

### DIFF
--- a/instructor/cache/__init__.py
+++ b/instructor/cache/__init__.py
@@ -148,6 +148,7 @@ def make_cache_key(
     model: str | None,
     response_model: type[BaseModel] | None,
     mode: str | None = None,
+    system: Any = None,
 ) -> str:  # noqa: ANN401
     """Compute a *deterministic* cache key.
 
@@ -157,6 +158,10 @@ def make_cache_key(
     Components that influence the key:
         • provider/model name
         • serialized *messages* (user + system prompt, etc.)
+        • *system* – providers such as Anthropic and Bedrock hoist system
+          messages out of ``messages`` into a separate top-level parameter,
+          so it has to be hashed separately or two calls that only differ in
+          their system prompt would collide.
         • *mode* (Tools, JSON, …) – helps when users change Instructor mode
         • *response_model* schema – so edits to field definitions or
           descriptions invalidate prior cache entries (critical!).
@@ -167,6 +172,11 @@ def make_cache_key(
         "messages": messages,
         "mode": mode,
     }
+
+    # Only added when present so keys for providers that keep the system
+    # prompt inside ``messages`` (OpenAI & friends) stay unchanged.
+    if system is not None:
+        payload["system"] = system
 
     if response_model is not None:
         # Include the entire JSON schema – guarantees busting when either

--- a/instructor/v2/core/patch.py
+++ b/instructor/v2/core/patch.py
@@ -255,6 +255,7 @@ def _create_sync_wrapper(
                     model=new_kwargs.get("model"),
                     response_model=response_model,
                     mode=str(mode.value),
+                    system=new_kwargs.get("system"),
                 )
                 cached = load_cached_response(cache, key, response_model)
                 if cached is not None:
@@ -295,6 +296,7 @@ def _create_sync_wrapper(
                         model=new_kwargs.get("model"),
                         response_model=response_model,
                         mode=str(mode.value),
+                        system=new_kwargs.get("system"),
                     )
                     store_cached_response(cache, key, response, ttl=cache_ttl)
             except ModuleNotFoundError:
@@ -378,6 +380,7 @@ def _create_async_wrapper(
                     model=new_kwargs.get("model"),
                     response_model=response_model,
                     mode=str(mode.value),
+                    system=new_kwargs.get("system"),
                 )
                 cached = load_cached_response(cache, key, response_model)
                 if cached is not None:
@@ -418,6 +421,7 @@ def _create_async_wrapper(
                         model=new_kwargs.get("model"),
                         response_model=response_model,
                         mode=str(mode.value),
+                        system=new_kwargs.get("system"),
                     )
                     store_cached_response(cache, key, response, ttl=cache_ttl)
             except ModuleNotFoundError:

--- a/tests/cache/test_cache_integration.py
+++ b/tests/cache/test_cache_integration.py
@@ -101,3 +101,68 @@ def test_auto_cache_prevents_duplicate_calls_after_a_retry(monkeypatch):
     assert call_counter["n"] == 2, (
         "Second, identical call should hit the cache instead of calling the provider again"
     )
+
+
+def test_cache_key_accounts_for_hoisted_system_prompt():
+    """Regression test: a system prompt hoisted out of ``messages`` must be hashed.
+
+    Providers like Anthropic and Bedrock move ``role="system"`` messages out of
+    ``messages`` into a separate top-level ``system`` parameter during request
+    preparation, which happens *before* patch.py computes the cache key. If the
+    key only hashes the remaining ``messages``, two calls that differ solely in
+    their system prompt collide and the second silently returns the first
+    call's answer.
+    """
+    import anthropic
+    from anthropic.types import Message, TextBlock, Usage
+
+    class Answer(BaseModel):
+        value: str
+
+    call_counter = {"n": 0}
+
+    def fake_create(*_args, **_kwargs):
+        call_counter["n"] += 1
+        content = Answer(value=f"call-{call_counter['n']}").model_dump_json()
+        return Message(
+            id="msg_1",
+            model="claude-3-5-sonnet-latest",
+            role="assistant",
+            type="message",
+            stop_reason="end_turn",
+            content=[TextBlock(type="text", text=content)],
+            usage=Usage(input_tokens=1, output_tokens=1),
+        )
+
+    raw_client = anthropic.Anthropic(api_key="sk-not-used")
+    raw_client.messages.create = fake_create
+    client = instructor.from_anthropic(raw_client, mode=instructor.Mode.JSON)
+
+    cache = AutoCache(maxsize=10)
+
+    def ask(system_prompt: str) -> Answer:
+        return client.create(
+            model="claude-3-5-sonnet-latest",
+            max_tokens=100,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": "hello"},
+            ],
+            response_model=Answer,
+            cache=cache,
+        )
+
+    first = ask("Always answer in French.")
+    assert call_counter["n"] == 1
+    assert first.value == "call-1"
+
+    second = ask("Always answer in German.")
+    assert call_counter["n"] == 2, (
+        "A different system prompt must not reuse the cached response"
+    )
+    assert second.value == "call-2"
+
+    # Repeating the very first request must still hit the cache.
+    repeat = ask("Always answer in French.")
+    assert call_counter["n"] == 2, "Identical request should still be served from cache"
+    assert repeat.value == "call-1"

--- a/tests/cache/test_cache_integration.py
+++ b/tests/cache/test_cache_integration.py
@@ -135,7 +135,7 @@ def test_cache_key_accounts_for_hoisted_system_prompt():
         )
 
     raw_client = anthropic.Anthropic(api_key="sk-not-used")
-    raw_client.messages.create = fake_create
+    raw_client.messages.create = fake_create  # ty: ignore[invalid-assignment]
     client = instructor.from_anthropic(raw_client, mode=instructor.Mode.JSON)
 
     cache = AutoCache(maxsize=10)

--- a/tests/cache/test_cache_key.py
+++ b/tests/cache/test_cache_key.py
@@ -59,3 +59,29 @@ def test_cache_key_changes_on_docstring_change():
     k1 = make_cache_key(messages=messages, model=model_name, response_model=UserDoc1)
     k2 = make_cache_key(messages=messages, model=model_name, response_model=UserDoc2)
     assert k1 != k2, "Changing class docstring should bust the cache key"
+
+
+def test_cache_key_changes_on_system_prompt_change():
+    k1 = make_cache_key(
+        messages=messages,
+        model=model_name,
+        response_model=UserV1,
+        system="Always answer in French.",
+    )
+    k2 = make_cache_key(
+        messages=messages,
+        model=model_name,
+        response_model=UserV1,
+        system="Always answer in German.",
+    )
+    assert k1 != k2, "Changing the hoisted system prompt should bust the cache key"
+
+
+def test_cache_key_unchanged_when_no_system_prompt():
+    without = make_cache_key(messages=messages, model=model_name, response_model=UserV1)
+    explicit_none = make_cache_key(
+        messages=messages, model=model_name, response_model=UserV1, system=None
+    )
+    assert without == explicit_none, (
+        "Keys must stay stable for providers without a hoisted system prompt"
+    )


### PR DESCRIPTION
With `cache=` enabled on an Anthropic (or Bedrock) client, two calls that differ only in their system prompt hit the same cache entry, so the second one silently returns the first one's answer:

```python
client = instructor.from_anthropic(anthropic.Anthropic(), mode=instructor.Mode.JSON)
cache = AutoCache(maxsize=10)

def ask(system):
    return client.create(
        model="claude-3-5-sonnet-latest",
        max_tokens=100,
        messages=[
            {"role": "system", "content": system},
            {"role": "user", "content": "hello"},
        ],
        response_model=Answer,
        cache=cache,
    )

ask("Always answer in French.")   # provider called
ask("Always answer in German.")   # provider NOT called - returns the French answer
```

## Root cause

The Anthropic and Bedrock request handlers hoist `role="system"` messages out of `messages` into a separate top-level `system` parameter (`anthropic/handlers.py:346-352`, `bedrock/handlers.py:387`). `patch.py` computes the cache key *after* the request handler runs, and `make_cache_key` only hashes `messages` / `contents` / `chat_history` — so the system prompt is not part of the key at all for those providers.

OpenAI-style providers keep the system message inside `messages`, which is why this never showed up there. The docstring on `make_cache_key` and the cache-key table in `docs/concepts/caching.md` both claim the system prompt is covered, so the current behaviour also contradicts the documented contract.

## Fix

`make_cache_key` takes an optional `system` argument and adds it to the hashed payload only when it is not `None`. `patch.py` passes `new_kwargs.get("system")` at the four call sites (sync/async x lookup/store). Because the field is omitted when absent, keys for providers that keep the system prompt in `messages` are byte-identical to before, so no existing cache is invalidated by this change.

`system` is stable across the retry loop — the Anthropic reask handlers only append to `messages` — so the lookup key and the store key still agree after a reask (the case #2457 fixed).

## Tests

- `tests/cache/test_cache_integration.py::test_cache_key_accounts_for_hoisted_system_prompt` — end-to-end through the patch layer with a stubbed `messages.create`, no API key needed. Asserts a different system prompt calls the provider again, and that repeating the original request still hits the cache.
- `tests/cache/test_cache_key.py` — two unit tests: a changed system prompt busts the key, and passing `system=None` produces the same key as omitting it (backwards compatibility).

Before the fix:

```
        second = ask("Always answer in German.")
>       assert call_counter["n"] == 2, (
            "A different system prompt must not reuse the cached response"
        )
E       AssertionError: A different system prompt must not reuse the cached response
E       assert 1 == 2
```

After: `9 passed` for `tests/cache/`.

Note: the `genai`/`gemini` handlers put the system prompt inside a nested `config` object rather than a top-level kwarg, so they are not covered by this change — happy to follow up separately if you want that hashed too.
