### PR TITLE
fix(gemini): stop MD_JSON prepare_request from mutating caller messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Gemini message handling**: Keep caller-owned `messages` unchanged during Gemini request preparation. `Mode.MD_JSON` injected its JSON schema instruction directly into the caller's list and system message dict, and the prompt conversion hoisted the system prompt into the caller's own content list, so a single successful call with no retry left both altered. ([#2417](https://github.com/567-labs/instructor/issues/2417))
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -108,10 +108,16 @@ def merge_consecutive_messages(messages: list[dict[str, Any]]) -> list[dict[str,
 
 
 def get_message_content(message: ChatCompletionMessageParam) -> list[Any]:
-    """Return message content in list form for Gemini-style APIs."""
+    """Return message content in list form for Gemini-style APIs.
+
+    The returned list is always a new object. Callers treat it as their own
+    `parts` list and insert into it (see `transform_to_gemini_prompt` hoisting
+    the system prompt), which would otherwise splice into the caller's own
+    message content.
+    """
     if not message:
         return [""]
     content = message.get("content", "")
     if isinstance(content, list):
-        return content if content else [""]
+        return list(content) if content else [""]
     return [content if content is not None else ""]

--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -14,7 +14,10 @@ from pydantic import BaseModel
 from instructor.v2.dsl.partial import Partial, PartialBase
 from instructor.v2.core.errors import ConfigurationError
 from instructor.v2.core.multimodal import Audio, Image, PDF
-from instructor.v2.core.messages import get_message_content
+from instructor.v2.core.messages import (
+    copy_messages_for_mutation,
+    get_message_content,
+)
 
 if TYPE_CHECKING:
     from google.genai.types import Content as GenAIContent
@@ -508,11 +511,10 @@ def handle_gemini_json(
         """
     )
 
-    messages = new_kwargs.get("messages") or []
+    messages = copy_messages_for_mutation(new_kwargs.get("messages") or [])
+    new_kwargs["messages"] = messages
     if not messages or messages[0].get("role") != "system":
-        new_kwargs.setdefault("messages", []).insert(
-            0, {"role": "system", "content": message}
-        )
+        messages.insert(0, {"role": "system", "content": message})
     else:
         messages[0]["content"] += f"\n\n{message}"
 

--- a/tests/coverage/test_gemini_coverage.py
+++ b/tests/coverage/test_gemini_coverage.py
@@ -385,9 +385,11 @@ def test_gemini_handlers_prepare_expected_tool_and_json_requests(
     }
     assert json_model is Answer
     assert json_request["generation_config"]["response_mime_type"] == "application/json"
-    assert original["messages"][0]["role"] == "system"
-    assert "json_schema" in original["messages"][0]["content"]
-    assert original["messages"][1] == {"role": "user", "content": "extract 4"}
+    # The schema instruction is hoisted into the outgoing Gemini contents, and
+    # the caller's own `messages` stays exactly as it was passed in.
+    assert "json_schema" in json_request["contents"][0]["parts"][0]
+    assert json_request["contents"][0]["parts"][1] == "extract 4"
+    assert original == {"messages": [{"role": "user", "content": "extract 4"}]}
 
 
 def test_gemini_tools_handler_parses_and_finalizes_a_valid_tool_response() -> None:

--- a/tests/v2/test_messages_not_mutated.py
+++ b/tests/v2/test_messages_not_mutated.py
@@ -227,3 +227,58 @@ def test_reask_does_not_mutate_caller_messages(provider: Provider, mode: Mode) -
     handlers.reask_handler(new_kwargs, response, exception)
 
     assert caller_messages == original_snapshot
+
+
+GEMINI_MESSAGE_SHAPES: list[list[dict[str, Any]]] = [
+    # Appends the schema instruction onto the existing system message dict.
+    [{"role": "system", "content": "keep me"}, {"role": "user", "content": "hi"}],
+    # Inserts a brand new system message at the head of the list.
+    [{"role": "user", "content": "hi"}],
+]
+
+
+@pytest.mark.parametrize(
+    "caller_messages",
+    GEMINI_MESSAGE_SHAPES,
+    ids=["existing-system-message", "no-system-message"],
+)
+def test_gemini_md_json_does_not_mutate_caller_messages(
+    caller_messages: list[dict[str, Any]],
+) -> None:
+    """Gemini MD_JSON injects its schema instruction inside `prepare_request`,
+    so a single successful call with no retry is enough to corrupt the caller's
+    messages. Both injection branches are covered because they mutate different
+    objects: one rewrites the caller's system message dict, the other inserts
+    into the caller's list.
+
+    Gemini is checked separately from `FIXED_PAIRS` above because it rejects
+    `model=` in the create kwargs, so it cannot share those parametrized cases.
+    """
+    original_snapshot = deepcopy(caller_messages)
+
+    handlers = mode_registry.get_handlers(Provider.GEMINI, Mode.MD_JSON)
+    handlers.request_handler(
+        response_model=Answer, kwargs={"messages": caller_messages}
+    )
+
+    assert caller_messages == original_snapshot
+
+
+def test_gemini_md_json_without_response_model_does_not_mutate_caller_messages() -> (
+    None
+):
+    """`response_model=None` skips the schema injection above and goes straight
+    to the Gemini prompt conversion, which hoists the system prompt into the
+    first message's parts. Those parts must not be the caller's own content
+    list, or the hoisted prompt lands in the caller's message.
+    """
+    caller_messages: list[dict[str, Any]] = [
+        {"role": "system", "content": "sys rules"},
+        {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+    ]
+    original_snapshot = deepcopy(caller_messages)
+
+    handlers = mode_registry.get_handlers(Provider.GEMINI, Mode.MD_JSON)
+    handlers.request_handler(response_model=None, kwargs={"messages": caller_messages})
+
+    assert caller_messages == original_snapshot


### PR DESCRIPTION
Issue #2417 was fixed for OpenAI-compat, Cohere, Mistral, OpenRouter, Writer, and xAI. Gemini MD_JSON was missed because the sweep passed model= and Gemini raises ConfigurationError before reaching the injection code.

handle_gemini_json inserted the schema instruction into the caller list, and get_message_content returned the caller content list so transform_to_gemini_prompt spliced the system prompt into it. Both now copy first.

Tests: uv run pytest tests/v2/test_messages_not_mutated.py tests/coverage/test_gemini_coverage.py tests/v2/test_gemini_utils_deterministic.py tests/v2/test_gemini_json_messages.py tests/processing/test_message_processing.py tests/processing/test_response_model_conversion.py -q -> 149 passed.

Distinct from #2538/#2539/#2542/#2543.