### PR TITLE
fix(registry): publish handlers before retiring lazy loader (#2535)

### DIFF
--- a/instructor/v2/core/registry.py
+++ b/instructor/v2/core/registry.py
@@ -200,9 +200,10 @@ class ModeRegistry:
                 return self._handlers[mode_key]
 
             if mode_key in self._lazy_loaders:
-                loader = self._lazy_loaders.pop(mode_key)
+                loader = self._lazy_loaders[mode_key]
                 handlers = loader()
                 self._handlers[mode_key] = handlers
+                self._lazy_loaders.pop(mode_key, None)
                 return handlers
 
         raise KeyError(

--- a/tests/v2/test_registry.py
+++ b/tests/v2/test_registry.py
@@ -186,3 +186,56 @@ def test_get_handlers_concurrent_first_access_does_not_race():
     )
     # The loader must run exactly once, not once per racing thread.
     assert load_count == 1
+
+
+def test_is_registered_and_list_modes_during_concurrent_lazy_load():
+    """Regression test for #2535.
+
+    When thread A is in the middle of resolving a lazy loader, concurrent
+    readers calling is_registered() or list_modes() must still see the mode
+    as registered rather than raising RegistryError due to a momentary gap
+    between popping _lazy_loaders and publishing _handlers.
+    """
+    import threading
+    import time
+    from typing import cast
+
+    from instructor.v2.core.registry import ModeHandlers, ModeRegistry
+
+    registry = ModeRegistry()
+    load_in_progress = threading.Event()
+    finish_load = threading.Event()
+
+    def slow_loader() -> ModeHandlers:
+        load_in_progress.set()
+        finish_load.wait(timeout=5)
+        return ModeHandlers(
+            request_handler=cast(Any, lambda *_a, **_k: None),
+            reask_handler=cast(Any, lambda *_a, **_k: None),
+            response_parser=cast(Any, lambda *_a, **_k: None),
+        )
+
+    registry.register_lazy(Provider.OPENAI, Mode.JSON, slow_loader)
+
+    # Thread 1 starts lazy load
+    t1 = threading.Thread(target=lambda: registry.get_handlers(Provider.OPENAI, Mode.JSON))
+    t1.start()
+
+    # Wait until thread 1 has popped the loader and is executing the slow loader
+    assert load_in_progress.wait(timeout=5)
+
+    # Thread 2 checks registration while thread 1 is still inside the loader
+    assert registry.is_registered(Provider.OPENAI, Mode.JSON), (
+        "is_registered() must return True even while lazy loading is in-flight"
+    )
+    assert (Provider.OPENAI, Mode.JSON) in registry.list_modes(), (
+        "list_modes() must include mode even while lazy loading is in-flight"
+    )
+
+    finish_load.set()
+    t1.join(timeout=5)
+
+    # Post-load sanity check
+    assert registry.is_registered(Provider.OPENAI, Mode.JSON)
+    assert (Provider.OPENAI, Mode.JSON) in registry.list_modes()
+

--- a/tests/v2/test_registry.py
+++ b/tests/v2/test_registry.py
@@ -197,7 +197,6 @@ def test_is_registered_and_list_modes_during_concurrent_lazy_load():
     between popping _lazy_loaders and publishing _handlers.
     """
     import threading
-    import time
     from typing import cast
 
     from instructor.v2.core.registry import ModeHandlers, ModeRegistry


### PR DESCRIPTION
Fixes #2535

### Summary

In \ModeRegistry.get_handlers()\, a lazy loader was previously popped from \self._lazy_loaders\ *before* the resulting handlers were published to \self._handlers\. 

During the module import / resolution window, concurrent reader threads calling \is_registered()\ or \list_modes()\ would find the mode key in neither dictionary, causing \alidate_mode_registration\ to raise \RegistryError\ during cold concurrent startup.

### Changes

1. **Publish before retiring:** In \ModeRegistry.get_handlers()\, read \self._lazy_loaders[mode_key]\, invoke the loader, assign \self._handlers[mode_key] = handlers\, and only then pop \self._lazy_loaders.pop(mode_key, None)\.
2. **Atomic visibility:** At every instant, the \mode_key\ is present in \_lazy_loaders\, in both dictionaries during the transition, or in \_handlers\.
3. **Tests:** Added \	est_is_registered_and_list_modes_during_concurrent_lazy_load()\ in \	ests/v2/test_registry.py\ asserting that \is_registered()\ and \list_modes()\ return \True\ even while a slow lazy loader is in-flight on another thread.

### Verification

All 169 unit tests in \	ests/v2/test_registry.py\ pass.