### PR TITLE
fix: extract Bedrock text from the first block that has it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Bedrock text extraction**: Return the first Converse content block that actually contains text, so responses that lead with a reasoning or tool-use block no longer yield `None` from `_extract_text_content`.
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/v2/core/function_calls.py
+++ b/instructor/v2/core/function_calls.py
@@ -77,7 +77,12 @@ def _extract_text_content(completion: Any) -> str:
             content = message.get("content")
             if not isinstance(content, list):
                 return ""
-            return content[0].get("text")
+            # Bedrock can prepend non-text blocks (reasoning, tool use) before
+            # the text block, so return the first block that actually has text.
+            for block in content:
+                if isinstance(block, dict) and isinstance(block.get("text"), str):
+                    return block["text"]
+            return ""
         except (AttributeError, IndexError):
             pass
 

--- a/tests/coverage/test_core_schema_coverage.py
+++ b/tests/coverage/test_core_schema_coverage.py
@@ -116,12 +116,29 @@ def test_extract_text_content_returns_empty_for_anthropic_tool_only_response() -
         {"output": {"message": {"content": "not-a-list"}}},
         {"output": {"message": {"content": []}}},
         {"output": {"message": {"content": [None]}}},
+        {"output": {"message": {"content": [{"toolUse": {"name": "Answer"}}]}}},
+        {"output": {"message": {"content": [{"text": None}]}}},
     ],
 )
 def test_extract_text_content_tolerates_malformed_bedrock_responses(
     completion: dict[str, Any],
 ) -> None:
     assert _extract_text_content(completion) == ""
+
+
+def test_extract_text_content_skips_bedrock_blocks_without_text() -> None:
+    completion = {
+        "output": {
+            "message": {
+                "content": [
+                    {"reasoningContent": {"reasoningText": {"text": "thinking"}}},
+                    {"text": '{"value": 7}'},
+                ]
+            }
+        }
+    }
+
+    assert _extract_text_content(completion) == '{"value": 7}'
 
 
 def test_validate_non_model_type_uses_type_adapter_and_honors_strictness() -> None:


### PR DESCRIPTION
_extract_text_content took the first Converse content block and returned block.get("text"). A leading toolUse or reasoningContent block returned None (annotated -> str), and callers then TypeError in json.loads. #2548 fixed the OpenAI empty-choices path in the same helper; this is the Bedrock branch.

Scan for the first string text, else "".

Tests: uv run pytest tests/coverage/test_core_schema_coverage.py tests/processing/test_json_extraction.py tests/coverage/test_bedrock_coverage.py tests/v2/test_bedrock_handlers.py -q — 98 passed. Distinct from #2537-#2548.