### PR TITLE
fix(genai): copy contents in structured-outputs reask so retry does not mutate the caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **GenAI structured-output reask**: Copy the `contents` list before appending the validation error, so retries no longer mutate the caller's list, and handle a missing or non-list `contents` instead of raising `KeyError`. This matches the guard `reask_genai_tools` already had.
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/v2/providers/genai/handlers.py
+++ b/instructor/v2/providers/genai/handlers.py
@@ -19,14 +19,8 @@ from instructor.v2.dsl.simple_type import AdapterBase
 from instructor.v2.providers.gemini import utils as gemini_utils
 
 
-def reask_genai_tools(
-    kwargs: dict[str, Any],
-    response: Any,
-    exception: Exception,
-):
-    """Build a GenAI tool reask payload after validation failure."""
-    from google.genai import types
-
+def _copy_kwargs_with_contents(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Copy kwargs and its contents list so reasks never mutate the caller's list."""
     kwargs = kwargs.copy()
     existing_contents = kwargs.get("contents")
     if isinstance(existing_contents, list):
@@ -35,6 +29,18 @@ def reask_genai_tools(
         kwargs["contents"] = []
     else:
         kwargs["contents"] = list(existing_contents)
+    return kwargs
+
+
+def reask_genai_tools(
+    kwargs: dict[str, Any],
+    response: Any,
+    exception: Exception,
+):
+    """Build a GenAI tool reask payload after validation failure."""
+    from google.genai import types
+
+    kwargs = _copy_kwargs_with_contents(kwargs)
 
     model_content = None
     function_call_content = None
@@ -91,7 +97,7 @@ def reask_genai_structured_outputs(
     """Build a GenAI structured-output reask payload after validation failure."""
     from google.genai import types
 
-    kwargs = kwargs.copy()
+    kwargs = _copy_kwargs_with_contents(kwargs)
     genai_response = (
         response.text
         if response and hasattr(response, "text")

--- a/tests/test_genai_reask.py
+++ b/tests/test_genai_reask.py
@@ -6,6 +6,7 @@ pytest.importorskip("google.genai")
 
 from google.genai import types
 
+from instructor.v2.providers.genai.handlers import reask_genai_structured_outputs
 from instructor.v2.providers.gemini.utils import reask_genai_tools
 
 
@@ -82,3 +83,32 @@ def test_reask_genai_tools_falls_back_when_no_function_call():
 
     assert result["contents"][0] is model_content
     assert result["contents"][1].role == "user"
+
+
+def test_reask_genai_structured_outputs_does_not_mutate_caller_contents():
+    user_content = types.Content(
+        role="user", parts=[types.Part.from_text(text="hello")]
+    )
+    original_kwargs = {"contents": [user_content]}
+
+    result = reask_genai_structured_outputs(
+        kwargs=original_kwargs,
+        response=types.GenerateContentResponse(),
+        exception=Exception("boom"),
+    )
+
+    assert original_kwargs["contents"] == [user_content]
+    assert result["contents"][0] is user_content
+    assert len(result["contents"]) == 2
+    assert "boom" in result["contents"][-1].parts[0].text
+
+
+def test_reask_genai_structured_outputs_handles_missing_contents():
+    result = reask_genai_structured_outputs(
+        kwargs={},
+        response=None,
+        exception=Exception("boom"),
+    )
+
+    assert len(result["contents"]) == 1
+    assert "boom" in result["contents"][0].parts[0].text

--- a/tests/v2/test_genai_handlers_deterministic.py
+++ b/tests/v2/test_genai_handlers_deterministic.py
@@ -81,6 +81,24 @@ def test_reask_genai_structured_outputs_appends_model_content(
     assert '{"bad": true}' in result["contents"][-1].parts[0].text
 
 
+def test_structured_outputs_handler_reask_does_not_mutate_caller_contents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_genai_types(monkeypatch)
+    caller_contents = [FakeContent(role="user", parts=[FakePart(text="hi")])]
+    handler = GenAIStructuredOutputsHandler(mode=Mode.JSON)
+
+    result = handler.handle_reask(
+        {"contents": caller_contents},
+        SimpleNamespace(text='{"bad": true}'),
+        ValueError("bad json"),
+    )
+
+    assert len(caller_contents) == 1
+    assert result["contents"][:1] == caller_contents
+    assert len(result["contents"]) == 2
+
+
 def test_tools_handler_prepare_request_without_response_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
`reask_genai_structured_outputs` did a shallow `kwargs.copy()` then appended the validation-error turn onto `kwargs["contents"]`. The list is shared, so every retry mutated the caller's `contents`. Missing `contents` also raised `KeyError`.

`reask_genai_tools` already copied the list. Pulled that guard into `_copy_kwargs_with_contents` and used it in both reask builders.

Follow-up to #2538 (Perplexity `messages`) on the GenAI structured-outputs path.

## Test plan
- [x] New tests fail on current main and pass after
- [x] `uv run pytest tests/test_genai_reask.py tests/v2/test_genai_handlers_deterministic.py tests/coverage/test_genai_coverage.py tests/coverage/test_gemini_coverage.py -q` → 58 passed