### PR TITLE
fix(core): normalize remote media types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Remote multimodal media types**: Accept valid case-insensitive HTTP `Content-Type` values with optional parameters when loading images, audio, and PDFs. ([#2525](https://github.com/567-labs/instructor/pull/2525))
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/v2/core/multimodal.py
+++ b/instructor/v2/core/multimodal.py
@@ -50,6 +50,13 @@ CacheControlType = Mapping[str, str]
 OptionalCacheControlType = Optional[CacheControlType]
 
 
+def _normalize_media_type(media_type: str | None) -> str | None:
+    """Return the lowercase media type without optional HTTP parameters."""
+    if media_type is None:
+        return None
+    return media_type.split(";", 1)[0].strip().lower()
+
+
 class ImageParamsBase(TypedDict):
     type: Literal["image"]
     source: str
@@ -151,7 +158,7 @@ class Image(BaseModel):
         try:
             response = requests.get(public_url, timeout=timeout)
             response.raise_for_status()
-            media_type = response.headers.get("Content-Type")
+            media_type = _normalize_media_type(response.headers.get("Content-Type"))
             if media_type not in VALID_MIME_TYPES:
                 raise ValueError(f"Unsupported image format: {media_type}")
 
@@ -204,7 +211,7 @@ class Image(BaseModel):
         if not media_type:
             try:
                 response = requests.head(url, allow_redirects=True, timeout=30)
-                media_type = response.headers.get("Content-Type")
+                media_type = _normalize_media_type(response.headers.get("Content-Type"))
             except requests.RequestException as e:
                 raise ValueError(f"Failed to fetch image from URL") from e
 
@@ -325,7 +332,7 @@ class Audio(BaseModel):
         if url.startswith("gs://"):
             return cls.from_gs_url(url)
         response = requests.get(url, timeout=30)
-        content_type = response.headers.get("content-type")
+        content_type = _normalize_media_type(response.headers.get("content-type"))
         if content_type not in VALID_AUDIO_MIME_TYPES:
             raise ValueError(
                 f"Unsupported audio format: {content_type}. "
@@ -381,7 +388,7 @@ class Audio(BaseModel):
         try:
             response = requests.get(public_url, timeout=timeout)
             response.raise_for_status()
-            media_type = response.headers.get("Content-Type")
+            media_type = _normalize_media_type(response.headers.get("Content-Type"))
             if media_type not in VALID_AUDIO_MIME_TYPES:
                 raise ValueError(f"Unsupported audio format: {media_type}")
 
@@ -569,7 +576,9 @@ class PDF(BaseModel):
         try:
             response = requests.get(public_url, timeout=timeout)
             response.raise_for_status()
-            media_type = response.headers.get("Content-Type", "application/pdf")
+            media_type = _normalize_media_type(
+                response.headers.get("Content-Type", "application/pdf")
+            )
             if media_type not in VALID_PDF_MIME_TYPES:
                 raise ValueError(f"Unsupported PDF format: {media_type}")
 
@@ -592,7 +601,7 @@ class PDF(BaseModel):
         if not media_type:
             try:
                 response = requests.head(url, allow_redirects=True, timeout=30)
-                media_type = response.headers.get("Content-Type")
+                media_type = _normalize_media_type(response.headers.get("Content-Type"))
             except requests.RequestException as e:
                 raise ValueError("Failed to fetch PDF from URL") from e
 

--- a/tests/coverage/test_core_multimodal_coverage.py
+++ b/tests/coverage/test_core_multimodal_coverage.py
@@ -104,6 +104,28 @@ def test_image_url_errors_missing_path_and_unsupported_data_uri(
         Image.from_base64("data:image/tiff;base64,aW1hZ2U=")
 
 
+def test_remote_media_types_ignore_http_parameters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def head(url: str, **_kwargs: Any) -> requests.Response:
+        media_type = "image/png" if "photo" in url else "application/pdf"
+        return response(b"", f"{media_type}; charset=binary")
+
+    def get(_url: str, **_kwargs: Any) -> requests.Response:
+        return response(b"audio", "Audio/WAV; codecs=1")
+
+    monkeypatch.setattr(requests, "head", head)
+    monkeypatch.setattr(requests, "get", get)
+
+    image = Image.from_url("https://example.test/photo")
+    audio = Audio.from_url("https://example.test/audio")
+    pdf = PDF.from_url("https://example.test/report")
+
+    assert image.media_type == "image/png"
+    assert audio.media_type == "audio/wav"
+    assert pdf.media_type == "application/pdf"
+
+
 def test_image_path_probe_falls_back_to_raw_base64(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What

Normalize remote `Content-Type` headers before validating image, audio, and PDF media types.

## Why

HTTP media types are case-insensitive and may include optional parameters. Valid responses such as `application/pdf; charset=binary` or `Audio/WAV; codecs=1` were rejected because the complete header value was compared against the allowlist.

## Changes

- centralize media-type normalization in the v2 multimodal core
- strip optional parameters, surrounding whitespace, and casing differences
- apply the normalized value to HTTP and GCS image, audio, and PDF sources
- add deterministic regression coverage for all three media categories

## Testing

- `uv run pytest tests/coverage/test_core_multimodal_coverage.py -q` (28 passed)
- `uv run ruff check instructor/v2/core/multimodal.py tests/coverage/test_core_multimodal_coverage.py`
- `uv run ruff format --check instructor/v2/core/multimodal.py tests/coverage/test_core_multimodal_coverage.py`
- `uv run ty check instructor/v2/core/multimodal.py tests/coverage/test_core_multimodal_coverage.py`
- `git diff --check`
