### PR TITLE
docs: consolidate 1.16.1 provider guide corrections

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -436,11 +436,16 @@ jobs:
           set +e
           uv run --frozen pytest tests/providers/test_auto_client.py --asyncio-mode=auto -n auto
           status=$?
-          set -e
           if [ $status -eq 5 ]; then
             echo "No tests collected; treating as success."
             exit 0
           fi
+          if [ $status -eq 1 ]; then
+            echo "Retrying only failed live-provider tests once."
+            uv run --frozen pytest tests/providers/test_auto_client.py --asyncio-mode=auto -n auto --last-failed
+            status=$?
+          fi
+          set -e
           exit $status
         env:
           INSTRUCTOR_ENV: CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Changed
 - **CLI cost metadata**: Add an explicit mapping annotation to the model-cost table so static analysis preserves its nested numeric value shape. ([#2521](https://github.com/567-labs/instructor/pull/2521))
 - **Provider documentation**: Correct the Mistral installation extra and xAI Python requirement, document Cerebras request-parameter forwarding with a runnable example, and clean up tracing and extraction typos. ([#2550](https://github.com/567-labs/instructor/pull/2550), [#2554](https://github.com/567-labs/instructor/pull/2554), [#2556](https://github.com/567-labs/instructor/pull/2556), [#2561](https://github.com/567-labs/instructor/pull/2561), [#2562](https://github.com/567-labs/instructor/pull/2562))
-- **Live-provider CI signal**: Retry only failed tests once in the mixed provider lane so transient API failures do not obscure deterministic regressions, while setup, collection, repeated, and other failures remain red.
+- **Live-provider CI signal**: Retry only failed tests once in the mixed-provider and auto-client lanes so transient API failures do not obscure deterministic regressions, while setup, collection, repeated, and other failures remain red.
 
 ### Security
 - **Remote multimodal fetching**: Block non-public and credential-bearing media URLs, revalidate redirects and connected peers, disable ambient proxy credentials, cap image, audio, and PDF downloads, and avoid caching decoded media payloads in process memory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Changed
 - **CLI cost metadata**: Add an explicit mapping annotation to the model-cost table so static analysis preserves its nested numeric value shape. ([#2521](https://github.com/567-labs/instructor/pull/2521))
-- **Provider documentation**: Correct the Mistral installation extra and xAI Python requirement, document Cerebras request-parameter forwarding with a runnable example, and clean up tracing and extraction typos. ([#2550](https://github.com/567-labs/instructor/pull/2550), [#2554](https://github.com/567-labs/instructor/pull/2554), [#2556](https://github.com/567-labs/instructor/pull/2556), [#2561](https://github.com/567-labs/instructor/pull/2561), [#2562](https://github.com/567-labs/instructor/pull/2562))
+- **Provider documentation**: Correct the Mistral installation extra and xAI Python requirement, document Cerebras request-parameter forwarding with a runnable example, repair the Langfuse tracing examples, and clean up extraction typos. ([#2550](https://github.com/567-labs/instructor/pull/2550), [#2554](https://github.com/567-labs/instructor/pull/2554), [#2556](https://github.com/567-labs/instructor/pull/2556), [#2561](https://github.com/567-labs/instructor/pull/2561), [#2562](https://github.com/567-labs/instructor/pull/2562))
 - **Live-provider CI signal**: Retry only failed tests once in the mixed-provider and auto-client lanes so transient API failures do not obscure deterministic regressions, while setup, collection, repeated, and other failures remain red.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,16 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
-### Security
-- **Remote multimodal fetching**: Block non-public and credential-bearing media URLs, revalidate redirects and connected peers, disable ambient proxy credentials, cap image, audio, and PDF downloads, and avoid caching decoded media payloads in process memory.
-- **Supply-chain hardening**: Require a patched `urllib3` release and pin GitHub Actions to reviewed commit SHAs, including secret-bearing scheduled workflows.
-
-## [1.16.1] - 2026-08-27
+## [1.16.1] - 2026-08-28
 
 ### Changed
 - **CLI cost metadata**: Add an explicit mapping annotation to the model-cost table so static analysis preserves its nested numeric value shape. ([#2521](https://github.com/567-labs/instructor/pull/2521))
-- **Live-provider CI signal**: Retry only failed tests once in the mixed provider lane so transient API failures do not obscure deterministic regressions.
+- **Provider documentation**: Correct the Mistral installation extra and xAI Python requirement, document Cerebras request-parameter forwarding with a runnable example, and clean up tracing and extraction typos. ([#2550](https://github.com/567-labs/instructor/pull/2550), [#2554](https://github.com/567-labs/instructor/pull/2554), [#2556](https://github.com/567-labs/instructor/pull/2556), [#2561](https://github.com/567-labs/instructor/pull/2561), [#2562](https://github.com/567-labs/instructor/pull/2562))
+- **Live-provider CI signal**: Retry only failed tests once in the mixed provider lane so transient API failures do not obscure deterministic regressions, while setup, collection, repeated, and other failures remain red.
 
 ### Security
+- **Remote multimodal fetching**: Block non-public and credential-bearing media URLs, revalidate redirects and connected peers, disable ambient proxy credentials, cap image, audio, and PDF downloads, and avoid caching decoded media payloads in process memory.
+- **Supply-chain hardening**: Require a patched `urllib3` release and pin GitHub Actions to reviewed commit SHAs, including secret-bearing scheduled workflows.
 - **Release workflow hardening**: Avoid persisting checkout credentials, disable dependency-cache restoration in the PyPI publishing job, and pass release metadata to shell steps through environment variables instead of direct expression interpolation.
 
 ### Fixed

--- a/docs/concepts/prompt_caching.md
+++ b/docs/concepts/prompt_caching.md
@@ -33,7 +33,7 @@ Caching is based on prefix matching, so if you're using a system prompt that con
 
 ## Prompt Caching in Anthropic
 
-Prompt Caching is now generally avaliable for Anthropic. This enables you to cache specific prompt portions, reuse cached content in subsequent calls, and reduce processed data per request.
+Prompt Caching is now generally available for Anthropic. This enables you to cache specific prompt portions, reuse cached content in subsequent calls, and reduce processed data per request.
 
 ??? note "Source Text"
 

--- a/docs/concepts/types.md
+++ b/docs/concepts/types.md
@@ -264,7 +264,7 @@ MarkdownDataFrame = Annotated[
             "description": """
             The markdown representation of the table,
             each one should be tidy, do not try to join
-            tables that should be seperate""",
+            tables that should be separate""",
         }
     ),
 ]

--- a/docs/examples/batch_job_oai.md
+++ b/docs/examples/batch_job_oai.md
@@ -210,5 +210,5 @@ if os.path.exists("./output.jsonl"):
 
 This will then return a list of two elements
 
-- `parsed` is a list of responses that have been succesfully parsed into the `QuestionAnswerPair` Base Model class
+- `parsed` is a list of responses that have been successfully parsed into the `QuestionAnswerPair` Base Model class
 - `unparsed` is a second list which contains responses which were not able to be parsed into the `QuestionAnswerPair` Base Model class

--- a/docs/examples/extracting_tables.md
+++ b/docs/examples/extracting_tables.md
@@ -50,7 +50,7 @@ MarkdownDataFrame = Annotated[
     WithJsonSchema(
         {
             "type": "string",
-            "description": "The markdown representation of the table, each one should be tidy, do not try to join tables that should be seperate",
+            "description": "The markdown representation of the table, each one should be tidy, do not try to join tables that should be separate",
         }
     ),
 ]
@@ -93,7 +93,7 @@ MarkdownDataFrame = Annotated[
     WithJsonSchema(
         {
             "type": "string",
-            "description": "The markdown representation of the table, each one should be tidy, do not try to join tables that should be seperate",
+            "description": "The markdown representation of the table, each one should be tidy, do not try to join tables that should be separate",
         }
     ),
 ]

--- a/docs/examples/pandas_df.md
+++ b/docs/examples/pandas_df.md
@@ -52,7 +52,7 @@ MarkdownDataFrame = Annotated[
             "description": """
             The markdown representation of the table,
             each one should be tidy, do not try to join
-            tables that should be seperate""",
+            tables that should be separate""",
         }
     ),
 ]

--- a/docs/examples/tables_from_vision.md
+++ b/docs/examples/tables_from_vision.md
@@ -56,7 +56,7 @@ MarkdownDataFrame = Annotated[
             "description": """
                 The markdown representation of the table,
                 each one should be tidy, do not try to join tables
-                that should be seperate""",
+                that should be separate""",
         }
     ),
 ]

--- a/docs/examples/tracing_with_langfuse.md
+++ b/docs/examples/tracing_with_langfuse.md
@@ -19,8 +19,8 @@ This cookbook shows how to use Langfuse to trace and monitor model calls made wi
 
 First, let's start by installing the necessary dependencies.
 
-```python
-pip install langfuse instructor
+```shell
+pip install --upgrade langfuse openai pydantic instructor
 ```
 
 It is easy to use instructor with Langfuse. We use the [Langfuse OpenAI Integration](https://langfuse.com/docs/integrations/openai) and simply patch the client with instructor. This works with both synchronous and asynchronous clients.
@@ -28,19 +28,20 @@ It is easy to use instructor with Langfuse. We use the [Langfuse OpenAI Integrat
 ### Langfuse-Instructor integration with synchronous OpenAI client
 
 ```python
-import instructor
-from langfuse.openai import openai
-from pydantic import BaseModel
 import os
+
+import instructor
+from langfuse.openai import OpenAI
+from pydantic import BaseModel
 
 # Set your API keys Here
 os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-..."
 os.environ["LANGFUSE_SECRET_KEY"] = "sk-..."
-os.environ["LANGFUSE_HOST"] = "https://us.cloud.langfuse.com"
-os.environ["OPENAI_API_KEY] = "sk-..."
+os.environ["LANGFUSE_BASE_URL"] = "https://us.cloud.langfuse.com"
+os.environ["OPENAI_API_KEY"] = "sk-..."
 
 # Patch Langfuse wrapper of synchronous OpenAI client with instructor
-client = instructor.from_provider("openai/gpt-5-nano")
+client = instructor.patch(OpenAI())
 
 
 class WeatherDetail(BaseModel):
@@ -49,7 +50,7 @@ class WeatherDetail(BaseModel):
 
 
 # Run synchronous OpenAI client
-weather_info = client.create(
+weather_info = client.chat.completions.create(
     model="gpt-4o",
     response_model=WeatherDetail,
     messages=[
@@ -71,21 +72,22 @@ Once we've run this request successfully, we'll see that we have a trace availab
 ### Langfuse-Instructor integration with asynchronous OpenAI client
 
 ```python
-import instructor
-from langfuse.openai import openai
-from pydantic import BaseModel
-import os
 import asyncio
+import os
+
+import instructor
+from langfuse.openai import AsyncOpenAI
+from pydantic import BaseModel
 
 # Set your API keys Here
 os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-"
 os.environ["LANGFUSE_SECRET_KEY"] = "sk-"
-os.environ["LANGFUSE_HOST"] = "https://us.cloud.langfuse.com"
-os.environ["OPENAI_API_KEY] = "sk-..."
+os.environ["LANGFUSE_BASE_URL"] = "https://us.cloud.langfuse.com"
+os.environ["OPENAI_API_KEY"] = "sk-..."
 
 
-# Patch Langfuse wrapper of synchronous OpenAI client with instructor
-client = instructor.from_provider("openai/gpt-5-nano", async_client=True)
+# Patch Langfuse wrapper of asynchronous OpenAI client with instructor
+client = instructor.patch(AsyncOpenAI())
 
 
 class WeatherDetail(BaseModel):
@@ -94,8 +96,8 @@ class WeatherDetail(BaseModel):
 
 
 async def main():
-    # Run synchronous OpenAI client
-    weather_info = await client.create(
+    # Run asynchronous OpenAI client
+    weather_info = await client.chat.completions.create(
         model="gpt-4o",
         response_model=WeatherDetail,
         messages=[
@@ -123,30 +125,27 @@ Here's a [public link](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1
 In this example, we first classify customer feedback into categories like `PRAISE`, `SUGGESTION`, `BUG` and `QUESTION`, and further scores the relevance of each feedback to the business on a scale of 0.0 to 1.0. In this case, we use the asynchronous OpenAI client `AsyncOpenAI` to classify and evaluate the feedback.
 
 ```python
-from enum import Enum
-
 import asyncio
-import instructor
-
-from langfuse import Langfuse
-from langfuse.openai import AsyncOpenAI
-from langfuse.decorators import langfuse_context, observe
-
-from pydantic import BaseModel, Field, field_validator
+from enum import Enum
 import os
+
+import instructor
+from langfuse import get_client, observe
+from langfuse.openai import AsyncOpenAI
+from pydantic import BaseModel, Field, field_validator
 
 # Set your API keys Here
 os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-..."
 os.environ["LANGFUSE_SECRET_KEY"] = "sk-..."
-os.environ["LANGFUSE_HOST"] = "https://us.cloud.langfuse.com"
-os.environ["OPENAI_API_KEY] = "sk-..."
+os.environ["LANGFUSE_BASE_URL"] = "https://us.cloud.langfuse.com"
+os.environ["OPENAI_API_KEY"] = "sk-..."
 
 
-
-client = instructor.from_provider("openai/gpt-5-nano", async_client=True)
+# Patch the Langfuse wrapper with Instructor.
+client = instructor.patch(AsyncOpenAI(), mode=instructor.Mode.TOOLS)
 
 # Initialize Langfuse (needed for scoring)
-langfuse = Langfuse()
+langfuse = get_client()
 
 # Rate limit the number of requests
 sem = asyncio.Semaphore(5)
@@ -185,7 +184,7 @@ async def classify_feedback(feedback: str):
     Classify customer feedback into categories and evaluate relevance.
     """
     async with sem:  # simple rate limiting
-        response = await client.create(
+        response = await client.chat.completions.create(
             model="gpt-4o",
             response_model=FeedbackClassification,
             max_retries=2,
@@ -198,7 +197,7 @@ async def classify_feedback(feedback: str):
         )
 
         # Retrieve observation_id of current span
-        observation_id = langfuse_context.get_current_observation_id()
+        observation_id = langfuse.get_current_observation_id()
 
         return feedback, response, observation_id
 
@@ -207,7 +206,7 @@ def score_relevance(trace_id: str, observation_id: str, relevance_score: float):
     """
     Score the relevance of a feedback query in Langfuse given the observation_id.
     """
-    langfuse.score(
+    langfuse.create_score(
         trace_id=trace_id,
         observation_id=observation_id,
         name="feedback-relevance",
@@ -230,13 +229,13 @@ async def main(feedbacks: list[str]):
         results.append(result)
 
         # Retrieve trace_id of current trace
-        trace_id = langfuse_context.get_current_trace_id()
+        trace_id = langfuse.get_current_trace_id()
 
         # Score the relevance of the feedback in Langfuse
         score_relevance(trace_id, observation_id, classification.relevance_score)
 
     # Flush observations to Langfuse
-    langfuse_context.flush()
+    langfuse.flush()
     return results
 
 

--- a/docs/examples/tracing_with_langfuse.md
+++ b/docs/examples/tracing_with_langfuse.md
@@ -66,9 +66,9 @@ print(weather_info.model_dump_json(indent=2))
 """
 ```
 
-Once we've run this request succesfully, we'll see that we have a trace avaliable in the Langfuse dashboard for you to look at.
+Once we've run this request successfully, we'll see that we have a trace available in the Langfuse dashboard for you to look at.
 
-### Langfuse-Instructor integration with asychnronous OpenAI client
+### Langfuse-Instructor integration with asynchronous OpenAI client
 
 ```python
 import instructor

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,7 +37,7 @@ pip install "instructor[google-genai]"         # For Google/Gemini
 pip install "instructor[vertexai]"             # For Vertex AI
 pip install "instructor[cohere]"               # For Cohere
 pip install "instructor[litellm]"              # For LiteLLM (multiple providers)
-pip install "instructor[mistralai]"            # For Mistral
+pip install "instructor[mistral]"               # For Mistral
 pip install "instructor[xai]"                  # For xAI
 ```
 

--- a/docs/integrations/cerebras.md
+++ b/docs/integrations/cerebras.md
@@ -22,6 +22,17 @@ the Cerebras SDK. This lets you use Cerebras request parameters without falling
 back to a generic OpenAI client. For example:
 
 ```python
+import instructor
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+client = instructor.from_provider("cerebras/gpt-oss-120b")
+
 resp = client.create(
     messages=[{"role": "user", "content": "Return a short user record."}],
     response_model=User,

--- a/docs/integrations/cerebras.md
+++ b/docs/integrations/cerebras.md
@@ -15,6 +15,30 @@ Install Instructor with Cerebras support:
 pip install "instructor[cerebras_cloud_sdk]"
 ```
 
+## Cerebras request parameters
+
+Instructor forwards additional keyword arguments from `client.create(...)` to
+the Cerebras SDK. This lets you use Cerebras request parameters without falling
+back to a generic OpenAI client. For example:
+
+```python
+resp = client.create(
+    messages=[{"role": "user", "content": "Return a short user record."}],
+    response_model=User,
+    max_completion_tokens=256,
+    reasoning_effort="none",
+    seed=42,
+)
+```
+
+Use `max_completion_tokens` for the canonical output limit. The compatibility
+alias `max_tokens` is forwarded separately, so do not send both fields in the
+same request. Other Cerebras parameters, including `temperature`, `top_p`,
+`stop`, `response_format`, `parallel_tool_calls`, log probabilities, and
+penalties, can be supplied in the same way when supported by the selected
+model. See the [Cerebras API reference](https://inference-docs.cerebras.ai/api-reference/chat-completions)
+for the current request schema.
+
 ## Simple User Example (Sync)
 
 ```python

--- a/docs/integrations/xai.md
+++ b/docs/integrations/xai.md
@@ -9,7 +9,9 @@ xAI provides access to Grok models through the `xai-sdk` package, enabling struc
 
 ## Quick Start
 
-Instructor is distributed without xAI dependencies by default. Install xAI support with the optional `xai` extra:
+Instructor is distributed without xAI dependencies by default. The `xai` extra
+requires Python 3.10 or later because it installs `xai-sdk`. Install xAI support
+with the optional `xai` extra:
 
 ```bash
 pip install "instructor[xai]"

--- a/docs/learning/getting_started/installation.md
+++ b/docs/learning/getting_started/installation.md
@@ -88,7 +88,7 @@ export COHERE_API_KEY=your_cohere_key
 To use with Mistral AI's models:
 
 ```shell
-pip install "instructor[mistralai]"
+pip install "instructor[mistral]"
 ```
 
 Set up your Mistral API key:


### PR DESCRIPTION
## Summary

- correct the Mistral optional-extra name in both installation guides
- document the xAI Python 3.10+ dependency requirement
- document Cerebras request-parameter forwarding with a runnable example
- repair the Langfuse sync, async, and scoring examples and clean up matching extraction typos
- extend the fail-closed one-retry policy to the Auto Client live-provider lane
- finalize the 1.16.1 changelog across the merged security, runtime, CI, and documentation work

## Consolidated work

Supersedes #2550, #2554, #2556, #2561, and #2562.

The five original contributor commits and authors are preserved. Consolidation follow-ups make the Cerebras snippet self-contained, repair all three Langfuse examples, complete matching typo cleanup, and keep transient live-provider retries narrow and fail-closed.

## Final changelog resolution

- leaves the required `[Unreleased]` section empty
- dates `1.16.1` as 2026-08-28
- includes the merged remote-fetch, supply-chain, and release-workflow hardening
- preserves every reliability, provider-correctness, CI, and contributor-linked documentation entry

## Validation

- exact head: `67dd5f5a9b96c0e16a39a5f0b5086e22ba8783b8` on merged runtime main `5053d7bb7178a342e49bdee8c262aaa9adb1d48a`
- release validator reports `1.16.1`
- release-validator tests: 8 passed
- all three Langfuse Python blocks parse
- full MkDocs build passes with only the recorded pre-existing Griffe, nav, and link warnings
- `git diff --check` passes
- exact-head CI, all live-provider lanes, Release Readiness, wheel smokes, and Workers pass
- exact-head Codex Security diff scan covers all 13 changed files with 0 findings and no deferred work

Strict MkDocs mode reaches the complete build but promotes three pre-existing Griffe annotation warnings in untouched runtime files to errors; this PR does not widen into those unrelated typing changes.

## Intentionally separate

- provider additions, architecture work, broad dependency updates, and unclear provider semantics remain outside this patch release
- no runtime library behavior is introduced; the only non-doc change is the bounded CI retry
