### PR TITLE
fix(batch): parse OpenAI batch jobs when request_counts or metadata is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **OpenAI batch listing**: Keep `BatchJobInfo.from_openai()` working when the OpenAI SDK returns `request_counts` or `metadata` as `null`, which previously raised an error and made `list_batches()` fail for the whole page.
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 - **OpenAI batch listing**: Keep `BatchJobInfo.from_openai()` working when the OpenAI SDK returns `request_counts` or `metadata` as `null`, which previously raised an error and made `list_batches()` fail for the whole page.
+- **OpenAI batch errors**: Read batch-level failures from the `{"object": "list", "data": [...]}` shape the OpenAI Batch API returns, so `BatchJobInfo.error` carries the reported code and message instead of empty values.
 
 ## [1.16.0] - 2026-08-09
 

--- a/instructor/batch/models.py
+++ b/instructor/batch/models.py
@@ -195,8 +195,15 @@ class BatchJobInfo(BaseModel):
 
         # Parse error information
         error = None
-        if batch_data.get("errors"):
-            error_data = batch_data["errors"]
+        errors_data = batch_data.get("errors") or {}
+        if "data" in errors_data:
+            # OpenAI reports batch-level errors as {"object": "list", "data": [...]}
+            entries = errors_data["data"] or []
+            error_data = entries[0] if entries else None
+        else:
+            error_data = errors_data or None
+
+        if error_data:
             error = BatchErrorInfo(
                 error_type=error_data.get("type"),
                 error_message=error_data.get("message"),

--- a/instructor/batch/models.py
+++ b/instructor/batch/models.py
@@ -179,7 +179,7 @@ class BatchJobInfo(BaseModel):
         )
 
         # Parse request counts
-        request_counts_data = batch_data.get("request_counts", {})
+        request_counts_data = batch_data.get("request_counts") or {}
         request_counts = BatchRequestCounts(
             total=request_counts_data.get("total"),
             completed=request_counts_data.get("completed"),
@@ -212,7 +212,7 @@ class BatchJobInfo(BaseModel):
             request_counts=request_counts,
             files=files,
             error=error,
-            metadata=batch_data.get("metadata", {}),
+            metadata=batch_data.get("metadata") or {},
             raw_data=batch_data,
             endpoint=batch_data.get("endpoint"),
             completion_window=batch_data.get("completion_window"),

--- a/tests/coverage/test_batch_api_coverage.py
+++ b/tests/coverage/test_batch_api_coverage.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from openai.types import Batch as OpenAIBatch
 from pydantic import BaseModel
 
 from instructor.batch import (
@@ -295,6 +296,28 @@ def test_openai_batch_job_info_normalizes_status_timestamps_counts_and_error() -
     assert minimal.status is BatchStatus.PENDING
     assert minimal.timestamps == minimal.timestamps.__class__()
     assert minimal.error is None
+
+
+def test_openai_batch_job_info_accepts_unset_optional_sdk_fields() -> None:
+    payload = OpenAIBatch(
+        id="batch-validating",
+        completion_window="24h",
+        created_at=1_700_000_000,
+        endpoint="/v1/chat/completions",
+        input_file_id="file-input",
+        object="batch",
+        status="validating",
+    ).model_dump()
+
+    assert payload["request_counts"] is None
+    assert payload["metadata"] is None
+
+    result = BatchJobInfo.from_openai(payload)
+
+    assert result.status is BatchStatus.PENDING
+    assert result.request_counts == result.request_counts.__class__()
+    assert result.metadata == {}
+    assert result.error is None
 
 
 def test_anthropic_batch_job_info_accepts_timestamp_variants_and_counts() -> None:

--- a/tests/coverage/test_batch_api_coverage.py
+++ b/tests/coverage/test_batch_api_coverage.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 from openai.types import Batch as OpenAIBatch
+from openai.types.batch import BatchError as OpenAIBatchError
+from openai.types.batch import Errors as OpenAIBatchErrors
 from pydantic import BaseModel
 
 from instructor.batch import (
@@ -317,6 +319,55 @@ def test_openai_batch_job_info_accepts_unset_optional_sdk_fields() -> None:
     assert result.status is BatchStatus.PENDING
     assert result.request_counts == result.request_counts.__class__()
     assert result.metadata == {}
+    assert result.error is None
+
+
+def test_openai_batch_job_info_reads_error_list_payload() -> None:
+    payload = OpenAIBatch(
+        id="batch-failed",
+        completion_window="24h",
+        created_at=1_700_000_000,
+        endpoint="/v1/chat/completions",
+        input_file_id="file-input",
+        object="batch",
+        status="failed",
+        errors=OpenAIBatchErrors(
+            object="list",
+            data=[
+                OpenAIBatchError(
+                    code="invalid_json_line",
+                    message="Line 3 is not valid JSON.",
+                    line=3,
+                ),
+                OpenAIBatchError(
+                    code="missing_required_parameter",
+                    message="Line 5 is missing model.",
+                    line=5,
+                    param="model",
+                ),
+            ],
+        ),
+    ).model_dump()
+
+    result = BatchJobInfo.from_openai(payload)
+
+    assert result.error is not None
+    assert result.error.model_dump() == {
+        "error_type": None,
+        "error_message": "Line 3 is not valid JSON.",
+        "error_code": "invalid_json_line",
+    }
+
+
+def test_openai_batch_job_info_ignores_empty_error_list() -> None:
+    result = BatchJobInfo.from_openai(
+        {
+            "id": "batch-empty-errors",
+            "status": "completed",
+            "errors": {"object": "list", "data": []},
+        }
+    )
+
     assert result.error is None
 
 


### PR DESCRIPTION
## Summary
`BatchJobInfo.from_openai()` assumed `request_counts` and `metadata` were always dicts. The OpenAI SDK dumps them as `None` when optional fields are unset, so `dict.get(key, {})` returns `None` and listing batches raises `AttributeError`. One such job empties the whole CLI table.

Also parse the Batch API error list (`{"object":"list","data":[...]}`) instead of reading `type`/`message`/`code` off the outer object.

Distinct from #2529 (`from_anthropic` only).

## Test plan
- [x] New tests fail on current main and pass after
- [x] `python3 -m pytest tests/coverage/test_batch_api_coverage.py -q` → 17 passed