### PR TITLE
fix(bedrock): return a toolResult for every toolUse on reask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Bedrock parallel tool reask**: Return a `toolResult` for every `toolUse` block in the previous assistant turn instead of only the first one, so retries after a validation error no longer fail with a Converse 400 when the model emits parallel tool calls.
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/v2/providers/bedrock/handlers.py
+++ b/instructor/v2/providers/bedrock/handlers.py
@@ -108,14 +108,21 @@ def reask_bedrock_tools(
     assistant_message = response["output"]["message"]
     reask_msgs = [assistant_message]
 
-    tool_use_id = None
+    # Bedrock Converse requires a toolResult for *every* toolUse in the prior turn.
+    # Keeping only the first id drops results when the model emits parallel tool
+    # calls and makes the reask request fail with a 400.
+    tool_use_ids: list[str] = []
     if "content" in assistant_message:
         for content_block in assistant_message["content"]:
             if "toolUse" in content_block:
-                tool_use_id = content_block["toolUse"]["toolUseId"]
-                break
+                tool_use_ids.append(content_block["toolUse"]["toolUseId"])
 
-    if tool_use_id:
+    if tool_use_ids:
+        error_text = (
+            "Validation Error found:\n"
+            f"{exception}\n"
+            "Recall the function correctly, fix the errors"
+        )
         reask_msgs.append(
             {
                 "role": "user",
@@ -123,18 +130,11 @@ def reask_bedrock_tools(
                     {
                         "toolResult": {
                             "toolUseId": tool_use_id,
-                            "content": [
-                                {
-                                    "text": (
-                                        "Validation Error found:\n"
-                                        f"{exception}\n"
-                                        "Recall the function correctly, fix the errors"
-                                    )
-                                }
-                            ],
+                            "content": [{"text": error_text}],
                             "status": "error",
                         }
                     }
+                    for tool_use_id in tool_use_ids
                 ],
             }
         )

--- a/tests/coverage/test_bedrock_coverage.py
+++ b/tests/coverage/test_bedrock_coverage.py
@@ -188,6 +188,33 @@ def test_tools_reask_without_tool_invocation_adds_plain_correction() -> None:
     ]
 
 
+def test_tools_reask_returns_a_tool_result_for_every_tool_use() -> None:
+    original = {"messages": [{"role": "user", "content": [{"text": "extract"}]}]}
+    response = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"toolUse": {"toolUseId": "tool-1", "name": "Answer", "input": {}}},
+                    {"text": "thinking"},
+                    {"toolUse": {"toolUseId": "tool-2", "name": "Answer", "input": {}}},
+                ],
+            }
+        }
+    }
+
+    result = reask_bedrock_tools(original, response, ValueError("value is required"))
+
+    # Bedrock Converse requires a toolResult for *every* toolUse block in the
+    # previous assistant turn, otherwise the retry fails with a 400.
+    tool_results = result["messages"][-1]["content"]
+    assert [block["toolResult"]["toolUseId"] for block in tool_results] == [
+        "tool-1",
+        "tool-2",
+    ]
+    assert all(block["toolResult"]["status"] == "error" for block in tool_results)
+
+
 def test_tools_reask_without_content_adds_plain_correction() -> None:
     original = {"messages": [{"role": "user", "content": [{"text": "extract"}]}]}
     response = {"output": {"message": {"role": "assistant"}}}


### PR DESCRIPTION
## Summary
`reask_bedrock_tools` took the first `toolUseId` and broke. Bedrock Converse requires a `toolResult` for every `toolUse` in the previous assistant turn, so parallel tool calls made the retry a 400 and validation never reached the model.

Same bug Anthropic already fixed in #2485. Distinct from #2530 and #2532.

## Test plan
- [x] New test fails on current main (`['tool-1']` vs `['tool-1', 'tool-2']`) and passes after
- [x] `python3 -m pytest tests/coverage/test_bedrock_coverage.py -q` → 31 passed