### PR TITLE
fix(genai): map OpenAI assistant role to Gemini model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **v2 genai**: Map the OpenAI `assistant` role to GenAI's `model` role in `convert_to_genai_messages` so multi-turn history and few-shot examples no longer raise `ValueError: Unsupported role: assistant`. `transform_to_gemini_prompt` already applied this mapping.
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -408,13 +408,17 @@ def convert_to_genai_messages(
             if message["role"] == "system":
                 continue
 
-            if message["role"] not in {"user", "model"}:
+            # OpenAI-style history uses "assistant" where GenAI expects "model",
+            # matching the mapping ``transform_to_gemini_prompt`` already applies.
+            role = "model" if message["role"] == "assistant" else message["role"]
+
+            if role not in {"user", "model"}:
                 raise ValueError(f"Unsupported role: {message['role']}")
 
             if isinstance(message["content"], str):
                 result.append(
                     types.Content(
-                        role=message["role"],
+                        role=role,
                         parts=[types.Part.from_text(text=message["content"])],
                     )
                 )
@@ -434,7 +438,7 @@ def convert_to_genai_messages(
 
                 result.append(
                     types.Content(
-                        role=message["role"],
+                        role=role,
                         parts=content_parts,
                     )
                 )

--- a/tests/coverage/test_gemini_coverage.py
+++ b/tests/coverage/test_gemini_coverage.py
@@ -741,9 +741,16 @@ def test_genai_message_conversion_rejects_invalid_roles_parts_and_message_types(
         == "hi"
     )
 
-    with pytest.raises(ValueError, match="Unsupported role: assistant"):
+    assert (
         utils.convert_to_genai_messages(
-            [{"role": "assistant", "content": "not a GenAI role"}]
+            [{"role": "assistant", "content": "mapped to model"}]
+        )[0].role
+        == "model"
+    )
+
+    with pytest.raises(ValueError, match="Unsupported role: tool"):
+        utils.convert_to_genai_messages(
+            [{"role": "tool", "content": "not a GenAI role"}]
         )
 
     with pytest.raises(ValueError, match="Unsupported content item type"):

--- a/tests/v2/test_gemini_utils_deterministic.py
+++ b/tests/v2/test_gemini_utils_deterministic.py
@@ -200,6 +200,34 @@ def test_convert_to_genai_messages_supports_strings_existing_content_and_media(
     assert result[3].parts[1] == "image-part"
 
 
+def test_convert_to_genai_messages_maps_assistant_role_to_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_genai_types(monkeypatch)
+
+    class FakeImage:
+        def to_genai(self) -> str:
+            return "image-part"
+
+    monkeypatch.setattr(utils, "Image", FakeImage)
+
+    result = utils.convert_to_genai_messages(
+        [
+            {"role": "user", "content": "who won?"},
+            {"role": "assistant", "content": "the home team"},
+            {"role": "assistant", "content": ["by", "two goals"]},
+            {"role": "model", "content": "already a genai role"},
+        ]
+    )
+
+    assert [content.role for content in result] == ["user", "model", "model", "model"]
+    assert result[1].parts[0].text == "the home team"
+    assert [part.text for part in result[2].parts] == ["by", "two goals"]
+
+    with pytest.raises(ValueError, match="Unsupported role: tool"):
+        utils.convert_to_genai_messages([{"role": "tool", "content": "result"}])
+
+
 def test_handle_genai_message_conversion_extracts_system_and_contents(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
convert_to_genai_messages rejected OpenAI-style assistant messages with ValueError: Unsupported role: assistant, so multi-turn history and few-shot examples never reached Gemini. The sibling transform_to_gemini_prompt already maps assistant to model; this does the same.

Intentionally updates tests/coverage/test_gemini_coverage.py, which previously asserted the ValueError for assistant (coverage of the buggy branch). ValueError coverage now uses the tool role.

Tests: uv run pytest tests/v2/test_gemini_utils_deterministic.py tests/coverage/test_gemini_coverage.py tests/v2/test_genai_handlers_deterministic.py -q — 48 passed. Distinct from #2542 and #2534.