### PR TITLE
docs(integrations): note xAI Python version requirement

### DIFF
--- a/docs/integrations/xai.md
+++ b/docs/integrations/xai.md
@@ -9,7 +9,9 @@ xAI provides access to Grok models through the `xai-sdk` package, enabling struc
 
 ## Quick Start
 
-Instructor is distributed without xAI dependencies by default. Install xAI support with the optional `xai` extra:
+Instructor is distributed without xAI dependencies by default. The `xai` extra
+requires Python 3.10 or later because it installs `xai-sdk`. Install xAI support
+with the optional `xai` extra:
 
 ```bash
 pip install "instructor[xai]"


### PR DESCRIPTION
## Describe your changes

Clarifies that the `xai` optional extra requires Python 3.10 or later because it installs `xai-sdk`.

Instructor supports Python 3.9 overall, but the provider dependency is guarded by `python_version >= '3.10'`. Calling this out in the xAI quick start prevents a confusing install where the optional dependency is skipped on Python 3.9.

## Issue ticket number and link

No issue. I searched open issues and pull requests for `xai-sdk`, `xAI Python 3.10`, and `instructor[xai]`; no duplicate was found.

## Checklist before requesting a review

- [x] I have performed a self-review of the change.
- [x] This is not a core feature; no core tests are required.
- [x] The guide now matches the existing dependency marker in `pyproject.toml`.

## Testing

- `git diff --check -- docs/integrations/xai.md`
- Confirmed `xai = ["xai-sdk>=0.2.0 ; python_version >= '3.10'"]` in `pyproject.toml`

The full MkDocs build was not run because this checkout contains only the files needed for the focused documentation change.
