### PR TITLE
fix(genai): keep OpenAI-style text blocks in the system instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **GenAI system messages**: Read `{"type": "text", "text": ...}` blocks from list-form system message content so those instructions reach `system_instruction` instead of being dropped. Previously only plain strings inside the list were kept, unlike `transform_to_gemini_prompt`, which already handled both shapes.
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -366,6 +366,10 @@ def extract_genai_system_message(
                     for item in message.get("content", []):
                         if isinstance(item, str):
                             system_messages += item + "\n\n"
+                        elif isinstance(item, dict) and item.get("type") == "text":
+                            text = item.get("text")
+                            if isinstance(text, str):
+                                system_messages += text + "\n\n"
 
     if system_messages and len(messages) == 1:
         raise ValueError(

--- a/tests/v2/test_gemini_utils_deterministic.py
+++ b/tests/v2/test_gemini_utils_deterministic.py
@@ -160,6 +160,35 @@ def test_extract_genai_system_message_validates_edge_cases() -> None:
     with pytest.raises(ValueError, match="At least one user message"):
         utils.extract_genai_system_message([{"role": "system", "content": "only"}])
 
+    assert (
+        utils.extract_genai_system_message(
+            [
+                {
+                    "role": "system",
+                    "content": [
+                        {"type": "text", "text": "be helpful"},
+                        {"type": "image_url", "image_url": {"url": "image.png"}},
+                        {"type": "text", "text": 42},
+                        {"type": "text", "text": "and brief"},
+                    ],
+                },
+                {"role": "user", "content": "hello"},
+            ]
+        )
+        == "be helpful\n\nand brief\n\n"
+    )
+
+    with pytest.raises(ValueError, match="Jinja templating"):
+        utils.extract_genai_system_message(
+            [
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": "Hello {{ name }}"}],
+                },
+                {"role": "user", "content": "hi"},
+            ]
+        )
+
     with pytest.raises(ValueError, match="Jinja templating"):
         utils.extract_genai_system_message(
             [


### PR DESCRIPTION
## Summary
`extract_genai_system_message` only kept plain-string items in list-form `content`. An OpenAI-style system message like `{"role":"system","content":[{"type":"text","text":"..."}]}` produced an empty string, so GenAI got no `system_instruction`. `convert_to_genai_messages` already skips `role == "system"`.

Read `{"type":"text","text":...}` blocks the same way the legacy Gemini path already does.

## Test plan
- [x] New assertions fail on current main (`''` vs the prompt) and pass after
- [x] `uv run pytest tests/v2/test_gemini_utils_deterministic.py tests/coverage/test_gemini_coverage.py -q` → 42 passed