### PR TITLE
fix: do not skip the next object when streamed JSON objects abut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Iterable streaming**: Keep the opening brace of the next object when two streamed objects arrive with no separator between them, so `create_iterable` no longer drops a task after a `}{` boundary.
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/v2/dsl/iterable.py
+++ b/instructor/v2/dsl/iterable.py
@@ -197,7 +197,13 @@ class IterableBase:
             elif c == "}":
                 stack -= 1
                 if stack == 0:
-                    return s[start_index : i + 1], s[i + 2 :]
+                    remainder = s[i + 1 :]
+                    # Only a comma is a separator worth consuming; dropping the
+                    # character unconditionally eats the `{` of the next object
+                    # when two objects arrive with nothing between them.
+                    if remainder.startswith(","):
+                        remainder = remainder[1:]
+                    return s[start_index : i + 1], remainder
         return None, s
 
 

--- a/tests/v2/test_iterable_streaming.py
+++ b/tests/v2/test_iterable_streaming.py
@@ -51,6 +51,30 @@ def test_iterable_get_object_handles_even_backslashes_before_quote() -> None:
     assert rest == '{"bio": "next"}'
 
 
+def test_iterable_get_object_keeps_next_object_when_objects_abut() -> None:
+    """`}` followed straight by `{` must not lose the second object's brace."""
+    obj, rest = IterableBase.get_object('{"bio": "first"}{"bio": "next"}', 0)
+
+    assert obj == '{"bio": "first"}'
+    assert rest == '{"bio": "next"}'
+
+
+def test_iterable_tasks_from_chunks_parses_objects_without_separators() -> None:
+    chunks = [
+        "[",
+        '{"name": "Alice", "bio": "first"}{"name": "Bob", "bio": "second"}',
+        "]",
+    ]
+
+    iterable_model = cast(Any, IterableModel(User))
+    users = list(iterable_model.tasks_from_chunks(chunks))
+
+    assert users == [
+        User(name="Alice", bio="first"),
+        User(name="Bob", bio="second"),
+    ]
+
+
 def test_iterable_tasks_from_chunks_handles_braces_inside_strings() -> None:
     chunks = [
         '{"tasks": [',


### PR DESCRIPTION
## Summary
`IterableBase.get_object` returned `s[i + 2:]` to skip the comma between array elements. When two streamed objects abut with nothing between them (`}{`), that skip eats the next object's opening brace and the item is silently dropped.

Consume the separator only when it is actually a comma. Existing `},{` / `}, {` cases stay the same.

## Test plan
- [x] New tests fail on current main and pass after
- [x] `uv run pytest tests/v2/test_iterable_streaming.py -q` → 11 passed