### PR TITLE
docs: fix incorrect Mistral extra name in installation guides

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,7 +37,7 @@ pip install "instructor[google-genai]"         # For Google/Gemini
 pip install "instructor[vertexai]"             # For Vertex AI
 pip install "instructor[cohere]"               # For Cohere
 pip install "instructor[litellm]"              # For LiteLLM (multiple providers)
-pip install "instructor[mistralai]"            # For Mistral
+pip install "instructor[mistral]"               # For Mistral
 pip install "instructor[xai]"                  # For xAI
 ```
 

--- a/docs/learning/getting_started/installation.md
+++ b/docs/learning/getting_started/installation.md
@@ -88,7 +88,7 @@ export COHERE_API_KEY=your_cohere_key
 To use with Mistral AI's models:
 
 ```shell
-pip install "instructor[mistralai]"
+pip install "instructor[mistral]"
 ```
 
 Set up your Mistral API key:


### PR DESCRIPTION
## Problem

Two installation guides tell users to install the Mistral provider with:

```bash
pip install "instructor[mistralai]"
```

but `mistralai` is the **installed package name**, not the **extra name**. The actual extra defined in `pyproject.toml` is `mistral`:

```toml
mistral = ["mistralai<3.0.0,>=1.5.1"]
```

Because the `mistralai` extra does not exist, `pip install "instructor[mistralai]"` silently installs Instructor **without** the `mistralai` SDK. The user's first `import mistralai` then fails with `ModuleNotFoundError`, and the getting-started guide is the first page a new Mistral user lands on.

## Solution

Changed `instructor[mistralai]` → `instructor[mistral]` in the two affected files:

- `docs/getting-started.md` (the "Installation" section)
- `docs/learning/getting_started/installation.md` (the "Mistral" section)

This now matches `pyproject.toml` and the already-correct `docs/integrations/mistral.md`.

## Testing

- Verified the extra name `mistral` in `pyproject.toml` (line 95: `mistral = ["mistralai<3.0.0,>=1.5.1"]`).
- Confirmed no remaining `instructor[mistralai]` references anywhere under `docs/`:
  ```
  $ grep -rn 'instructor\[mistralai\]' docs/ --include="*.md"
  (no matches)
  ```
- Confirmed the corrected `instructor[mistral]` now appears consistently in `docs/getting-started.md`, `docs/learning/getting_started/installation.md`, and the already-correct `docs/integrations/mistral.md`.
- Documentation-only change; no code, tests, or dependencies affected.
