### PR TITLE
fix: merge JSON schema instruction into the first text content part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **v2 system instructions**: Append the generated JSON schema instruction to the first text part of a structured system message instead of assuming the first part is text, so JSON and MD_JSON requests no longer raise `KeyError: 'text'` (or `IndexError`) for OpenAI-compatible, Mistral, Writer, and xAI handlers.
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -38,6 +38,39 @@ def copy_messages_for_mutation(messages: list[dict[str, Any]]) -> list[dict[str,
     return copied
 
 
+def merge_system_instruction(
+    messages: list[dict[str, Any]], instruction: str
+) -> list[dict[str, Any]]:
+    """Attach `instruction` to the leading system message, adding one if needed.
+
+    System content can be a list of parts, and the first part is not
+    necessarily text (an image or an audio part may come first), so the
+    instruction goes on the first text part and falls back to a new text part
+    when the list has none.
+
+    `messages` is mutated in place when it already starts with a system
+    message, so pass a list that is safe to edit (see
+    `copy_messages_for_mutation`).
+    """
+    if not messages or messages[0].get("role") != "system":
+        return [{"role": "system", "content": instruction}, *messages]
+
+    content = messages[0].get("content")
+    if isinstance(content, str):
+        messages[0]["content"] = f"{content}\n\n{instruction}"
+        return messages
+
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                part["text"] += f"\n\n{instruction}"
+                return messages
+        content.append({"type": "text", "text": instruction})
+        return messages
+
+    return [{"role": "system", "content": instruction}, *messages]
+
+
 def isolate_retry_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     """Copy request lists that reask handlers mutate during retries."""
     isolated = dict(kwargs)

--- a/instructor/v2/providers/mistral/handlers.py
+++ b/instructor/v2/providers/mistral/handlers.py
@@ -47,6 +47,7 @@ from instructor.v2.core.messages import (
     copy_messages_for_mutation,
     dump_message,
     merge_consecutive_messages,
+    merge_system_instruction,
 )
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.core.handler import ModeHandler
@@ -532,24 +533,7 @@ class MistralMDJSONHandler(MistralHandlerBase):
 
         # Add system message with schema
         messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
-        if messages and messages[0]["role"] != "system":
-            messages.insert(
-                0,
-                {
-                    "role": "system",
-                    "content": message,
-                },
-            )
-        elif messages and isinstance(messages[0]["content"], str):
-            messages[0]["content"] += f"\n\n{message}"
-        elif (
-            messages
-            and isinstance(messages[0]["content"], list)
-            and messages[0]["content"]
-        ):
-            messages[0]["content"][0]["text"] += f"\n\n{message}"
-        else:
-            messages.insert(0, {"role": "system", "content": message})
+        messages = merge_system_instruction(messages, message)
 
         # Add user message requesting JSON in code block
         messages.append(

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -45,6 +45,7 @@ from instructor.v2.core.messages import (
     copy_messages_for_mutation,
     dump_message,
     merge_consecutive_messages,
+    merge_system_instruction,
 )
 from instructor.v2.providers.openai.schema import generate_openai_schema
 from instructor.v2.core.decorators import register_mode_handler
@@ -877,20 +878,7 @@ class OpenAIJSONHandler(OpenAIHandlerBase):
             """
         )
         messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
-        if messages and messages[0]["role"] != "system":
-            messages.insert(
-                0,
-                {
-                    "role": "system",
-                    "content": message,
-                },
-            )
-        elif messages and isinstance(messages[0]["content"], str):
-            messages[0]["content"] += f"\n\n{message}"
-        elif messages and isinstance(messages[0]["content"], list):
-            messages[0]["content"][0]["text"] += f"\n\n{message}"
-        else:
-            messages.insert(0, {"role": "system", "content": message})
+        messages = merge_system_instruction(messages, message)
         new_kwargs["messages"] = merge_consecutive_messages(messages)
         return response_model, new_kwargs
 
@@ -965,20 +953,7 @@ class OpenAIMDJSONHandler(OpenAIHandlerBase):
 
         # Add system message with schema
         messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
-        if messages and messages[0]["role"] != "system":
-            messages.insert(
-                0,
-                {
-                    "role": "system",
-                    "content": message,
-                },
-            )
-        elif messages and isinstance(messages[0]["content"], str):
-            messages[0]["content"] += f"\n\n{message}"
-        elif messages and isinstance(messages[0]["content"], list):
-            messages[0]["content"][0]["text"] += f"\n\n{message}"
-        else:
-            messages.insert(0, {"role": "system", "content": message})
+        messages = merge_system_instruction(messages, message)
 
         # Add user message requesting JSON in code block
         messages.append(

--- a/instructor/v2/providers/writer/handlers.py
+++ b/instructor/v2/providers/writer/handlers.py
@@ -24,6 +24,7 @@ from instructor.v2.core.messages import (
     copy_messages_for_mutation,
     dump_message,
     merge_consecutive_messages,
+    merge_system_instruction,
 )
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.providers.openai.handlers import OpenAIHandlerBase
@@ -247,20 +248,7 @@ class WriterMDJSONHandler(WriterHandlerBase):
 
         # Add system message with schema
         messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
-        if messages and messages[0]["role"] != "system":
-            messages.insert(
-                0,
-                {
-                    "role": "system",
-                    "content": message,
-                },
-            )
-        elif messages and isinstance(messages[0]["content"], str):
-            messages[0]["content"] += f"\n\n{message}"
-        elif messages and isinstance(messages[0]["content"], list):
-            messages[0]["content"][0]["text"] += f"\n\n{message}"
-        else:
-            messages.insert(0, {"role": "system", "content": message})
+        messages = merge_system_instruction(messages, message)
 
         # Add user message requesting JSON in code block
         messages.append(

--- a/instructor/v2/providers/xai/handlers.py
+++ b/instructor/v2/providers/xai/handlers.py
@@ -52,7 +52,10 @@ from instructor.v2.core.json import (
 )
 from instructor.v2.core.decorators import register_mode_handler
 from instructor.v2.core.handler import ModeHandler
-from instructor.v2.core.messages import copy_messages_for_mutation
+from instructor.v2.core.messages import (
+    copy_messages_for_mutation,
+    merge_system_instruction,
+)
 
 
 def _convert_messages(messages: list[dict[str, Any]]) -> list[Any]:
@@ -708,24 +711,7 @@ class XAIMDJSONHandler(XAIHandlerBase):
 
         # Add system message with schema
         messages = copy_messages_for_mutation(new_kwargs.get("messages", []))
-        if messages and messages[0]["role"] != "system":
-            messages.insert(
-                0,
-                {
-                    "role": "system",
-                    "content": message,
-                },
-            )
-        elif messages and isinstance(messages[0]["content"], str):
-            messages[0]["content"] += f"\n\n{message}"
-        elif (
-            messages
-            and isinstance(messages[0]["content"], list)
-            and messages[0]["content"]
-        ):
-            messages[0]["content"][0]["text"] += f"\n\n{message}"
-        else:
-            messages.insert(0, {"role": "system", "content": message})
+        messages = merge_system_instruction(messages, message)
 
         # Add user message requesting JSON in code block
         messages.append(

--- a/tests/v2/test_system_instruction_merge.py
+++ b/tests/v2/test_system_instruction_merge.py
@@ -1,0 +1,143 @@
+"""Regression tests for merging the JSON schema instruction into a system message.
+
+JSON/MD_JSON handlers append their generated schema instruction to the leading
+system message. When that message carries structured content (a list of parts)
+the handlers used to write to `content[0]["text"]` unconditionally, which raised
+`KeyError: 'text'` for a system message that leads with a non-text part (an
+image, for example) and `IndexError` for an empty content list.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from instructor.v2.core.handler import ModeHandler
+from instructor.v2.core.messages import merge_system_instruction
+from instructor.v2.providers.mistral.handlers import MistralMDJSONHandler
+from instructor.v2.providers.openai.handlers import (
+    OpenAIJSONHandler,
+    OpenAIMDJSONHandler,
+)
+from instructor.v2.providers.writer.handlers import WriterMDJSONHandler
+from instructor.v2.providers.xai.handlers import XAIMDJSONHandler
+
+INSTRUCTION = "return json"
+
+
+class Answer(BaseModel):
+    name: str
+
+
+def test_merge_system_instruction_appends_to_string_content() -> None:
+    messages = merge_system_instruction(
+        [{"role": "system", "content": "be terse"}], INSTRUCTION
+    )
+
+    assert messages == [{"role": "system", "content": f"be terse\n\n{INSTRUCTION}"}]
+
+
+def test_merge_system_instruction_appends_to_first_text_part() -> None:
+    messages = merge_system_instruction(
+        [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "be terse"},
+                    {"type": "text", "text": "and polite"},
+                ],
+            }
+        ],
+        INSTRUCTION,
+    )
+
+    assert messages[0]["content"] == [
+        {"type": "text", "text": f"be terse\n\n{INSTRUCTION}"},
+        {"type": "text", "text": "and polite"},
+    ]
+
+
+def test_merge_system_instruction_skips_leading_non_text_part() -> None:
+    image_part = {"type": "image_url", "image_url": {"url": "https://x/y.png"}}
+    messages = merge_system_instruction(
+        [
+            {
+                "role": "system",
+                "content": [image_part, {"type": "text", "text": "be terse"}],
+            }
+        ],
+        INSTRUCTION,
+    )
+
+    assert messages[0]["content"] == [
+        image_part,
+        {"type": "text", "text": f"be terse\n\n{INSTRUCTION}"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "content",
+    [[], [{"type": "image_url", "image_url": {"url": "https://x/y.png"}}]],
+    ids=["empty", "image-only"],
+)
+def test_merge_system_instruction_adds_text_part_when_none_exists(
+    content: list[dict[str, Any]],
+) -> None:
+    messages = merge_system_instruction(
+        [{"role": "system", "content": list(content)}], INSTRUCTION
+    )
+
+    assert messages[0]["content"] == [*content, {"type": "text", "text": INSTRUCTION}]
+
+
+def test_merge_system_instruction_prepends_when_no_system_message() -> None:
+    user_message = {"role": "user", "content": "hi"}
+
+    messages = merge_system_instruction([user_message], INSTRUCTION)
+
+    assert messages == [{"role": "system", "content": INSTRUCTION}, user_message]
+
+
+def test_merge_system_instruction_prepends_for_unusable_content() -> None:
+    system_message = {"role": "system", "content": None}
+
+    messages = merge_system_instruction([system_message], INSTRUCTION)
+
+    assert messages == [{"role": "system", "content": INSTRUCTION}, system_message]
+
+
+@pytest.mark.parametrize(
+    "handler_cls",
+    [
+        OpenAIJSONHandler,
+        OpenAIMDJSONHandler,
+        MistralMDJSONHandler,
+        WriterMDJSONHandler,
+        XAIMDJSONHandler,
+    ],
+    ids=lambda handler_cls: handler_cls.__name__,
+)
+def test_prepare_request_handles_system_message_without_leading_text(
+    handler_cls: type[ModeHandler],
+) -> None:
+    image_part = {"type": "image_url", "image_url": {"url": "https://x/y.png"}}
+    kwargs: dict[str, Any] = {
+        "model": "test",
+        "messages": [
+            {"role": "system", "content": [image_part, {"type": "text", "text": "hi"}]},
+            {"role": "user", "content": "Ada"},
+        ],
+    }
+
+    _, new_kwargs = handler_cls().prepare_request(Answer, kwargs)
+
+    system_content = new_kwargs["messages"][0]["content"]
+    assert image_part in system_content
+    text_parts = [
+        part["text"]
+        for part in system_content
+        if isinstance(part, dict) and part.get("type") == "text"
+    ]
+    assert any("json_schema" in text for text in text_parts)


### PR DESCRIPTION
## Summary
JSON and MD_JSON handlers append the generated schema instruction to `messages[0]["content"][0]["text"]`. If the first content part is not text (an image) this raises `KeyError: 'text'`; an empty content list raises `IndexError`. Confirmed on 21 (provider, mode) handler pairs.

`merge_system_instruction()` now appends to the first text part, or adds a new text part when there is none. OpenAI, Mistral, Writer, and xAI handlers share that helper.

Distinct from #2542 (GenAI system text blocks).

## Test plan
- [x] New tests fail on current main and pass after
- [x] `uv run pytest tests/v2/test_system_instruction_merge.py -q` → 12 passed