### PR TITLE
fix(bedrock): preserve nested caller config

### DIFF
--- a/instructor/v2/providers/bedrock/handlers.py
+++ b/instructor/v2/providers/bedrock/handlers.py
@@ -324,10 +324,13 @@ def _prepare_bedrock_converse_kwargs_internal(
 
     if additional_model_request_fields:
         if "additionalModelRequestFields" in call_kwargs:
-            existing_additional_fields = call_kwargs["additionalModelRequestFields"]
+            existing_additional_fields = call_kwargs[
+                "additionalModelRequestFields"
+            ].copy()
             for key, value in additional_model_request_fields.items():
                 if key not in existing_additional_fields:
                     existing_additional_fields[key] = value
+            call_kwargs["additionalModelRequestFields"] = existing_additional_fields
         else:
             call_kwargs["additionalModelRequestFields"] = (
                 additional_model_request_fields
@@ -335,10 +338,11 @@ def _prepare_bedrock_converse_kwargs_internal(
 
     if inference_config_params:
         if "inferenceConfig" in call_kwargs:
-            existing_inference_config = call_kwargs["inferenceConfig"]
+            existing_inference_config = call_kwargs["inferenceConfig"].copy()
             for key, value in inference_config_params.items():
                 if key not in existing_inference_config:
                     existing_inference_config[key] = value
+            call_kwargs["inferenceConfig"] = existing_inference_config
         else:
             call_kwargs["inferenceConfig"] = inference_config_params
 

--- a/tests/v2/test_bedrock_handlers.py
+++ b/tests/v2/test_bedrock_handlers.py
@@ -112,6 +112,21 @@ class TestBedrockToolsHandler:
         assert "tools" in result_kwargs["toolConfig"]
         assert "toolChoice" in result_kwargs["toolConfig"]
 
+    def test_prepare_request_does_not_mutate_nested_config(self, handler):
+        """Preparing Bedrock kwargs treats nested caller config as read-only."""
+        kwargs = {
+            "messages": [{"role": "user", "content": "What is 2+2?"}],
+            "temperature": 0.2,
+            "top_k": 10,
+            "inferenceConfig": {"maxTokens": 100},
+            "additionalModelRequestFields": {"thinking": {"type": "enabled"}},
+        }
+        original = deepcopy(kwargs)
+
+        handler.request_handler(Answer, kwargs)
+
+        assert kwargs == original
+
     def test_parse_response_from_tool_use(self, handler):
         """parse_response extracts tool input."""
         response = _bedrock_tool_response({"answer": 4.0})


### PR DESCRIPTION
## Describe your changes

Bedrock request preparation shallow-copies the caller's keyword arguments, then merges normalized `temperature` and `top_k` values into existing nested `inferenceConfig` and `additionalModelRequestFields` dictionaries. That silently changes caller-owned configuration and can affect later retries or reused requests.

This copies the two nested dictionaries before merging and adds a regression test covering both paths.

Validation:

- `uv run pytest tests/v2/test_bedrock_handlers.py -q` (21 passed)
- `uv run ruff check instructor/v2/providers/bedrock/handlers.py tests/v2/test_bedrock_handlers.py`
- `uv run ruff format --check instructor/v2/providers/bedrock/handlers.py tests/v2/test_bedrock_handlers.py`
- `uv run ty check instructor/v2/providers/bedrock/handlers.py tests/v2/test_bedrock_handlers.py`

## Issue ticket number and link

No issue; independently discovered while reviewing Bedrock request normalization. Searches of open and closed issues and PRs found no report or competing fix for this mutation.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.
