### PR TITLE
fix(genai): use user role for validation reasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Google GenAI**: Use the user role for validation-retry function responses so Gemini accepts the corrected request. ([#2557](https://github.com/567-labs/instructor/pull/2557))
+
 ## [1.16.1] - 2026-08-28
 
 ### Changed

--- a/instructor/v2/providers/genai/handlers.py
+++ b/instructor/v2/providers/genai/handlers.py
@@ -78,7 +78,7 @@ def reask_genai_tools(
     )
     kwargs["contents"].append(function_call_content)
     kwargs["contents"].append(
-        types.Content(role="tool", parts=[function_response_part])
+        types.Content(role="user", parts=[function_response_part])
     )
     return kwargs
 

--- a/tests/coverage/test_genai_coverage.py
+++ b/tests/coverage/test_genai_coverage.py
@@ -251,12 +251,13 @@ def test_reask_tools_preserves_model_turn_and_adds_function_error() -> None:
 
     assert result["contents"][0] is original_contents[0]
     assert result["contents"][1] is model_content
-    tool_turn = result["contents"][2]
-    assert tool_turn.role == "tool"
-    assert tool_turn.parts[0].function_response.name == "Answer"
+    function_response_turn = result["contents"][2]
+    assert function_response_turn.role == "user"
+    assert function_response_turn.role != "tool"
+    assert function_response_turn.parts[0].function_response.name == "Answer"
     assert (
         "answer must be an int"
-        in tool_turn.parts[0].function_response.response["error"]
+        in function_response_turn.parts[0].function_response.response["error"]
     )
     assert len(original_contents) == 1
 

--- a/tests/coverage/test_genai_coverage.py
+++ b/tests/coverage/test_genai_coverage.py
@@ -253,7 +253,6 @@ def test_reask_tools_preserves_model_turn_and_adds_function_error() -> None:
     assert result["contents"][1] is model_content
     function_response_turn = result["contents"][2]
     assert function_response_turn.role == "user"
-    assert function_response_turn.role != "tool"
     assert function_response_turn.parts[0].function_response.name == "Answer"
     assert (
         "answer must be an int"

--- a/tests/test_genai_reask.py
+++ b/tests/test_genai_reask.py
@@ -31,9 +31,9 @@ def test_reask_genai_tools_preserves_thought_signature():
     assert result["contents"][-2] is model_content
     assert result["contents"][-2].parts[0].thought_signature == b"sig"
 
-    tool_content = result["contents"][-1]
-    assert tool_content.role == "tool"
-    assert tool_content.parts[0].function_response.name == "test_fn"
+    function_response_content = result["contents"][-1]
+    assert function_response_content.role == "user"
+    assert function_response_content.parts[0].function_response.name == "test_fn"
 
 
 def test_reask_genai_tools_finds_function_call_part_when_not_first():
@@ -55,7 +55,7 @@ def test_reask_genai_tools_finds_function_call_part_when_not_first():
     )
 
     assert result["contents"][-2] is model_content
-    assert result["contents"][-1].role == "tool"
+    assert result["contents"][-1].role == "user"
 
 
 def test_reask_genai_tools_handles_none_response():

--- a/tests/v2/test_genai_handlers_deterministic.py
+++ b/tests/v2/test_genai_handlers_deterministic.py
@@ -50,7 +50,7 @@ def test_reask_genai_tools_without_function_call_appends_user_error(
     assert "Validation Error found" in result["contents"][1].parts[0].text
 
 
-def test_reask_genai_tools_with_function_call_appends_tool_response(
+def test_reask_genai_tools_with_function_call_appends_user_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install_fake_genai_types(monkeypatch)
@@ -61,7 +61,8 @@ def test_reask_genai_tools_with_function_call_appends_tool_response(
     result = reask_genai_tools({"contents": []}, response, ValueError("bad schema"))
 
     assert result["contents"][0] is content
-    assert result["contents"][1].role == "tool"
+    assert result["contents"][1].role == "user"
+    assert result["contents"][1].role != "tool"
     function_response = result["contents"][1].parts[0].function_response
     assert function_response["name"] == "Answer"
     assert "Validation Error found" in function_response["response"]["error"]

--- a/tests/v2/test_genai_handlers_deterministic.py
+++ b/tests/v2/test_genai_handlers_deterministic.py
@@ -62,7 +62,6 @@ def test_reask_genai_tools_with_function_call_appends_user_response(
 
     assert result["contents"][0] is content
     assert result["contents"][1].role == "user"
-    assert result["contents"][1].role != "tool"
     function_response = result["contents"][1].parts[0].function_response
     assert function_response["name"] == "Answer"
     assert "Validation Error found" in function_response["response"]["error"]

--- a/tests/v2/test_genai_integration.py
+++ b/tests/v2/test_genai_integration.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
+from pydantic import BaseModel
 
 from instructor.mode import Mode
 from instructor.utils.providers import Provider
+from instructor.v2.core.errors import InstructorRetryException
 
 try:
     from instructor.v2 import from_genai
@@ -62,6 +65,113 @@ class DummyClient:
     def __init__(self):
         self.models = DummyModels()
         self.aio = SimpleNamespace(models=DummyAsyncModels())
+
+
+class WireResult(BaseModel):
+    item_id: str
+
+
+def _wire_response(item_id: str | None, signature: bytes):
+    thought = types.Part.from_text(text="checking")
+    thought.thought = True
+    function_call = types.Part.from_function_call(
+        name="WireResult", args={"item_id": item_id}
+    )
+    function_call.thought_signature = signature
+    return types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(
+                    role="model",
+                    parts=[thought, function_call],
+                )
+            )
+        ]
+    )
+
+
+class RetryModels:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+        self.requests: list[dict[str, Any]] = []
+
+    def generate_content(self, **kwargs: Any):
+        self.requests.append(kwargs)
+        return self.responses[len(self.requests) - 1]
+
+
+class RetryClient:
+    responses: list[Any] = []
+
+    def __init__(self) -> None:
+        self.models = RetryModels(self.responses)
+
+
+def _assert_retry_history(
+    request: dict[str, Any], expected_contents: list[Any]
+) -> None:
+    contents = request["contents"]
+    assert len(contents) == 1 + 2 * len(expected_contents)
+    for index, expected_content in enumerate(expected_contents):
+        model_content = contents[1 + index * 2]
+        function_response_content = contents[2 + index * 2]
+        assert model_content == expected_content
+        assert model_content.parts == expected_content.parts
+        assert (
+            model_content.parts[1].thought_signature
+            == expected_content.parts[1].thought_signature
+        )
+        assert function_response_content.role == "user"
+        assert function_response_content.role != "tool"
+        function_response = function_response_content.parts[0].function_response
+        assert function_response.name == "WireResult"
+        assert "Validation Error found" in function_response.response["error"]
+
+
+def test_genai_invalid_then_valid_preserves_signed_wire_history(monkeypatch):
+    invalid = _wire_response(None, b"invalid-signature")
+    valid = _wire_response("ok", b"valid-signature")
+    RetryClient.responses = [invalid, valid]
+    monkeypatch.setattr("instructor.v2.providers.genai.client.Client", RetryClient)
+    client = RetryClient()
+    instructor = from_genai(client, mode=Mode.TOOLS, use_async=False)
+
+    result = instructor.chat.completions.create(
+        model="gemini-test",
+        messages=[{"role": "user", "content": "pick"}],
+        response_model=WireResult,
+        max_retries=2,
+    )
+
+    assert result.item_id == "ok"
+    assert len(client.models.requests) == 2
+    _assert_retry_history(client.models.requests[-1], [invalid.candidates[0].content])
+
+
+def test_genai_three_invalid_attempts_preserve_bound(monkeypatch):
+    invalid = [
+        _wire_response(None, f"invalid-signature-{attempt}".encode())
+        for attempt in range(1, 4)
+    ]
+    RetryClient.responses = invalid
+    monkeypatch.setattr("instructor.v2.providers.genai.client.Client", RetryClient)
+    client = RetryClient()
+    instructor = from_genai(client, mode=Mode.TOOLS, use_async=False)
+
+    with pytest.raises(InstructorRetryException) as exc_info:
+        instructor.chat.completions.create(
+            model="gemini-test",
+            messages=[{"role": "user", "content": "pick"}],
+            response_model=WireResult,
+            max_retries=2,
+        )
+
+    assert exc_info.value.n_attempts == 3
+    assert len(client.models.requests) == 3
+    _assert_retry_history(
+        client.models.requests[-1],
+        [response.candidates[0].content for response in invalid[:2]],
+    )
 
 
 def test_mode_registry_has_genai_handlers():

--- a/tests/v2/test_genai_integration.py
+++ b/tests/v2/test_genai_integration.py
@@ -122,7 +122,6 @@ def _assert_retry_history(
             == expected_content.parts[1].thought_signature
         )
         assert function_response_content.role == "user"
-        assert function_response_content.role != "tool"
         function_response = function_response_content.parts[0].function_response
         assert function_response.name == "WireResult"
         assert "Validation Error found" in function_response.response["error"]


### PR DESCRIPTION
## Describe your changes

### Observed failure

> HTTP 400 "Role 'tool' is not supported"

This was observed with `gemini-3.6-flash` through the google-genai SDK in `GENAI_TOOLS` mode. The first request succeeds, but every validation reask (attempt 2 and later) is rejected before the model can correct its structured response.

### Why `role="user"` is correct

The [google-genai `Content.role` reference](https://googleapis.github.io/python-genai/genai.html) documents the producer as: “Must be either 'user' or 'model'.” Google’s [manual function-calling examples](https://ai.google.dev/gemini-api/docs/generate-content/function-calling) append the `functionResponse` turn as `role="user"`.

`tool` has never been a legal `Content.role` value. Older Gemini models silently tolerated it; newer models validate the role strictly. The same Instructor reask function already uses `role="user"` for its no-function-call fallback, so this change aligns both paths.

### Minimal reproduction

1. Make a `GENAI_TOOLS` request whose first model response fails Pydantic validation.
2. Instructor constructs a reask containing the validation `functionResponse`.
3. With `role="tool"`, the Gemini API rejects that retry request with the HTTP 400 above before the model receives the validation feedback.

### Change

- Send the validation-reask `functionResponse` Content with `role="user"`.
- Preserve the original signed model Content, multipart order, function name, validation payload, and retry behavior.
- Update the existing role assertions and cover invalid-to-valid recovery plus three-invalid exhaustion.
- Add the Unreleased / Fixed changelog entry.

### Testing

- Focused GenAI tests: 41 passed.
- Secret-free core tests: 2,093 passed, 180 skipped.
- Offline coverage tests: 767 passed; 91% coverage.
- Ruff lint/format, ty, lock, and diff checks passed.

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Documentation: N/A — bug fix.