### PR TITLE
fix(gemini): preserve caller safety settings

### DIFF
--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -339,7 +339,7 @@ def update_gemini_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
         result.setdefault("safety_settings", {})
         return result
 
-    safety_settings = result.get("safety_settings", {})
+    safety_settings = result.get("safety_settings", {}).copy()
     result["safety_settings"] = safety_settings
 
     for category, threshold in default_safety_thresholds.items():

--- a/tests/v2/test_gemini_utils_deterministic.py
+++ b/tests/v2/test_gemini_utils_deterministic.py
@@ -359,7 +359,7 @@ def test_map_to_gemini_function_schema_raises_helpful_error_when_jsonref_missing
         utils.map_to_gemini_function_schema(Answer.model_json_schema())
 
 
-def test_update_gemini_kwargs_applies_safety_defaults(
+def test_update_gemini_kwargs_applies_safety_defaults_without_mutating_input(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class Category:
@@ -374,14 +374,17 @@ def test_update_gemini_kwargs_applies_safety_defaults(
         lambda: {hate: 2, harassment: 1},
     )
 
+    safety_settings = {hate: 3}
     result = utils.update_gemini_kwargs(
         {
             "generation_config": {"max_tokens": 32},
             "messages": [{"role": "user", "content": "hello"}],
-            "safety_settings": {hate: 3},
+            "safety_settings": safety_settings,
         }
     )
 
+    assert safety_settings == {hate: 3}
+    assert result["safety_settings"] is not safety_settings
     assert result["generation_config"]["max_output_tokens"] == 32
     assert result["contents"][0]["parts"] == ["hello"]
     assert result["safety_settings"][hate] == 2


### PR DESCRIPTION
## Describe your changes

`update_gemini_kwargs` now copies a caller-provided `safety_settings` mapping before merging the Gemini default thresholds.

Previously, the function made only a shallow copy of the request kwargs, then reused and updated the original nested mapping. A request could therefore silently lower thresholds or add categories in application-owned configuration, so reusing the same dictionary produced stateful behavior outside Instructor.

The regression test verifies both sides of the contract: defaults are still applied to the outgoing request, while the original mapping remains unchanged and is not aliased by the result.

## Issue ticket number and link

N/A — independently discovered while auditing Gemini request preparation. This is separate from #2545, which covers caller-owned `messages`.

## Validation

- `pytest tests/v2/test_gemini_utils_deterministic.py -q` — 19 passed
- v2, Gemini coverage, and processing regression suite — 1734 passed, 168 skipped
- non-LLM code suite excluding pre-existing docs-format baseline failures — 2969 passed, 199 skipped, 27 deselected
- full Ruff check and format check — passed
- `ty` checks for `instructor/` and `tests` — passed

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added a focused regression test
- [x] Documentation is not required because this restores input immutability without changing the public API
