### PR TITLE
fix(core): consolidate 1.16.1 reliability fixes

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,10 +21,13 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          enable-cache: true
+          # Publishing runs with a long-lived registry credential. Avoid
+          # restoring a cache populated by less-privileged workflows.
+          enable-cache: false
           python-version: "3.11"
       - name: Download tested release artifacts
         env:

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -113,14 +114,19 @@ jobs:
           retention-days: 14
 
       - name: Summarize readiness
+        env:
+          RELEASE_NEEDED: ${{ steps.metadata.outputs.release_needed }}
+          RELEASE_TAG: ${{ steps.metadata.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.metadata.outputs.version }}
+          PUBLISH_REQUESTED: ${{ inputs.publish || false }}
         run: |
           {
             echo "## Release readiness"
-            echo "- Version: ${{ steps.metadata.outputs.version }}"
-            echo "- Tag: ${{ steps.metadata.outputs.tag }}"
+            echo "- Version: $RELEASE_VERSION"
+            echo "- Tag: $RELEASE_TAG"
             echo "- Commit: $GITHUB_SHA"
-            echo "- Release needed: ${{ steps.metadata.outputs.release_needed }}"
-            echo "- Publish requested: ${{ inputs.publish || false }}"
+            echo "- Release needed: $RELEASE_NEEDED"
+            echo "- Publish requested: $PUBLISH_REQUESTED"
           } >> "$GITHUB_STEP_SUMMARY"
 
   smoke:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 - **Remote multimodal media types**: Accept valid case-insensitive HTTP `Content-Type` values with optional parameters when loading images, audio, and PDFs. ([#2525](https://github.com/567-labs/instructor/pull/2525))
 - **Message history**: Preserve tool-call and other protocol fields when normalizing consecutive messages, and keep protocol messages as separate turns. ([#2527](https://github.com/567-labs/instructor/pull/2527))
+- **v2 mode registry**: Keep lazily loaded modes registered while their handlers initialize, preventing concurrent first calls from failing spuriously. ([#2536](https://github.com/567-labs/instructor/pull/2536), [#2535](https://github.com/567-labs/instructor/issues/2535))
 
 ## [1.16.0] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
+- **Anthropic batch accounting**: Include canceled and expired requests in reported batch totals. ([#2529](https://github.com/567-labs/instructor/pull/2529))
+- **Cache key isolation**: Include provider-hoisted system prompts in sync and async cache keys so requests with different instructions cannot share a cached response. ([#2524](https://github.com/567-labs/instructor/pull/2524))
+- **Provider initialization**: Reject provider strings with an empty provider or model component before client construction. ([#2522](https://github.com/567-labs/instructor/pull/2522))
 - **Remote multimodal media types**: Accept valid case-insensitive HTTP `Content-Type` values with optional parameters when loading images, audio, and PDFs. ([#2525](https://github.com/567-labs/instructor/pull/2525))
 - **Message history**: Preserve tool-call and other protocol fields when normalizing consecutive messages, and keep protocol messages as separate turns. ([#2527](https://github.com/567-labs/instructor/pull/2527))
 - **v2 mode registry**: Keep lazily loaded modes registered while their handlers initialize, preventing concurrent first calls from failing spuriously. ([#2536](https://github.com/567-labs/instructor/pull/2536), [#2535](https://github.com/567-labs/instructor/issues/2535))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 - **Remote multimodal media types**: Accept valid case-insensitive HTTP `Content-Type` values with optional parameters when loading images, audio, and PDFs. ([#2525](https://github.com/567-labs/instructor/pull/2525))
+- **Message history**: Preserve tool-call and other protocol fields when normalizing consecutive messages, and keep protocol messages as separate turns. ([#2527](https://github.com/567-labs/instructor/pull/2527))
 
 ## [1.16.0] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Remote multimodal media types**: Accept valid case-insensitive HTTP `Content-Type` values with optional parameters when loading images, audio, and PDFs. ([#2525](https://github.com/567-labs/instructor/pull/2525))
+
 ## [1.16.0] - 2026-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [1.16.1] - 2026-08-27
+
+### Changed
+- **CLI cost metadata**: Add an explicit mapping annotation to the model-cost table so static analysis preserves its nested numeric value shape. ([#2521](https://github.com/567-labs/instructor/pull/2521))
+
 ### Fixed
 - **Anthropic batch accounting**: Include canceled and expired requests in reported batch totals. ([#2529](https://github.com/567-labs/instructor/pull/2529))
 - **Cache key isolation**: Include provider-hoisted system prompts in sync and async cache keys so requests with different instructions cannot share a cached response. ([#2524](https://github.com/567-labs/instructor/pull/2524))
@@ -296,5 +301,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 - Pydantic v2 deprecation warnings resolved by migrating from class `Config` to `ConfigDict` ([#1782](https://github.com/567-labs/instructor/pull/1782))
 
-[Unreleased]: https://github.com/567-labs/instructor/compare/v1.16.0...HEAD
+[Unreleased]: https://github.com/567-labs/instructor/compare/v1.16.1...HEAD
+[1.16.1]: https://github.com/567-labs/instructor/compare/v1.16.0...v1.16.1
 [1.16.0]: https://github.com/567-labs/instructor/compare/v1.15.4...v1.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Changed
 - **CLI cost metadata**: Add an explicit mapping annotation to the model-cost table so static analysis preserves its nested numeric value shape. ([#2521](https://github.com/567-labs/instructor/pull/2521))
 
+### Security
+- **Release workflow hardening**: Avoid persisting checkout credentials, disable dependency-cache restoration in the PyPI publishing job, and pass release metadata to shell steps through environment variables instead of direct expression interpolation.
+
 ### Fixed
 - **Anthropic batch accounting**: Include canceled and expired requests in reported batch totals. ([#2529](https://github.com/567-labs/instructor/pull/2529))
 - **Cache key isolation**: Include provider-hoisted system prompts in sync and async cache keys so requests with different instructions cannot share a cached response. ([#2524](https://github.com/567-labs/instructor/pull/2524))

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -66,7 +66,7 @@ if TYPE_CHECKING:
         openai_moderation as openai_moderation,
     )
 
-__version__ = "1.16.0"
+__version__ = "1.16.1"
 
 __all__ = [
     "Instructor",

--- a/instructor/batch/models.py
+++ b/instructor/batch/models.py
@@ -268,7 +268,9 @@ class BatchJobInfo(BaseModel):
             expired=request_counts_data.get("expired"),
             total=request_counts_data.get("processing", 0)
             + request_counts_data.get("succeeded", 0)
-            + request_counts_data.get("errored", 0),
+            + request_counts_data.get("errored", 0)
+            + request_counts_data.get("canceled", 0)
+            + request_counts_data.get("expired", 0),
         )
 
         # Parse files

--- a/instructor/cache/__init__.py
+++ b/instructor/cache/__init__.py
@@ -148,6 +148,7 @@ def make_cache_key(
     model: str | None,
     response_model: type[BaseModel] | None,
     mode: str | None = None,
+    system: Any = None,
 ) -> str:  # noqa: ANN401
     """Compute a *deterministic* cache key.
 
@@ -157,6 +158,10 @@ def make_cache_key(
     Components that influence the key:
         • provider/model name
         • serialized *messages* (user + system prompt, etc.)
+        • *system* – providers such as Anthropic and Bedrock hoist system
+          messages out of ``messages`` into a separate top-level parameter,
+          so it has to be hashed separately or two calls that only differ in
+          their system prompt would collide.
         • *mode* (Tools, JSON, …) – helps when users change Instructor mode
         • *response_model* schema – so edits to field definitions or
           descriptions invalidate prior cache entries (critical!).
@@ -167,6 +172,11 @@ def make_cache_key(
         "messages": messages,
         "mode": mode,
     }
+
+    # Only added when present so keys for providers that keep the system
+    # prompt inside ``messages`` (OpenAI & friends) stay unchanged.
+    if system is not None:
+        payload["system"] = system
 
     if response_model is not None:
         # Include the entire JSON schema – guarantees busting when either

--- a/instructor/cli/usage.py
+++ b/instructor/cli/usage.py
@@ -50,7 +50,7 @@ async def get_usage_for_past_n_days(
 
 
 # Define the cost per unit for each model
-MODEL_COSTS = {
+MODEL_COSTS: dict[str, Union[dict[str, float], float]] = {
     "gpt-4o": {"prompt": 0.005 / 1000, "completion": 0.015 / 1000},
     "gpt-4o-2024-05-13": {"prompt": 0.005 / 1000, "completion": 0.015 / 1000},
     "gpt-4-turbo": {"prompt": 0.01 / 1000, "completion": 0.03 / 1000},

--- a/instructor/v2/auto_client.py
+++ b/instructor/v2/auto_client.py
@@ -114,6 +114,14 @@ def from_provider(
             '(e.g. "openai/gpt-4" or "anthropic/claude-3-sonnet")'
         ) from None
 
+    if not provider or not model_name:
+        from instructor.v2.core.errors import ConfigurationError
+
+        raise ConfigurationError(
+            'Model string must be in format "provider/model-name" '
+            'with both parts non-empty (e.g. "openai/gpt-4")'
+        )
+
     provider_info = {"provider": provider, "operation": "initialize"}
     logger.info(
         "Initializing %s provider with model %s",

--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -93,6 +93,8 @@ def merge_consecutive_messages(messages: list[dict[str, Any]]) -> list[dict[str,
         is_plain_message = set(message).issubset({"role", "content"})
         if new_content is None:
             new_content = ""
+        elif isinstance(new_content, list):
+            new_content = list(new_content)
         if not flat_string and isinstance(new_content, str):
             new_content = [{"type": "text", "text": new_content}]
 

--- a/instructor/v2/core/messages.py
+++ b/instructor/v2/core/messages.py
@@ -70,6 +70,7 @@ def dump_message(message: ChatCompletionMessage) -> ChatCompletionMessageParam:
 
 
 def merge_consecutive_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Merge adjacent plain messages without crossing protocol boundaries."""
     if not messages:
         return []
 
@@ -89,12 +90,18 @@ def merge_consecutive_messages(messages: list[dict[str, Any]]) -> list[dict[str,
     for message in messages:
         role = message.get("role", "user")
         new_content = message.get("content", "")
+        is_plain_message = set(message).issubset({"role", "content"})
         if new_content is None:
             new_content = ""
         if not flat_string and isinstance(new_content, str):
             new_content = [{"type": "text", "text": new_content}]
 
-        if new_messages and role == new_messages[-1]["role"]:
+        if (
+            new_messages
+            and role == new_messages[-1]["role"]
+            and is_plain_message
+            and set(new_messages[-1]).issubset({"role", "content"})
+        ):
             if flat_string:
                 new_messages[-1]["content"] += f"\n\n{new_content}"
             elif isinstance(new_content, list):
@@ -102,7 +109,9 @@ def merge_consecutive_messages(messages: list[dict[str, Any]]) -> list[dict[str,
             else:
                 new_messages[-1]["content"].append(new_content)
         else:
-            new_messages.append({"role": role, "content": new_content})
+            new_message = dict(message)
+            new_message.update(role=role, content=new_content)
+            new_messages.append(new_message)
 
     return new_messages
 

--- a/instructor/v2/core/multimodal.py
+++ b/instructor/v2/core/multimodal.py
@@ -50,6 +50,13 @@ CacheControlType = Mapping[str, str]
 OptionalCacheControlType = Optional[CacheControlType]
 
 
+def _normalize_media_type(media_type: str | None) -> str | None:
+    """Return the lowercase media type without optional HTTP parameters."""
+    if media_type is None:
+        return None
+    return media_type.split(";", 1)[0].strip().lower()
+
+
 class ImageParamsBase(TypedDict):
     type: Literal["image"]
     source: str
@@ -151,7 +158,7 @@ class Image(BaseModel):
         try:
             response = requests.get(public_url, timeout=timeout)
             response.raise_for_status()
-            media_type = response.headers.get("Content-Type")
+            media_type = _normalize_media_type(response.headers.get("Content-Type"))
             if media_type not in VALID_MIME_TYPES:
                 raise ValueError(f"Unsupported image format: {media_type}")
 
@@ -204,7 +211,7 @@ class Image(BaseModel):
         if not media_type:
             try:
                 response = requests.head(url, allow_redirects=True, timeout=30)
-                media_type = response.headers.get("Content-Type")
+                media_type = _normalize_media_type(response.headers.get("Content-Type"))
             except requests.RequestException as e:
                 raise ValueError(f"Failed to fetch image from URL") from e
 
@@ -325,7 +332,7 @@ class Audio(BaseModel):
         if url.startswith("gs://"):
             return cls.from_gs_url(url)
         response = requests.get(url, timeout=30)
-        content_type = response.headers.get("content-type")
+        content_type = _normalize_media_type(response.headers.get("content-type"))
         if content_type not in VALID_AUDIO_MIME_TYPES:
             raise ValueError(
                 f"Unsupported audio format: {content_type}. "
@@ -381,7 +388,7 @@ class Audio(BaseModel):
         try:
             response = requests.get(public_url, timeout=timeout)
             response.raise_for_status()
-            media_type = response.headers.get("Content-Type")
+            media_type = _normalize_media_type(response.headers.get("Content-Type"))
             if media_type not in VALID_AUDIO_MIME_TYPES:
                 raise ValueError(f"Unsupported audio format: {media_type}")
 
@@ -569,7 +576,9 @@ class PDF(BaseModel):
         try:
             response = requests.get(public_url, timeout=timeout)
             response.raise_for_status()
-            media_type = response.headers.get("Content-Type", "application/pdf")
+            media_type = _normalize_media_type(
+                response.headers.get("Content-Type", "application/pdf")
+            )
             if media_type not in VALID_PDF_MIME_TYPES:
                 raise ValueError(f"Unsupported PDF format: {media_type}")
 
@@ -592,7 +601,7 @@ class PDF(BaseModel):
         if not media_type:
             try:
                 response = requests.head(url, allow_redirects=True, timeout=30)
-                media_type = response.headers.get("Content-Type")
+                media_type = _normalize_media_type(response.headers.get("Content-Type"))
             except requests.RequestException as e:
                 raise ValueError("Failed to fetch PDF from URL") from e
 

--- a/instructor/v2/core/patch.py
+++ b/instructor/v2/core/patch.py
@@ -255,6 +255,7 @@ def _create_sync_wrapper(
                     model=new_kwargs.get("model"),
                     response_model=response_model,
                     mode=str(mode.value),
+                    system=new_kwargs.get("system"),
                 )
                 cached = load_cached_response(cache, key, response_model)
                 if cached is not None:
@@ -295,6 +296,7 @@ def _create_sync_wrapper(
                         model=new_kwargs.get("model"),
                         response_model=response_model,
                         mode=str(mode.value),
+                        system=new_kwargs.get("system"),
                     )
                     store_cached_response(cache, key, response, ttl=cache_ttl)
             except ModuleNotFoundError:
@@ -378,6 +380,7 @@ def _create_async_wrapper(
                     model=new_kwargs.get("model"),
                     response_model=response_model,
                     mode=str(mode.value),
+                    system=new_kwargs.get("system"),
                 )
                 cached = load_cached_response(cache, key, response_model)
                 if cached is not None:
@@ -418,6 +421,7 @@ def _create_async_wrapper(
                         model=new_kwargs.get("model"),
                         response_model=response_model,
                         mode=str(mode.value),
+                        system=new_kwargs.get("system"),
                     )
                     store_cached_response(cache, key, response, ttl=cache_ttl)
             except ModuleNotFoundError:

--- a/instructor/v2/core/registry.py
+++ b/instructor/v2/core/registry.py
@@ -188,11 +188,9 @@ class ModeRegistry:
         if mode_key in self._handlers:
             return self._handlers[mode_key]
 
-        # Try lazy loading. Locked because the pop -> import -> set sequence
-        # below is not atomic: without the lock, a thread that loses the race
-        # to pop self._lazy_loaders[mode_key] would find it already gone and
-        # self._handlers[mode_key] not yet set, and raise KeyError even
-        # though the mode genuinely is registered (just still resolving).
+        # Try lazy loading. Locked because resolving and publishing a loader is
+        # not atomic; without the lock, concurrent first callers could run it
+        # repeatedly.
         with self._lazy_load_lock:
             # Re-check: another thread may have finished loading this key
             # while we were waiting for the lock.
@@ -200,9 +198,10 @@ class ModeRegistry:
                 return self._handlers[mode_key]
 
             if mode_key in self._lazy_loaders:
-                loader = self._lazy_loaders.pop(mode_key)
+                loader = self._lazy_loaders[mode_key]
                 handlers = loader()
                 self._handlers[mode_key] = handlers
+                self._lazy_loaders.pop(mode_key, None)
                 return handlers
 
         raise KeyError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "regex>=2023.0.0,<2027.0.0",
 ]
 name = "instructor"
-version = "1.16.0"
+version = "1.16.1"
 description = "structured outputs for llm"
 readme = "README.md"
 

--- a/tests/cache/test_cache_integration.py
+++ b/tests/cache/test_cache_integration.py
@@ -101,3 +101,68 @@ def test_auto_cache_prevents_duplicate_calls_after_a_retry(monkeypatch):
     assert call_counter["n"] == 2, (
         "Second, identical call should hit the cache instead of calling the provider again"
     )
+
+
+def test_cache_key_accounts_for_hoisted_system_prompt():
+    """Regression test: a system prompt hoisted out of ``messages`` must be hashed.
+
+    Providers like Anthropic and Bedrock move ``role="system"`` messages out of
+    ``messages`` into a separate top-level ``system`` parameter during request
+    preparation, which happens *before* patch.py computes the cache key. If the
+    key only hashes the remaining ``messages``, two calls that differ solely in
+    their system prompt collide and the second silently returns the first
+    call's answer.
+    """
+    import anthropic
+    from anthropic.types import Message, TextBlock, Usage
+
+    class Answer(BaseModel):
+        value: str
+
+    call_counter = {"n": 0}
+
+    def fake_create(*_args, **_kwargs):
+        call_counter["n"] += 1
+        content = Answer(value=f"call-{call_counter['n']}").model_dump_json()
+        return Message(
+            id="msg_1",
+            model="claude-3-5-sonnet-latest",
+            role="assistant",
+            type="message",
+            stop_reason="end_turn",
+            content=[TextBlock(type="text", text=content)],
+            usage=Usage(input_tokens=1, output_tokens=1),
+        )
+
+    raw_client = anthropic.Anthropic(api_key="sk-not-used")
+    raw_client.messages.create = fake_create
+    client = instructor.from_anthropic(raw_client, mode=instructor.Mode.JSON)
+
+    cache = AutoCache(maxsize=10)
+
+    def ask(system_prompt: str) -> Answer:
+        return client.create(
+            model="claude-3-5-sonnet-latest",
+            max_tokens=100,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": "hello"},
+            ],
+            response_model=Answer,
+            cache=cache,
+        )
+
+    first = ask("Always answer in French.")
+    assert call_counter["n"] == 1
+    assert first.value == "call-1"
+
+    second = ask("Always answer in German.")
+    assert call_counter["n"] == 2, (
+        "A different system prompt must not reuse the cached response"
+    )
+    assert second.value == "call-2"
+
+    # Repeating the very first request must still hit the cache.
+    repeat = ask("Always answer in French.")
+    assert call_counter["n"] == 2, "Identical request should still be served from cache"
+    assert repeat.value == "call-1"

--- a/tests/cache/test_cache_integration.py
+++ b/tests/cache/test_cache_integration.py
@@ -135,7 +135,7 @@ def test_cache_key_accounts_for_hoisted_system_prompt():
         )
 
     raw_client = anthropic.Anthropic(api_key="sk-not-used")
-    raw_client.messages.create = fake_create
+    raw_client.messages.create = fake_create  # ty: ignore[invalid-assignment]
     client = instructor.from_anthropic(raw_client, mode=instructor.Mode.JSON)
 
     cache = AutoCache(maxsize=10)

--- a/tests/cache/test_cache_key.py
+++ b/tests/cache/test_cache_key.py
@@ -59,3 +59,29 @@ def test_cache_key_changes_on_docstring_change():
     k1 = make_cache_key(messages=messages, model=model_name, response_model=UserDoc1)
     k2 = make_cache_key(messages=messages, model=model_name, response_model=UserDoc2)
     assert k1 != k2, "Changing class docstring should bust the cache key"
+
+
+def test_cache_key_changes_on_system_prompt_change():
+    k1 = make_cache_key(
+        messages=messages,
+        model=model_name,
+        response_model=UserV1,
+        system="Always answer in French.",
+    )
+    k2 = make_cache_key(
+        messages=messages,
+        model=model_name,
+        response_model=UserV1,
+        system="Always answer in German.",
+    )
+    assert k1 != k2, "Changing the hoisted system prompt should bust the cache key"
+
+
+def test_cache_key_unchanged_when_no_system_prompt():
+    without = make_cache_key(messages=messages, model=model_name, response_model=UserV1)
+    explicit_none = make_cache_key(
+        messages=messages, model=model_name, response_model=UserV1, system=None
+    )
+    assert without == explicit_none, (
+        "Keys must stay stable for providers without a hoisted system prompt"
+    )

--- a/tests/coverage/test_batch_api_coverage.py
+++ b/tests/coverage/test_batch_api_coverage.py
@@ -330,7 +330,7 @@ def test_anthropic_batch_job_info_accepts_timestamp_variants_and_counts() -> Non
         2025, 1, 2, 12, 0, tzinfo=timezone.utc
     )
     assert result.request_counts.model_dump() == {
-        "total": 10,
+        "total": 17,
         "completed": None,
         "failed": None,
         "processing": 1,

--- a/tests/coverage/test_core_multimodal_coverage.py
+++ b/tests/coverage/test_core_multimodal_coverage.py
@@ -104,6 +104,28 @@ def test_image_url_errors_missing_path_and_unsupported_data_uri(
         Image.from_base64("data:image/tiff;base64,aW1hZ2U=")
 
 
+def test_remote_media_types_ignore_http_parameters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def head(url: str, **_kwargs: Any) -> requests.Response:
+        media_type = "image/png" if "photo" in url else "application/pdf"
+        return response(b"", f"{media_type}; charset=binary")
+
+    def get(_url: str, **_kwargs: Any) -> requests.Response:
+        return response(b"audio", "Audio/WAV; codecs=1")
+
+    monkeypatch.setattr(requests, "head", head)
+    monkeypatch.setattr(requests, "get", get)
+
+    image = Image.from_url("https://example.test/photo")
+    audio = Audio.from_url("https://example.test/audio")
+    pdf = PDF.from_url("https://example.test/report")
+
+    assert image.media_type == "image/png"
+    assert audio.media_type == "audio/wav"
+    assert pdf.media_type == "application/pdf"
+
+
 def test_image_path_probe_falls_back_to_raw_base64(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/coverage/test_core_multimodal_coverage.py
+++ b/tests/coverage/test_core_multimodal_coverage.py
@@ -16,6 +16,7 @@ from instructor.v2.core.multimodal import (
     ImageWithCacheControl,
     PDF,
     PDFWithGenaiFile,
+    _normalize_media_type,
     autodetect_media,
     convert_messages,
 )
@@ -107,6 +108,8 @@ def test_image_url_errors_missing_path_and_unsupported_data_uri(
 def test_remote_media_types_ignore_http_parameters(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    assert _normalize_media_type(None) is None
+
     def head(url: str, **_kwargs: Any) -> requests.Response:
         media_type = "image/png" if "photo" in url else "application/pdf"
         return response(b"", f"{media_type}; charset=binary")

--- a/tests/processing/test_message_processing.py
+++ b/tests/processing/test_message_processing.py
@@ -105,9 +105,37 @@ class TestMergeConsecutiveMessages:
             },
         ]
         result = merge_consecutive_messages(messages)
-        assert len(result) == 2
+        assert len(result) == 3
         assert result[0]["role"] == "user"
         assert result[1]["role"] == "assistant"
+        assert result[1]["tool_calls"] == [{"id": "call_1"}]
+        assert result[2]["tool_calls"] == [{"id": "call_2"}]
+
+    def test_tool_call_fields_are_preserved(self):
+        """Tool-call history must keep the fields that link calls to results."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": "result",
+                "tool_call_id": "call_1",
+            },
+        ]
+
+        result = merge_consecutive_messages(messages)
+
+        assert result[0]["tool_calls"] == messages[0]["tool_calls"]
+        assert result[1]["tool_call_id"] == "call_1"
 
 
 class TestGetMessageContent:

--- a/tests/processing/test_message_processing.py
+++ b/tests/processing/test_message_processing.py
@@ -137,6 +137,21 @@ class TestMergeConsecutiveMessages:
         assert result[0]["tool_calls"] == messages[0]["tool_calls"]
         assert result[1]["tool_call_id"] == "call_1"
 
+    def test_merging_list_content_does_not_mutate_input(self):
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "first"}]},
+            {"role": "user", "content": [{"type": "text", "text": "second"}]},
+        ]
+        original_content = list(messages[0]["content"])
+
+        result = merge_consecutive_messages(messages)
+
+        assert messages[0]["content"] == original_content
+        assert result[0]["content"] == [
+            {"type": "text", "text": "first"},
+            {"type": "text", "text": "second"},
+        ]
+
 
 class TestGetMessageContent:
     """Test the get_message_content function."""

--- a/tests/test_batch_in_memory.py
+++ b/tests/test_batch_in_memory.py
@@ -225,3 +225,27 @@ class TestProviderInMemorySupport:
             anthropic_provider.submit_batch(
                 123  # ty: ignore[invalid-argument-type] - deliberately invalid input
             )
+
+
+def test_from_anthropic_total_counts_all_buckets():
+    """total must include canceled and expired requests.
+
+    Anthropic returns five request_counts buckets. ``from_anthropic`` summed only
+    processing + succeeded + errored, silently dropping canceled and expired, so
+    the reported total undercounted the batch.
+    """
+    from instructor.batch.models import BatchJobInfo
+
+    data = {
+        "id": "msgbatch_1",
+        "processing_status": "ended",
+        "request_counts": {
+            "processing": 0,
+            "succeeded": 10,
+            "errored": 2,
+            "canceled": 3,
+            "expired": 5,
+        },
+    }
+    rc = BatchJobInfo.from_anthropic(data).request_counts
+    assert rc.total == 20

--- a/tests/test_batch_in_memory.py
+++ b/tests/test_batch_in_memory.py
@@ -225,27 +225,3 @@ class TestProviderInMemorySupport:
             anthropic_provider.submit_batch(
                 123  # ty: ignore[invalid-argument-type] - deliberately invalid input
             )
-
-
-def test_from_anthropic_total_counts_all_buckets():
-    """total must include canceled and expired requests.
-
-    Anthropic returns five request_counts buckets. ``from_anthropic`` summed only
-    processing + succeeded + errored, silently dropping canceled and expired, so
-    the reported total undercounted the batch.
-    """
-    from instructor.batch.models import BatchJobInfo
-
-    data = {
-        "id": "msgbatch_1",
-        "processing_status": "ended",
-        "request_counts": {
-            "processing": 0,
-            "succeeded": 10,
-            "errored": 2,
-            "canceled": 3,
-            "expired": 5,
-        },
-    }
-    rc = BatchJobInfo.from_anthropic(data).request_counts
-    assert rc.total == 20

--- a/tests/v2/test_auto_client_deterministic.py
+++ b/tests/v2/test_auto_client_deterministic.py
@@ -19,9 +19,10 @@ def test_from_provider_requires_provider_prefix() -> None:
         auto_client.from_provider("gpt-5")
 
 
-def test_from_provider_rejects_empty_model_name() -> None:
+@pytest.mark.parametrize("model", ["openai/", "/gpt-4"])
+def test_from_provider_rejects_empty_model_parts(model: str) -> None:
     with pytest.raises(ConfigurationError, match="Model string must be in format"):
-        auto_client.from_provider("openai/")
+        auto_client.from_provider(model)
 
 
 def test_from_provider_rejects_unknown_provider() -> None:

--- a/tests/v2/test_auto_client_deterministic.py
+++ b/tests/v2/test_auto_client_deterministic.py
@@ -19,6 +19,11 @@ def test_from_provider_requires_provider_prefix() -> None:
         auto_client.from_provider("gpt-5")
 
 
+def test_from_provider_rejects_empty_model_name() -> None:
+    with pytest.raises(ConfigurationError, match="Model string must be in format"):
+        auto_client.from_provider("openai/")
+
+
 def test_from_provider_rejects_unknown_provider() -> None:
     with pytest.raises(ConfigurationError, match="Unsupported provider: mystery"):
         auto_client.from_provider("mystery/model")

--- a/tests/v2/test_registry.py
+++ b/tests/v2/test_registry.py
@@ -186,3 +186,36 @@ def test_get_handlers_concurrent_first_access_does_not_race():
     )
     # The loader must run exactly once, not once per racing thread.
     assert load_count == 1
+
+
+def test_registry_stays_registered_while_lazy_loader_runs():
+    """The mode remains registered while its lazy loader is in progress."""
+    import threading
+
+    from instructor.v2.core.registry import ModeHandlers, ModeRegistry
+
+    registry = ModeRegistry()
+    load_started = threading.Event()
+    finish_load = threading.Event()
+
+    def slow_loader() -> ModeHandlers:
+        load_started.set()
+        finish_load.wait(timeout=5)
+        return ModeHandlers(
+            request_handler=cast(Any, lambda *_a, **_k: None),
+            reask_handler=cast(Any, lambda *_a, **_k: None),
+            response_parser=cast(Any, lambda *_a, **_k: None),
+        )
+
+    registry.register_lazy(Provider.DEEPSEEK, Mode.TOOLS, slow_loader)
+    thread = threading.Thread(
+        target=registry.get_handlers, args=(Provider.DEEPSEEK, Mode.TOOLS)
+    )
+    thread.start()
+    assert load_started.wait(timeout=5)
+    try:
+        assert registry.is_registered(Provider.DEEPSEEK, Mode.TOOLS)
+    finally:
+        finish_load.set()
+        thread.join(timeout=5)
+    assert not thread.is_alive()

--- a/tests/v2/test_registry.py
+++ b/tests/v2/test_registry.py
@@ -215,7 +215,36 @@ def test_registry_stays_registered_while_lazy_loader_runs():
     assert load_started.wait(timeout=5)
     try:
         assert registry.is_registered(Provider.DEEPSEEK, Mode.TOOLS)
+        assert (Provider.DEEPSEEK, Mode.TOOLS) in registry.list_modes()
     finally:
         finish_load.set()
         thread.join(timeout=5)
     assert not thread.is_alive()
+
+
+def test_failed_lazy_loader_remains_retryable():
+    """A transient loader failure must not permanently unregister the mode."""
+    from instructor.v2.core.registry import ModeHandlers, ModeRegistry
+
+    registry = ModeRegistry()
+    attempts = 0
+
+    def flaky_loader() -> ModeHandlers:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("transient import failure")
+        return ModeHandlers(
+            request_handler=cast(Any, lambda *_a, **_k: None),
+            reask_handler=cast(Any, lambda *_a, **_k: None),
+            response_parser=cast(Any, lambda *_a, **_k: None),
+        )
+
+    registry.register_lazy(Provider.DEEPSEEK, Mode.TOOLS, flaky_loader)
+
+    with pytest.raises(RuntimeError, match="transient import failure"):
+        registry.get_handlers(Provider.DEEPSEEK, Mode.TOOLS)
+
+    assert registry.is_registered(Provider.DEEPSEEK, Mode.TOOLS)
+    assert registry.get_handlers(Provider.DEEPSEEK, Mode.TOOLS)
+    assert attempts == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1805,7 +1805,7 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.16.0"
+version = "1.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- prepare the source, lockfile, and changelog as the `1.16.1` maintenance line
- reject malformed `from_provider()` model strings before client construction
- include hoisted system prompts in sync and async cache keys
- normalize parameterized and case-insensitive remote media types
- preserve tool-call protocol fields and caller-owned content while merging messages
- include canceled and expired Anthropic requests in batch totals
- keep lazy registry entries visible and retryable while handlers load
- add the missing CLI cost-table annotation from #2521 without its stray commits

## Consolidated work

Supersedes #2521, #2522, #2524, #2525, #2527, #2529, and #2536.

Closes #2526 and #2535.

Original commits and authors are retained where the branches were clean. The follow-up commits resolve changelog overlap and strengthen boundary coverage: both empty provider components, list-content input immutability, the existing Anthropic count fixture, `list_modes()` visibility during lazy loading, retry after a transient loader failure, and the missing media-type guard.

## Validation

- release validator reports `1.16.1`
- `273 passed` across the affected cache, message, multimodal, batch, auto-client, and registry suites
- Ruff check passed on `instructor`, `examples`, and `tests`
- Ruff format check passed on `instructor`, `examples`, and `tests`
- strict `ty` source and changed-test checks passed
- `uv lock --check` passed
- commit preflight passed dependency installation, lock, Ruff, format, and type checks
- `git diff --check` passed

## Intentionally separate from 1.16.1

- OpenAI v3 support in #2558 needs bounded dependency and real sync/async/stream/retry compatibility coverage
- async validators in #2559 need correct return-value semantics and a clear sync-client failure contract
- #2534 and #2409 depend on provider protocol or SDK-internal decisions and need dedicated review
- broad provider additions, architecture changes, examples, and dependency batches remain outside this patch release

Small provider-correctness and documentation candidates will be evaluated independently after this PR lands; none are required for this consolidation's correctness.
