### PR TITLE
fix(v2/registry): keep mode registered while its lazy loader resolves

### DIFF
--- a/instructor/v2/core/registry.py
+++ b/instructor/v2/core/registry.py
@@ -200,9 +200,19 @@ class ModeRegistry:
                 return self._handlers[mode_key]
 
             if mode_key in self._lazy_loaders:
-                loader = self._lazy_loaders.pop(mode_key)
+                # Publish into _handlers *before* removing from _lazy_loaders so
+                # the key is present in at least one dict at every instant.
+                # is_registered() reads both dicts without this lock, so a
+                # pop-then-set order briefly exposes the key as unregistered
+                # while the loader runs, and a concurrent first-caller is told
+                # the mode is not registered (raising RegistryError). Keeping
+                # the loader in _lazy_loaders until the handlers are published
+                # also means a loader that raises leaves the mode registered
+                # and retryable instead of dropping it permanently. (#2535)
+                loader = self._lazy_loaders[mode_key]
                 handlers = loader()
                 self._handlers[mode_key] = handlers
+                self._lazy_loaders.pop(mode_key, None)
                 return handlers
 
         raise KeyError(

--- a/tests/v2/test_registry.py
+++ b/tests/v2/test_registry.py
@@ -186,3 +186,42 @@ def test_get_handlers_concurrent_first_access_does_not_race():
     )
     # The loader must run exactly once, not once per racing thread.
     assert load_count == 1
+
+
+def test_lazy_load_keeps_mode_registered_during_loader():
+    """Regression test for #2535.
+
+    is_registered() reads _handlers / _lazy_loaders without the lazy-load
+    lock. While a lazy loader is resolving, the (provider, mode) key must
+    stay visible as registered — otherwise a second thread calling
+    from_litellm during the load window is told the mode is not registered
+    and patch_v2 raises RegistryError.
+
+    The old pop-then-set order removed the loader from _lazy_loaders before
+    _handlers was populated, so is_registered() returned False for the whole
+    duration of the loader. The loader below records is_registered() mid-load,
+    which reproduces exactly that window deterministically without threads.
+    """
+    from instructor.v2.core.registry import ModeHandlers, ModeRegistry
+
+    registry = ModeRegistry()
+    observed: dict[str, bool] = {}
+
+    def loader() -> ModeHandlers:
+        # Called while the key is mid-resolution: it must still look registered.
+        observed["registered_during_load"] = registry.is_registered(
+            Provider.DEEPSEEK, Mode.TOOLS
+        )
+        return ModeHandlers(
+            request_handler=cast(Any, lambda *_a, **_k: None),
+            reask_handler=cast(Any, lambda *_a, **_k: None),
+            response_parser=cast(Any, lambda *_a, **_k: None),
+        )
+
+    registry.register_lazy(Provider.DEEPSEEK, Mode.TOOLS, loader)
+    registry.get_handlers(Provider.DEEPSEEK, Mode.TOOLS)
+
+    assert observed["registered_during_load"] is True, (
+        "mode must stay registered while its lazy loader is resolving"
+    )
+    assert registry.is_registered(Provider.DEEPSEEK, Mode.TOOLS) is True


### PR DESCRIPTION
Fixes #2535

## Problem
On the first structured call of a cold process, concurrent callers can hit `RegistryError`. `ModeRegistry.get_handlers()` pops the lazy loader out of `_lazy_loaders` *before* publishing the resolved handlers into `_handlers`:

```python
loader = self._lazy_loaders.pop(mode_key)   # removed from _lazy_loaders
handlers = loader()                          # slow: imports a module
self._handlers[mode_key] = handlers          # published only now
```

The lazy-load lock added in #2422 stops concurrent `get_handlers()` callers from racing each other, but `is_registered()` reads `_handlers` / `_lazy_loaders` **without** that lock. During `loader()` the key is in neither dict, so a second thread calling `from_litellm(...)` in that window is told the mode is not registered and `patch_v2` raises `RegistryError`. It only affects the first call per process, so it reads as a rare flake — but it is deterministic when a cold process goes straight into concurrency.

## Fix
Publish into `_handlers` **before** removing from `_lazy_loaders`, so the key is present in at least one dict at every instant. A lock-free `is_registered()` therefore always sees the mode as registered. As a bonus, a loader that raises now leaves the mode registered and retryable instead of dropping it permanently.

## Tests
- `test_lazy_load_keeps_mode_registered_during_loader` — the lazy loader calls `is_registered()` mid-resolution and it must return `True`. This reproduces the exact window deterministically (no threads/sleeps). It fails on the old pop-then-set order and passes with the fix.
- Existing `test_get_handlers_concurrent_first_access_does_not_race` (#2422) and the rest of `tests/v2/test_registry.py` still pass (169 total).