### PR TITLE
fix(release): validate metadata 2.5 artifacts

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -46,7 +46,7 @@ jobs:
           python scripts/prepare_release.py \
             --expected-version "$VERSION" \
             --output /tmp/release-notes.md
-          uvx --from twine==6.2.0 twine check dist/*
+          uvx --from twine==7.0.0 twine check dist/*
       - name: Publish exact release artifacts to PyPI
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Build and validate distributions
         run: |
           uv build
-          uvx --from twine==6.2.0 twine check dist/*
+          uvx --from twine==7.0.0 twine check dist/*
 
       - name: Upload exact release candidate
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6


### PR DESCRIPTION
## Summary

- update the release-readiness and PyPI workflows from Twine 6.2.0 to Twine 7.0.0
- restore validation for artifacts generated with Core Metadata 2.5
- keep the pre-publication and publication checks on the same validator version

## Why

The scheduled release run on current `main` passed metadata validation and the complete test suite, then failed while checking the newly built `1.16.0` wheel:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Current `uv build` emits Core Metadata 2.5. Twine 7.0.0 requires `packaging>=26.1` and validates the exact wheel and sdist successfully.

## Validation

- `uv build --out-dir /private/tmp/instructor-1.16-twine7`
- `uvx --from twine==7.0.0 twine check /private/tmp/instructor-1.16-twine7/*` - passed wheel and sdist
- built wheel reports `Metadata-Version: 2.5` and package version `1.16.0`
- `pytest tests/test_prepare_release.py -q` - 8 passed
- parsed both changed workflow files as YAML
- `git diff --check`

Release blocker observed in [scheduled run 198](https://github.com/567-labs/instructor/actions/runs/32711007048). No package, tag, or release has been published by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency bump on distribution validation; no changes to library code or PyPI publish mechanics beyond the validator version.
> 
> **Overview**
> **Unblocks release validation** by pinning `twine check` to **Twine 7.0.0** in both the scheduled release-readiness workflow and the PyPI publish workflow (replacing 6.2.0).
> 
> Current `uv build` output uses **Core Metadata 2.5**, which Twine 6.2.0 rejects during `twine check`; 7.0.0 accepts those wheels/sdists so pre-publish checks stay aligned with what gets uploaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7bc06e61f7b8283d52f03aff9bdf2e9b64d610c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->