### PR TITLE
fix: skip whitespace-only chunks in iterable task-list streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Iterable streaming**: Skip whitespace-only chunks in `tasks_from_task_list_chunks` and its async variant so a keep-alive delta such as `"\n"` no longer raises `JSONDecodeError` mid-stream for Mistral and VertexAI tool streams.
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/v2/dsl/iterable.py
+++ b/instructor/v2/dsl/iterable.py
@@ -63,7 +63,9 @@ class IterableBase:
         """Process streaming chunks that contain a full tasks list."""
 
         async for chunk in json_chunks:
-            if not chunk:
+            # Providers emit keep-alive deltas that carry only whitespace; feeding
+            # those to json.loads raises JSONDecodeError mid-stream.
+            if not chunk or not chunk.strip():
                 continue
             json_response = json.loads(chunk)
             if not json_response["tasks"]:
@@ -79,7 +81,9 @@ class IterableBase:
     ) -> Generator[BaseModel, None, None]:
         """Process streaming chunks that contain a full tasks list."""
         for chunk in json_chunks:
-            if not chunk:
+            # Providers emit keep-alive deltas that carry only whitespace; feeding
+            # those to json.loads raises JSONDecodeError mid-stream.
+            if not chunk or not chunk.strip():
                 continue
             json_response = json.loads(chunk)
             if not json_response["tasks"]:

--- a/tests/coverage/test_dsl_iter_parallel_coverage.py
+++ b/tests/coverage/test_dsl_iter_parallel_coverage.py
@@ -174,6 +174,24 @@ def test_iterable_sync_rejects_missing_extractor_and_malformed_task_lists() -> N
         )
 
 
+def test_iterable_sync_skips_whitespace_only_task_list_chunks() -> None:
+    assert list(
+        EmailIterable.tasks_from_task_list_chunks(
+            ["\n", "  ", '{"tasks": [{"address": "third@example.test"}]}']
+        )
+    ) == [EmailJob(address="third@example.test")]
+
+
+@pytest.mark.asyncio
+async def test_iterable_async_skips_whitespace_only_task_list_chunks() -> None:
+    assert [
+        item
+        async for item in EmailIterable.tasks_from_task_list_chunks_async(
+            async_items(["\n", "  ", '{"tasks": [{"address": "third@example.test"}]}'])
+        )
+    ] == [EmailJob(address="third@example.test")]
+
+
 @pytest.mark.asyncio
 async def test_iterable_async_rejects_missing_extractor_and_malformed_task_lists() -> (
     None


### PR DESCRIPTION
IterableBase.tasks_from_task_list_chunks (and the async variant) only skipped falsy chunks before json.loads. A streamed delta of just whitespace like "\n" is truthy, so it raised JSONDecodeError and killed the Mistral/VertexAI Mode.TOOLS iterable stream.

Whitespace-only chunks are now skipped. None is still skipped without calling strip(). Malformed chunks still raise JSONDecodeError; missing tasks still raises KeyError.

Tests: uv run pytest tests/coverage/test_dsl_iter_parallel_coverage.py -q — 15 passed. Distinct from #2544.