### PR TITLE
fix: preserve optional TypedDict response fields

### DIFF
--- a/instructor/v2/core/response_model.py
+++ b/instructor/v2/core/response_model.py
@@ -5,7 +5,16 @@ from __future__ import annotations
 import inspect
 import sys
 from collections.abc import Iterable
-from typing import Any, Callable, TypeVar, Union, cast, get_args, get_origin
+from typing import (
+    Any,
+    Callable,
+    TypeVar,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 from pydantic import BaseModel, create_model
 
@@ -64,10 +73,35 @@ def prepare_response_model(response_model: type[T] | None) -> type[T] | None:
 
     if is_typed_dict(working_model):
         model_name = getattr(working_model, "__name__", "TypedDictModel")
-        annotations = getattr(working_model, "__annotations__", {})
+        annotations = get_type_hints(working_model, include_extras=True)
+        optional_keys = set(getattr(working_model, "__optional_keys__", set()))
+        if not getattr(working_model, "__total__", True):
+            optional_keys = set(annotations)
+        optional_keys.update(
+            name
+            for name, annotation in annotations.items()
+            if get_origin(annotation) is not None
+            and get_origin(annotation).__name__ == "NotRequired"
+        )
+
+        def _field_annotation(annotation: Any) -> Any:
+            annotation_origin = get_origin(annotation)
+            if annotation_origin is not None and annotation_origin.__name__ in {
+                "NotRequired",
+                "Required",
+            }:
+                return get_args(annotation)[0]
+            return annotation
+
         working_model = _create_dynamic_model(
             model_name,
-            **{name: (annotation, ...) for name, annotation in annotations.items()},
+            **{
+                name: (
+                    _field_annotation(annotation),
+                    None if name in optional_keys else ...,
+                )
+                for name, annotation in annotations.items()
+            },
         )
 
     origin = get_origin(working_model)
@@ -86,9 +120,7 @@ def prepare_response_model(response_model: type[T] | None) -> type[T] | None:
                 **{
                     name: (annotation, ...)
                     for name, annotation in getattr(
-                        iterable_element_class,
-                        "__annotations__",
-                        {},
+                        iterable_element_class, "__annotations__", {}
                     ).items()
                 },
             )

--- a/tests/v2/test_response_schema_compat.py
+++ b/tests/v2/test_response_schema_compat.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
+
+from typing_extensions import NotRequired, TypedDict
 
 import pytest
 
 from instructor import Mode, Provider
 from instructor.v2.core.function_calls import ResponseSchema
+from instructor.v2.core.response_model import prepare_response_model
 
 
 class Answer(ResponseSchema):
@@ -129,3 +132,25 @@ def test_provider_parse_helpers_delegate_to_registry(
         }
     ]
     assert calls[0]["warning"] is not None
+
+
+class OptionalUser(TypedDict):
+    name: str
+    age: NotRequired[int]
+
+
+class PartialUser(TypedDict, total=False):
+    nickname: str
+
+
+def test_prepare_response_model_preserves_typed_dict_optional_keys() -> None:
+    model = prepare_response_model(OptionalUser)
+
+    assert model is not None
+    model = cast(Any, model)
+    assert model.model_fields["name"].is_required()
+    assert not model.model_fields["age"].is_required()
+    assert model(name="Ada").model_dump() == {"name": "Ada", "age": None}
+
+    partial_model = cast(Any, prepare_response_model(PartialUser))
+    assert not partial_model.model_fields["nickname"].is_required()


### PR DESCRIPTION
## Summary

Fix TypedDict response-model conversion so optional keys remain optional.

`prepare_response_model` now resolves TypedDict annotations with extras, preserves `total=False` and `NotRequired` metadata, and unwraps `Required`/`NotRequired` before creating the Pydantic model. This prevents valid responses that omit optional fields from being rejected.

## Tests

- `python -m pytest tests/v2/test_response_schema_compat.py -q` (15 passed)
- `ruff check instructor/v2/core/response_model.py tests/v2/test_response_schema_compat.py`
- `ruff format instructor/v2/core/response_model.py tests/v2/test_response_schema_compat.py`
- `git diff --check`

The repository's frozen environment could not build its pinned `pydantic-core` on Python 3.14; the focused tests were run successfully with the system Python environment.
