### PR TITLE
fix(bedrock): reject unsupported structured-output constraints

### DIFF
--- a/instructor/v2/providers/bedrock/handlers.py
+++ b/instructor/v2/providers/bedrock/handlers.py
@@ -24,6 +24,13 @@ from instructor.v2.core.json import extract_json_from_codeblock
 def _prepare_bedrock_strict_schema(response_model: type[Any]) -> dict[str, Any]:
     """Return a Bedrock-compatible schema without mutating model-owned data."""
     schema = deepcopy(response_model.model_json_schema())
+    unsupported_constraints = {
+        "minimum",
+        "maximum",
+        "multipleOf",
+        "minLength",
+        "maxLength",
+    }
 
     def normalize(value: Any, path: str) -> None:
         if isinstance(value, list):
@@ -32,6 +39,13 @@ def _prepare_bedrock_strict_schema(response_model: type[Any]) -> dict[str, Any]:
             return
         if not isinstance(value, dict):
             return
+
+        if unsupported := unsupported_constraints.intersection(value):
+            constraint = sorted(unsupported)[0]
+            raise ConfigurationError(
+                "Bedrock native structured outputs do not support "
+                f"the `{constraint}` JSON Schema constraint at {path}."
+            )
 
         additional_properties = value.get("additionalProperties")
         if additional_properties is not None and additional_properties is not False:

--- a/tests/v2/test_bedrock_handlers.py
+++ b/tests/v2/test_bedrock_handlers.py
@@ -7,7 +7,7 @@ import json
 from typing import Any, cast
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from instructor import Mode, Provider
 from instructor.v2.core.errors import ConfigurationError
@@ -50,6 +50,12 @@ class FreeFormMetadata(BaseModel):
     """Model shape that Bedrock native structured outputs cannot represent."""
 
     metadata: dict[str, str]
+
+
+class ConstrainedScore(BaseModel):
+    """Model using a constraint unsupported by Bedrock structured outputs."""
+
+    score: int = Field(ge=0)
 
 
 def _bedrock_tool_response(
@@ -283,6 +289,18 @@ class TestBedrockNativeStructuredOutputs:
             handler.request_handler(
                 FreeFormMetadata,
                 {"messages": [{"role": "user", "content": "Extract metadata"}]},
+            )
+
+    @pytest.mark.parametrize("mode", [Mode.JSON_SCHEMA, Mode.TOOLS_STRICT])
+    def test_native_modes_reject_unsupported_schema_constraints(
+        self, mode: Mode
+    ) -> None:
+        handler = mode_registry.get_handlers(Provider.BEDROCK, mode)
+
+        with pytest.raises(ConfigurationError, match="minimum"):
+            handler.request_handler(
+                ConstrainedScore,
+                {"messages": [{"role": "user", "content": "Extract score"}]},
             )
 
     def test_json_schema_response_parses_text(self) -> None:


### PR DESCRIPTION
## Describe your changes

Bedrock native structured outputs reject JSON Schema numerical constraints (`minimum`, `maximum`, and `multipleOf`) and string-length constraints (`minLength` and `maxLength`). Pydantic emits these keywords for constrained fields, but Instructor currently forwards them to Bedrock, where the request fails remotely.

This change validates the generated schema recursively and raises a local `ConfigurationError` that identifies the unsupported keyword and its schema path. It covers both `JSON_SCHEMA` and `TOOLS_STRICT` modes with a regression test.

Validation:

- `uv run pytest tests/v2/test_bedrock_handlers.py -q` (22 passed)
- `uv run ruff check instructor/v2/providers/bedrock/handlers.py tests/v2/test_bedrock_handlers.py`
- `uv run ruff format --check instructor/v2/providers/bedrock/handlers.py tests/v2/test_bedrock_handlers.py`
- `uv run ty check instructor/v2/providers/bedrock/handlers.py tests/v2/test_bedrock_handlers.py`

## Issue ticket number and link

No issue; independently discovered regression in the recently added Bedrock native structured-output handling.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.
