### PR TITLE
fix(batch): preserve Anthropic system messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Anthropic batch messages**: Preserve every system instruction when converting batch requests instead of keeping only the final system message.
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/instructor/batch/request.py
+++ b/instructor/batch/request.py
@@ -109,6 +109,10 @@ class BatchRequest(BaseModel, Generic[T]):
 
     def to_anthropic_format(self) -> dict[str, Any]:
         """Convert to Anthropic batch format with JSON schema"""
+        from instructor.v2.providers.anthropic.handlers import (
+            combine_system_messages,
+        )
+
         schema = self.get_json_schema()
 
         # Ensure schema has proper format for Anthropic
@@ -123,11 +127,13 @@ class BatchRequest(BaseModel, Generic[T]):
 
         for message in self.messages:
             if message.get("role") == "system":
-                system_message = message.get("content", "")
+                content = message.get("content", "")
+                if content:
+                    system_message = combine_system_messages(system_message, content)
             else:
                 filtered_messages.append(message)
 
-        params = {
+        params: dict[str, Any] = {
             "model": self.model,
             "max_tokens": self.max_tokens,
             "temperature": self.temperature,

--- a/tests/coverage/test_batch_api_coverage.py
+++ b/tests/coverage/test_batch_api_coverage.py
@@ -412,6 +412,28 @@ def test_anthropic_batch_request_extracts_system_message_and_completes_schema() 
     }
 
 
+def test_anthropic_batch_request_combines_multiple_system_messages() -> None:
+    request = BatchRequest[TypelessResponse](
+        custom_id="anthropic-multiple-system-1",
+        messages=[
+            {"role": "system", "content": "Follow the extraction policy."},
+            {"role": "user", "content": "Extract the value."},
+            {"role": "system", "content": "Return exactly one value."},
+        ],
+        response_model=TypelessResponse,
+        model="claude-sonnet",
+    )
+
+    result = request.to_anthropic_format()
+
+    assert result["params"]["system"] == (
+        "Follow the extraction policy.\n\nReturn exactly one value."
+    )
+    assert result["params"]["messages"] == [
+        {"role": "user", "content": "Extract the value."}
+    ]
+
+
 def test_anthropic_batch_request_preserves_explicit_additional_properties() -> None:
     request = BatchRequest[RestrictedResponse](
         custom_id="anthropic-restricted-1",


### PR DESCRIPTION
## Describe your changes

`BatchRequest.to_anthropic_format()` previously overwrote `system_message` for every system turn, so Anthropic batch requests silently kept only the final instruction. This change combines every system message in order through the existing Anthropic helper, preserves both string and content-block forms, and continues to remove system turns from the provider `messages` list.

A regression test covers interleaved user and multiple system turns, and the fix is recorded in the unreleased changelog.

## Issue ticket number and link

N/A — no matching issue or pull request was found.

## Validation

- `uv run pytest tests/test_batch_processor_coverage.py tests/coverage/test_batch_openai_coverage.py tests/coverage/test_batch_anthropic_coverage.py tests/coverage/test_batch_api_coverage.py tests/test_batch_in_memory.py -q` — 102 passed
- `uv run ruff check instructor/batch/request.py tests/coverage/test_batch_api_coverage.py` — passed
- `uv run ruff format --check instructor/batch/request.py tests/coverage/test_batch_api_coverage.py` — passed
- `uv run ty check instructor/batch/request.py tests/coverage/test_batch_api_coverage.py` — passed

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.

OpenAI Codex assisted with the implementation and test preparation; the change was reviewed and verified with the commands above.
