### PR TITLE
fix: count canceled and expired requests in Anthropic batch total

### DIFF
--- a/instructor/batch/models.py
+++ b/instructor/batch/models.py
@@ -268,7 +268,9 @@ class BatchJobInfo(BaseModel):
             expired=request_counts_data.get("expired"),
             total=request_counts_data.get("processing", 0)
             + request_counts_data.get("succeeded", 0)
-            + request_counts_data.get("errored", 0),
+            + request_counts_data.get("errored", 0)
+            + request_counts_data.get("canceled", 0)
+            + request_counts_data.get("expired", 0),
         )
 
         # Parse files

--- a/tests/test_batch_in_memory.py
+++ b/tests/test_batch_in_memory.py
@@ -225,3 +225,27 @@ class TestProviderInMemorySupport:
             anthropic_provider.submit_batch(
                 123  # ty: ignore[invalid-argument-type] - deliberately invalid input
             )
+
+
+def test_from_anthropic_total_counts_all_buckets():
+    """total must include canceled and expired requests.
+
+    Anthropic returns five request_counts buckets. ``from_anthropic`` summed only
+    processing + succeeded + errored, silently dropping canceled and expired, so
+    the reported total undercounted the batch.
+    """
+    from instructor.batch.models import BatchJobInfo
+
+    data = {
+        "id": "msgbatch_1",
+        "processing_status": "ended",
+        "request_counts": {
+            "processing": 0,
+            "succeeded": 10,
+            "errored": 2,
+            "canceled": 3,
+            "expired": 5,
+        },
+    }
+    rc = BatchJobInfo.from_anthropic(data).request_counts
+    assert rc.total == 20


### PR DESCRIPTION
## Problem

`BatchJobInfo.from_anthropic` undercounts `request_counts.total`. Anthropic's
Message Batches API returns five buckets (processing, succeeded, errored,
canceled, expired), and `from_anthropic` already reads `canceled`/`expired` into
the model fields, but the `total` only sums the first three:

```python
from instructor.batch.models import BatchJobInfo
data = {"id": "msgbatch_1", "processing_status": "ended",
        "request_counts": {"processing": 0, "succeeded": 10, "errored": 2,
                           "canceled": 3, "expired": 5}}
rc = BatchJobInfo.from_anthropic(data).request_counts
rc.total    # -> 12, but the batch holds 20 requests
```

Any batch with canceled or expired requests reports a `total` smaller than the
number submitted. The OpenAI path (`from_openai`) reads `total` straight from the
API, so `total` is meant to be the true count of all requests.

## Fix

Add the `canceled` and `expired` buckets to the sum. `BatchRequestCounts` is
documented as "Unified request counts across providers", so the two paths now
agree.

## Test

Added `test_from_anthropic_total_counts_all_buckets` in
`tests/test_batch_in_memory.py`, which asserts `total == 20` for the example
above. It fails before this change (returns 12) and passes after. `ruff check`
and `ruff format` are clean.
