### PR TITLE
fix(validation): run declared async validators in the async retry loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Async validators**: Run the validators declared with `@async_field_validator` and `@async_model_validator`, including validators on nested models, after an async client parses a non-streaming response. Failures raise `AsyncValidationError` inside the retry loop so the existing reask path handles them, sync clients log a warning instead of silently skipping the validators, and both decorators are exported from the package root again. ([#2528](https://github.com/567-labs/instructor/issues/2528))
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/docs/concepts/reask_validation.md
+++ b/docs/concepts/reask_validation.md
@@ -275,6 +275,148 @@ In this example:
 
 For more advanced examples including multi-field validation and citation verification, check out our [exact citations example](../examples/exact_citations.md).
 
+### Async Validation
+
+Pydantic validators cannot await coroutines, so validation that needs a database
+query, an HTTP call, or another LLM request does not fit in `field_validator`.
+Instructor ships two decorators for that case: `async_field_validator` and
+`async_model_validator`. They run after the response parses and before the value
+is returned, so a failure is reasked like any other validation error.
+
+!!! warning "Async client required"
+
+    Async validators only run on an async client. On a sync client Instructor
+    logs a warning and skips them.
+
+Use `async_field_validator` to check one or more fields:
+
+```python
+import asyncio
+import instructor
+from instructor import async_field_validator
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+    occupation: str
+
+    @async_field_validator("name", "occupation")
+    async def must_be_uppercase(self, value: str) -> str:
+        await asyncio.sleep(0)  # stand-in for an async lookup
+        if not value.isupper():
+            raise ValueError(f"{value} must be uppercase")
+        return value
+
+
+client = instructor.from_provider("openai/gpt-4.1-mini", async_client=True)
+
+user = asyncio.run(
+    client.chat.completions.create(
+        response_model=User,
+        max_retries=2,
+        messages=[
+            {
+                "role": "user",
+                "content": "Ivan is a 27 year old software engineer",
+            }
+        ],
+    )
+)
+print(user)
+#> name='IVAN' occupation='SOFTWARE ENGINEER'
+```
+
+Use `async_model_validator` when the rule spans several fields. Validators on
+nested models run too, and every validator runs concurrently:
+
+```python
+import asyncio
+import instructor
+from instructor import async_model_validator
+from pydantic import BaseModel
+
+
+class Address(BaseModel):
+    city: str
+    country: str
+
+    @async_model_validator()
+    async def city_matches_country(self):
+        await asyncio.sleep(0)  # stand-in for an async lookup
+        if self.city == "Paris" and self.country != "France":
+            raise ValueError("Paris is in France")
+
+
+class User(BaseModel):
+    name: str
+    addresses: list[Address]
+
+
+client = instructor.from_provider("openai/gpt-4.1-mini", async_client=True)
+
+user = asyncio.run(
+    client.chat.completions.create(
+        response_model=User,
+        max_retries=2,
+        messages=[
+            {
+                "role": "user",
+                "content": "Ivan lives in Paris and in Berlin, Germany",
+            }
+        ],
+    )
+)
+print(user.addresses[0].country)
+#> France
+```
+
+Add an `info: ValidationInfo` parameter to either decorator to read the
+`context` you pass to `create()`:
+
+```python
+import asyncio
+import instructor
+from instructor import async_model_validator
+from pydantic import BaseModel, ValidationInfo
+
+
+class User(BaseModel):
+    name: str
+    occupation: str
+
+    @async_model_validator()
+    async def occupation_is_known(self, info: ValidationInfo):
+        await asyncio.sleep(0)  # stand-in for an async lookup
+        allowed = (info.context or {}).get("allowed_occupations", [])
+        if allowed and self.occupation not in allowed:
+            raise ValueError(f"occupation must be one of {allowed}")
+
+
+client = instructor.from_provider("openai/gpt-4.1-mini", async_client=True)
+
+user = asyncio.run(
+    client.chat.completions.create(
+        response_model=User,
+        max_retries=2,
+        context={"allowed_occupations": ["Engineer", "Barista"]},
+        messages=[
+            {
+                "role": "user",
+                "content": "Ivan is a 27 year old software engineer",
+            }
+        ],
+    )
+)
+print(user.occupation)
+#> Engineer
+```
+
+When a validator raises, Instructor collects every failure into a single
+`AsyncValidationError` that names the failing field path, then reasks the model
+with that message. If retries run out, the error is wrapped in
+`InstructorRetryException` like other validation failures.
+
 ## Optimizing Token usage
 
 Pydantic automatically includes a URL within the error message itself when an error is thrown so that users can learn more about the specific error that was thrown. Some users might want to remove this URL since it adds extra tokens that otherwise might not add much value to the validation process.

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -62,6 +62,8 @@ if TYPE_CHECKING:
     from .v2.providers.writer.client import from_writer as from_writer
     from .v2.providers.xai.client import from_xai as from_xai
     from .v2.validation import (
+        async_field_validator as async_field_validator,
+        async_model_validator as async_model_validator,
         llm_validator as llm_validator,
         openai_moderation as openai_moderation,
     )
@@ -104,6 +106,8 @@ __all__ = [
     "BatchJob",
     "llm_validator",
     "openai_moderation",
+    "async_field_validator",
+    "async_model_validator",
     "hooks",
     "v2",
 ]
@@ -138,6 +142,8 @@ _LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
     "generate_gemini_schema": (".v2.core.schema", "generate_gemini_schema"),
     "llm_validator": (".v2.validation", "llm_validator"),
     "openai_moderation": (".v2.validation", "openai_moderation"),
+    "async_field_validator": (".v2.validation", "async_field_validator"),
+    "async_model_validator": (".v2.validation", "async_model_validator"),
     "Provider": (".utils.providers", "Provider"),
     "from_provider": (".auto_client", "from_provider"),
     "BatchProcessor": (".batch", "BatchProcessor"),

--- a/instructor/v2/core/retry.py
+++ b/instructor/v2/core/retry.py
@@ -40,6 +40,10 @@ from instructor.v2.core.messages import extract_messages
 from instructor.v2.core.usage import has_compatible_usage, update_total_usage
 from instructor.v2.core.exceptions import RegistryValidationMixin
 from instructor.v2.core.registry import mode_registry
+from instructor.v2.validation.async_validators import (
+    async_validate_model,
+    has_async_validators,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -343,6 +347,12 @@ def retry_sync_v2(
                         stream=stream,
                         is_async=False,
                     )
+                    if not stream and has_async_validators(parsed):
+                        logger.warning(
+                            "Async validators are declared on the response model but "
+                            "cannot run in a synchronous client. Use an async client "
+                            "to run them."
+                        )
                     logger.debug(
                         f"Successfully parsed response on attempt "
                         f"{attempt.retry_state.attempt_number}"
@@ -636,6 +646,8 @@ async def retry_async_v2(
                         stream=stream,
                         is_async=True,
                     )
+                    if not stream:
+                        await async_validate_model(parsed, context)
                     logger.debug(
                         f"Successfully parsed response on attempt "
                         f"{attempt.retry_state.attempt_number}"

--- a/instructor/v2/validation/async_validators.py
+++ b/instructor/v2/validation/async_validators.py
@@ -1,13 +1,24 @@
 """Async validation decorators owned by the v2 runtime."""
 
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator, MutableMapping
 from inspect import signature
 from typing import Any, Callable, TypeVar
+from weakref import WeakKeyDictionary
 
-from pydantic import ValidationInfo
+from pydantic import BaseModel, ValidationInfo
+
+from instructor.v2.core.errors import AsyncValidationError
 
 ASYNC_VALIDATOR_KEY = "__async_validator__"
 ASYNC_MODEL_VALIDATOR_KEY = "__async_model_validator__"
 T = TypeVar("T", bound=Callable[..., Any])
+_DeclaredValidators = tuple[
+    list[tuple[tuple[str, ...], Callable[..., Any], bool]],
+    list[tuple[Callable[..., Any], bool]],
+]
 
 
 class AsyncValidationContext:
@@ -73,3 +84,129 @@ def async_model_validator() -> Callable[[T], T]:
         return func
 
     return decorator
+
+
+_DECLARED_VALIDATORS: MutableMapping[type[BaseModel], _DeclaredValidators] = (
+    WeakKeyDictionary()
+)
+
+
+def _declared_async_validators(model_class: type[BaseModel]) -> _DeclaredValidators:
+    """Collect the async field and model validators declared on a model class."""
+    cached = _DECLARED_VALIDATORS.get(model_class)
+    if cached is not None:
+        return cached
+
+    field_validators: list[tuple[tuple[str, ...], Callable[..., Any], bool]] = []
+    model_validators: list[tuple[Callable[..., Any], bool]] = []
+    seen: set[str] = set()
+
+    for klass in model_class.__mro__:
+        for name, attribute in vars(klass).items():
+            if name in seen:
+                continue
+            seen.add(name)
+            # Unwrap classmethod/staticmethod so the decorator metadata stays visible.
+            candidate = getattr(attribute, "__func__", attribute)
+            field_metadata = getattr(candidate, ASYNC_VALIDATOR_KEY, None)
+            if field_metadata is not None:
+                field_validators.append(field_metadata)
+                continue
+            model_metadata = getattr(candidate, ASYNC_MODEL_VALIDATOR_KEY, None)
+            if model_metadata is not None:
+                model_validators.append(model_metadata)
+
+    declared = (field_validators, model_validators)
+    _DECLARED_VALIDATORS[model_class] = declared
+    return declared
+
+
+def _iter_models(
+    value: Any,
+    path: tuple[str, ...] = (),
+    visited: set[int] | None = None,
+) -> Iterator[tuple[BaseModel, tuple[str, ...]]]:
+    """Yield every model reachable from ``value`` with its dotted field path."""
+    visited = set() if visited is None else visited
+
+    if isinstance(value, BaseModel):
+        if id(value) in visited:
+            return
+        visited.add(id(value))
+        yield value, path
+        for field_name in type(value).model_fields:
+            yield from _iter_models(
+                getattr(value, field_name, None), path + (field_name,), visited
+            )
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        for index, item in enumerate(value):
+            yield from _iter_models(item, path + (str(index),), visited)
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            yield from _iter_models(item, path + (str(key),), visited)
+
+
+def has_async_validators(value: Any) -> bool:
+    """Return whether ``value`` or any nested model declares async validators."""
+    for model, _ in _iter_models(value):
+        field_validators, model_validators = _declared_async_validators(type(model))
+        if field_validators or model_validators:
+            return True
+    return False
+
+
+async def _run_validator(
+    func: Callable[..., Any], args: tuple[Any, ...], location: tuple[str, ...]
+) -> ValueError | None:
+    try:
+        await func(*args)
+    except Exception as exception:
+        suffix = f" at {'.'.join(location)}" if location else ""
+        return ValueError(f"Exception of {exception} encountered{suffix}")
+    return None
+
+
+async def async_validate_model(
+    value: Any, validation_context: dict[str, Any] | None = None
+) -> None:
+    """Await the async validators declared on ``value`` and its nested models.
+
+    Validators run concurrently and every failure is collected, so a single
+    ``AsyncValidationError`` reports all of them. The retry loop treats that
+    error like any other validation failure and reasks the model.
+
+    Args:
+        value: A model, or a container of models, produced by a response parser.
+        validation_context: Context exposed to validators that declare an
+            ``info`` parameter, mirroring Pydantic's validation context.
+
+    Raises:
+        AsyncValidationError: If at least one async validator fails.
+        ValueError: If a field validator names a field the model does not define.
+    """
+    info = AsyncValidationContext(context=validation_context or {})
+    calls: list[tuple[Callable[..., Any], tuple[Any, ...], tuple[str, ...]]] = []
+
+    for model, path in _iter_models(value):
+        field_validators, model_validators = _declared_async_validators(type(model))
+        for fields, func, requires_info in field_validators:
+            for field in fields:
+                if field not in type(model).model_fields:
+                    raise ValueError(f"Invalid Field of {field} provided")
+                args: tuple[Any, ...] = (model, getattr(model, field))
+                if requires_info:
+                    args += (info,)
+                calls.append((func, args, path + (field,)))
+        for func, requires_info in model_validators:
+            args = (model, info) if requires_info else (model,)
+            calls.append((func, args, path))
+
+    if not calls:
+        return
+
+    results = await asyncio.gather(*(_run_validator(*call) for call in calls))
+    errors = [error for error in results if error is not None]
+    if errors:
+        error = AsyncValidationError(f"Validation errors: {errors}")
+        error.errors = errors
+        raise error

--- a/tests/core/test_async_validation.py
+++ b/tests/core/test_async_validation.py
@@ -1,0 +1,188 @@
+"""Tests that async validator decorators actually run inside the retry loop.
+
+Regression tests for issue #2528, where `@async_field_validator` and
+`@async_model_validator` attached metadata to a model but nothing ever awaited
+the validators.
+"""
+
+import logging
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from pydantic import BaseModel, ValidationInfo
+
+import instructor
+from instructor.core.exceptions import InstructorRetryException
+from instructor.mode import Mode
+from instructor.validation import (
+    AsyncValidationError,
+    async_field_validator,
+    async_model_validator,
+)
+
+
+def _make_response(content: str) -> Mock:
+    response = Mock()
+    response.choices = [Mock()]
+    response.choices[0].message = Mock()
+    response.choices[0].message.content = content
+    response.choices[0].finish_reason = "stop"
+    response.usage = None
+    return response
+
+
+def _make_async_client(content: str):
+    mock_client = Mock()
+    mock_client.chat = Mock()
+    mock_client.chat.completions = Mock()
+    mock_client.chat.completions.create = AsyncMock(
+        return_value=_make_response(content)
+    )
+    return instructor.patch(mock_client, mode=Mode.JSON)
+
+
+def _make_sync_client(content: str):
+    mock_client = Mock()
+    mock_client.chat = Mock()
+    mock_client.chat.completions = Mock()
+    mock_client.chat.completions.create = Mock(return_value=_make_response(content))
+    return instructor.patch(mock_client, mode=Mode.JSON)
+
+
+@pytest.mark.asyncio
+async def test_async_field_validator_runs_on_parsed_model():
+    validated: list[str] = []
+
+    class User(BaseModel):
+        name: str
+
+        @async_field_validator("name")
+        async def uppercase_name(self, value: str) -> str:
+            validated.append(value)
+            return value
+
+    client = _make_async_client('{"name": "JASON"}')
+
+    user = await client.chat.completions.create(  # ty: ignore[no-matching-overload] - runtime-patched API
+        model="gpt-4o-mini",
+        response_model=User,
+        messages=[{"role": "user", "content": "test"}],
+        max_retries=0,
+    )
+
+    assert user.name == "JASON"
+    assert validated == ["JASON"]
+
+
+@pytest.mark.asyncio
+async def test_async_model_validator_failure_is_retried_and_reported():
+    class User(BaseModel):
+        name: str
+
+        @async_model_validator()
+        async def name_must_be_uppercase(self):
+            if not self.name.isupper():
+                raise ValueError("name must be uppercase")
+
+    client = _make_async_client('{"name": "jason"}')
+
+    with pytest.raises(InstructorRetryException) as exc_info:
+        await client.chat.completions.create(  # ty: ignore[no-matching-overload] - runtime-patched API
+            model="gpt-4o-mini",
+            response_model=User,
+            messages=[{"role": "user", "content": "test"}],
+            max_retries=1,
+        )
+
+    exception = exc_info.value
+    assert exception.n_attempts == 2
+    assert exception.failed_attempts is not None
+    assert len(exception.failed_attempts) == 2
+    for attempt in exception.failed_attempts:
+        assert isinstance(attempt.exception, AsyncValidationError)
+        assert "name must be uppercase" in str(attempt.exception)
+
+
+@pytest.mark.asyncio
+async def test_async_validators_run_on_nested_models():
+    validated: list[str] = []
+
+    class Address(BaseModel):
+        city: str
+
+        @async_model_validator()
+        async def city_must_be_known(self):
+            validated.append(self.city)
+            if self.city == "Atlantis":
+                raise ValueError("unknown city")
+
+    class User(BaseModel):
+        name: str
+        addresses: list[Address]
+
+    client = _make_async_client(
+        '{"name": "Jason", "addresses": [{"city": "Singapore"}, {"city": "Atlantis"}]}'
+    )
+
+    with pytest.raises(InstructorRetryException) as exc_info:
+        await client.chat.completions.create(  # ty: ignore[no-matching-overload] - runtime-patched API
+            model="gpt-4o-mini",
+            response_model=User,
+            messages=[{"role": "user", "content": "test"}],
+            max_retries=0,
+        )
+
+    assert validated == ["Singapore", "Atlantis"]
+    assert "addresses.1" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_async_validators_receive_validation_context():
+    class User(BaseModel):
+        name: str
+
+        @async_field_validator("name")
+        async def name_is_allowed(self, value: str, info: ValidationInfo) -> str:
+            context = info.context or {}
+            if value in context.get("forbidden_names", []):
+                raise ValueError(f"{value} is forbidden")
+            return value
+
+    client = _make_async_client('{"name": "Jason"}')
+
+    with pytest.raises(InstructorRetryException) as exc_info:
+        await client.chat.completions.create(  # ty: ignore[no-matching-overload] - runtime-patched API
+            model="gpt-4o-mini",
+            response_model=User,
+            messages=[{"role": "user", "content": "test"}],
+            context={"forbidden_names": ["Jason"]},
+            max_retries=0,
+        )
+
+    assert "Jason is forbidden" in str(exc_info.value)
+
+
+def test_sync_client_warns_that_async_validators_are_skipped(
+    caplog: pytest.LogCaptureFixture,
+):
+    class User(BaseModel):
+        name: str
+
+        @async_model_validator()
+        async def name_must_be_uppercase(self):
+            raise ValueError("name must be uppercase")
+
+    client = _make_sync_client('{"name": "jason"}')
+
+    with caplog.at_level(logging.WARNING, logger="instructor.v2.retry"):
+        user = client.chat.completions.create(  # ty: ignore[no-matching-overload] - runtime-patched API
+            model="gpt-4o-mini",
+            response_model=User,
+            messages=[{"role": "user", "content": "test"}],
+            max_retries=0,
+        )
+
+    assert user.name == "jason"
+    assert any(
+        "async validators" in record.message.lower() for record in caplog.records
+    )

--- a/tests/core/test_async_validation.py
+++ b/tests/core/test_async_validation.py
@@ -21,6 +21,11 @@ from instructor.validation import (
 )
 
 
+def test_decorators_are_exported_from_the_package_root():
+    assert instructor.async_field_validator is async_field_validator
+    assert instructor.async_model_validator is async_model_validator
+
+
 def _make_response(content: str) -> Mock:
     response = Mock()
     response.choices = [Mock()]


### PR DESCRIPTION
Fixes #2528.

@async_model_validator and @async_field_validator only attached metadata and were never awaited. After an async client parses a non-streaming response, the retry loop now awaits those validators (including nested models). Failures become AsyncValidationError and go through the existing reask path. Sync clients log a warning instead of silently returning an unvalidated model.

tests/core/test_async_validation.py: 6 passed.