### PR TITLE
fix(messages): preserve tool-call protocol fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Message history**: Preserve tool-call and other protocol fields when normalizing consecutive messages, and keep protocol messages as separate turns. ([#2527](https://github.com/567-labs/instructor/pull/2527))
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -70,6 +70,7 @@ def dump_message(message: ChatCompletionMessage) -> ChatCompletionMessageParam:
 
 
 def merge_consecutive_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Merge adjacent plain messages without crossing protocol boundaries."""
     if not messages:
         return []
 
@@ -89,12 +90,18 @@ def merge_consecutive_messages(messages: list[dict[str, Any]]) -> list[dict[str,
     for message in messages:
         role = message.get("role", "user")
         new_content = message.get("content", "")
+        is_plain_message = set(message).issubset({"role", "content"})
         if new_content is None:
             new_content = ""
         if not flat_string and isinstance(new_content, str):
             new_content = [{"type": "text", "text": new_content}]
 
-        if new_messages and role == new_messages[-1]["role"]:
+        if (
+            new_messages
+            and role == new_messages[-1]["role"]
+            and is_plain_message
+            and set(new_messages[-1]).issubset({"role", "content"})
+        ):
             if flat_string:
                 new_messages[-1]["content"] += f"\n\n{new_content}"
             elif isinstance(new_content, list):
@@ -102,7 +109,9 @@ def merge_consecutive_messages(messages: list[dict[str, Any]]) -> list[dict[str,
             else:
                 new_messages[-1]["content"].append(new_content)
         else:
-            new_messages.append({"role": role, "content": new_content})
+            new_message = dict(message)
+            new_message.update(role=role, content=new_content)
+            new_messages.append(new_message)
 
     return new_messages
 

--- a/tests/processing/test_message_processing.py
+++ b/tests/processing/test_message_processing.py
@@ -105,9 +105,37 @@ class TestMergeConsecutiveMessages:
             },
         ]
         result = merge_consecutive_messages(messages)
-        assert len(result) == 2
+        assert len(result) == 3
         assert result[0]["role"] == "user"
         assert result[1]["role"] == "assistant"
+        assert result[1]["tool_calls"] == [{"id": "call_1"}]
+        assert result[2]["tool_calls"] == [{"id": "call_2"}]
+
+    def test_tool_call_fields_are_preserved(self):
+        """Tool-call history must keep the fields that link calls to results."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": "result",
+                "tool_call_id": "call_1",
+            },
+        ]
+
+        result = merge_consecutive_messages(messages)
+
+        assert result[0]["tool_calls"] == messages[0]["tool_calls"]
+        assert result[1]["tool_call_id"] == "call_1"
 
 
 class TestGetMessageContent:


### PR DESCRIPTION
## Describe your changes

`merge_consecutive_messages()` rebuilt every message from only `role` and `content`. That silently removed protocol fields such as `tool_calls`, `tool_call_id`, `name`, and `function_call`, even when the message was not merged.

This change:
- merges only adjacent plain `role`/`content` messages;
- treats messages with protocol metadata as boundaries and preserves all their fields;
- keeps the existing string/list content normalization behavior;
- adds regression coverage for consecutive assistant tool calls and linked tool results;
- documents the fix in the changelog.

## Issue ticket number and link

Fixes #2526

## Validation

- `pytest` across message processing and affected OpenAI-compatible/Mistral handler suites: 215 passed, 1 skipped
- `ruff check` and `ruff format --check` on changed Python files
- `ty check` on changed Python files
- `git diff --check`
- manual behavior matrix covering plain merges, alternating roles, consecutive tool-call messages, tool results, and input immutability

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.

AI assistance was used for issue reproduction, implementation review, and test planning; all code paths and test outputs were manually verified.