### PR TITLE
fix: tolerate OpenAI completions with an empty choices list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **v2 completion helpers**: Treat an empty `choices` list as "no text" in `_handle_incomplete_output` and `_extract_text_content` so responses without choices no longer raise `IndexError`.
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/v2/core/function_calls.py
+++ b/instructor/v2/core/function_calls.py
@@ -38,10 +38,8 @@ logger = logging.getLogger("instructor")
 # Utility functions for common JSON parsing operations
 def _handle_incomplete_output(completion: Any) -> None:
     """Check if a completion was incomplete and raise appropriate exception."""
-    if (
-        hasattr(completion, "choices")
-        and completion.choices[0].finish_reason == "length"
-    ):
+    choices = getattr(completion, "choices", None)
+    if choices and choices[0].finish_reason == "length":
         raise IncompleteOutputException(last_completion=completion)
 
     # Handle Anthropic format
@@ -53,7 +51,10 @@ def _extract_text_content(completion: Any) -> str:
     """Extract text content from various completion formats."""
     # OpenAI format
     if hasattr(completion, "choices"):
-        return completion.choices[0].message.content or ""
+        choices = completion.choices
+        if not choices:
+            return ""
+        return choices[0].message.content or ""
 
     # Simple text format
     if hasattr(completion, "text"):

--- a/tests/coverage/test_core_schema_coverage.py
+++ b/tests/coverage/test_core_schema_coverage.py
@@ -101,6 +101,13 @@ def test_completed_openai_and_anthropic_outputs_are_not_reported_as_incomplete()
     assert _handle_incomplete_output(anthropic_completion) is None
 
 
+def test_openai_helpers_tolerate_responses_without_choices() -> None:
+    completion = chat_completion(content="dropped").model_copy(update={"choices": []})
+
+    assert _handle_incomplete_output(completion) is None
+    assert _extract_text_content(completion) == ""
+
+
 def test_extract_text_content_returns_empty_for_anthropic_tool_only_response() -> None:
     completion = _anthropic_message(tool=True)
 


### PR DESCRIPTION
_handle_incomplete_output and _extract_text_content indexed choices[0] as soon as a completion had a choices attribute. An empty choices list (OpenAI-compatible gateways, Azure content filtering) raised IndexError. The 1.16.0 changelog covered handler methods; the shared core helpers were left behind.

Empty choices is now treated as no usable text. Anthropic stop_reason still runs afterwards.

Tests: uv run pytest tests/coverage/test_core_schema_coverage.py tests/processing/test_json_extraction.py -q — 46 passed. Distinct from #2537-#2547.