### PR TITLE
fix(core): keep lazy modes registered while loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+
+- **v2 mode registry**: Keep lazily loaded modes registered while their handlers initialize, preventing concurrent first calls from failing spuriously. ([#2536](https://github.com/567-labs/instructor/pull/2536), [#2535](https://github.com/567-labs/instructor/issues/2535))
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/v2/core/registry.py
+++ b/instructor/v2/core/registry.py
@@ -188,11 +188,9 @@ class ModeRegistry:
         if mode_key in self._handlers:
             return self._handlers[mode_key]
 
-        # Try lazy loading. Locked because the pop -> import -> set sequence
-        # below is not atomic: without the lock, a thread that loses the race
-        # to pop self._lazy_loaders[mode_key] would find it already gone and
-        # self._handlers[mode_key] not yet set, and raise KeyError even
-        # though the mode genuinely is registered (just still resolving).
+        # Try lazy loading. Locked because resolving and publishing a loader is
+        # not atomic; without the lock, concurrent first callers could run it
+        # repeatedly.
         with self._lazy_load_lock:
             # Re-check: another thread may have finished loading this key
             # while we were waiting for the lock.
@@ -200,9 +198,10 @@ class ModeRegistry:
                 return self._handlers[mode_key]
 
             if mode_key in self._lazy_loaders:
-                loader = self._lazy_loaders.pop(mode_key)
+                loader = self._lazy_loaders[mode_key]
                 handlers = loader()
                 self._handlers[mode_key] = handlers
+                self._lazy_loaders.pop(mode_key, None)
                 return handlers
 
         raise KeyError(

--- a/tests/v2/test_registry.py
+++ b/tests/v2/test_registry.py
@@ -186,3 +186,36 @@ def test_get_handlers_concurrent_first_access_does_not_race():
     )
     # The loader must run exactly once, not once per racing thread.
     assert load_count == 1
+
+
+def test_registry_stays_registered_while_lazy_loader_runs():
+    """The mode remains registered while its lazy loader is in progress."""
+    import threading
+
+    from instructor.v2.core.registry import ModeHandlers, ModeRegistry
+
+    registry = ModeRegistry()
+    load_started = threading.Event()
+    finish_load = threading.Event()
+
+    def slow_loader() -> ModeHandlers:
+        load_started.set()
+        finish_load.wait(timeout=5)
+        return ModeHandlers(
+            request_handler=cast(Any, lambda *_a, **_k: None),
+            reask_handler=cast(Any, lambda *_a, **_k: None),
+            response_parser=cast(Any, lambda *_a, **_k: None),
+        )
+
+    registry.register_lazy(Provider.DEEPSEEK, Mode.TOOLS, slow_loader)
+    thread = threading.Thread(
+        target=registry.get_handlers, args=(Provider.DEEPSEEK, Mode.TOOLS)
+    )
+    thread.start()
+    assert load_started.wait(timeout=5)
+    try:
+        assert registry.is_registered(Provider.DEEPSEEK, Mode.TOOLS)
+    finally:
+        finish_load.set()
+        thread.join(timeout=5)
+    assert not thread.is_alive()


### PR DESCRIPTION
## Describe your changes

Keeps each lazy mode registered until its handlers are published, closing the window where concurrent `from_litellm` validation could raise `RegistryError`. Adds deterministic regression coverage and an Unreleased changelog entry.

## Issue ticket number and link

Fixes #2535

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. (Regression coverage added for this bug fix.)
- [x] If it is a core feature, I have added documentation. (N/A; this is a bug fix, and the changelog is updated.)