### PR TITLE
fix: copy messages in Perplexity prepare_request so reask does not mutate the caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **v2 Perplexity messages**: Copy the caller's `messages` list during Perplexity `MD_JSON` request preparation so a validation retry appends the reask turns to instructor's own list instead of the caller's. ([#2417](https://github.com/567-labs/instructor/issues/2417))
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/v2/providers/perplexity/handlers.py
+++ b/instructor/v2/providers/perplexity/handlers.py
@@ -60,6 +60,7 @@ class PerplexityMDJSONHandler(OpenAIMDJSONHandler):
         if response_model is None:
             return None, kwargs
         new_kwargs = kwargs.copy()
+        new_kwargs["messages"] = list(kwargs.get("messages", []))
         return handle_perplexity_json(response_model, new_kwargs)
 
     def handle_reask(

--- a/tests/v2/test_messages_not_mutated.py
+++ b/tests/v2/test_messages_not_mutated.py
@@ -20,10 +20,10 @@ The provider lists below are imported directly from the shared OpenAI-compat
 handler module so this test stays in sync with the source registrations
 rather than duplicating them.
 
-Independently-implemented handlers (Mistral, Cohere, Writer, xAI, OpenRouter)
-reproduce the same anti-pattern in their own provider-specific code and were
-previously tracked here as known-broken `xfail` cases. They are now fixed too
-and folded into `FIXED_PAIRS` below.
+Independently-implemented handlers (Mistral, Cohere, Writer, xAI, OpenRouter,
+Perplexity) reproduce the same anti-pattern in their own provider-specific
+code and were previously tracked here as known-broken `xfail` cases. They are
+now fixed too and folded into `FIXED_PAIRS` below.
 """
 
 from __future__ import annotations
@@ -82,6 +82,7 @@ FIXED_PAIRS: list[tuple[Provider, Mode]] = [
     (Provider.XAI, Mode.JSON_SCHEMA),
     (Provider.XAI, Mode.MD_JSON),
     (Provider.OPENROUTER, Mode.JSON_SCHEMA),
+    (Provider.PERPLEXITY, Mode.MD_JSON),
 ]
 
 
@@ -178,6 +179,7 @@ REASK_MUTATION_PAIRS: list[tuple[Provider, Mode]] = [
     (Provider.XAI, Mode.PARALLEL_TOOLS),
     (Provider.XAI, Mode.JSON_SCHEMA),
     (Provider.OPENROUTER, Mode.JSON_SCHEMA),
+    (Provider.PERPLEXITY, Mode.MD_JSON),
 ]
 
 


### PR DESCRIPTION
## Summary
The #2417 aliasing fix missed Perplexity: it registers its own \`MD_JSON\` handler instead of using \`OPENAI_COMPAT_PROVIDERS\`. \`prepare_request\` shallow-copied \`kwargs\` but not \`messages\`, so \`reask_perplexity_json\` \`.extend()\` appended retry turns onto the caller's list.

Copy the list the same way \`OpenRouterJSONSchemaHandler\` already does. Added Perplexity \`MD_JSON\` to the existing \`test_messages_not_mutated\` parametrizations.

## Test plan
- [x] \`uv run pytest tests/v2/test_messages_not_mutated.py -q\` → 68 passed
- [x] New Perplexity cases fail on current main (caller list gains assistant + correction turns) and pass after