### PR TITLE
fix(anthropic): read local PDF sources from disk instead of over HTTP

### DIFF
--- a/instructor/v2/providers/anthropic/multimodal.py
+++ b/instructor/v2/providers/anthropic/multimodal.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import base64
+from pathlib import Path
 from typing import Any
-
-import requests
 
 
 def image_to_anthropic(image: Any) -> dict[str, Any]:
@@ -25,6 +24,26 @@ def image_to_anthropic(image: Any) -> dict[str, Any]:
     }
 
 
+def _read_local_pdf(source: Any) -> bytes | None:
+    """Return the bytes of ``source`` when it points at a readable local file.
+
+    Returns ``None`` when the source is not a usable filesystem path — for
+    example an inline base64 payload or a non-HTTP remote URI — so callers can
+    raise a clear error instead of failing deeper in the stack.
+    """
+    try:
+        path = Path(source)
+    except TypeError:
+        return None
+    try:
+        if not path.is_file():
+            return None
+        return path.read_bytes()
+    except OSError:
+        # Inline base64 payloads and remote URIs are not valid path names.
+        return None
+
+
 def pdf_to_anthropic(pdf: Any) -> dict[str, Any]:
     if (
         isinstance(pdf.source, str)
@@ -33,8 +52,10 @@ def pdf_to_anthropic(pdf: Any) -> dict[str, Any]:
     ):
         return {"type": "document", "source": {"type": "url", "url": pdf.source}}
     if not pdf.data:
-        pdf.data = requests.get(str(pdf.source), timeout=30).content
-        pdf.data = base64.b64encode(pdf.data).decode("utf-8")
+        local_bytes = _read_local_pdf(pdf.source)
+        if local_bytes is None:
+            raise ValueError("PDF data is missing for base64 encoding.")
+        pdf.data = base64.b64encode(local_bytes).decode("utf-8")
     return {
         "type": "document",
         "source": {

--- a/tests/coverage/test_anthropic_support_coverage.py
+++ b/tests/coverage/test_anthropic_support_coverage.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, ValidationInfo, field_validator
 from instructor.v2.core.client import AsyncInstructor, Instructor
 from instructor.v2.core.errors import ClientError, ModeError
 from instructor.v2.core.mode import Mode
+from instructor.v2.core.multimodal import PDF
 from instructor.v2.core.providers import Provider
 from instructor.v2.providers import anthropic as anthropic_provider
 from instructor.v2.providers.anthropic import client as anthropic_client
@@ -164,7 +165,7 @@ async def test_anthropic_factory_uses_beta_sync_and_regular_async_create(
 
 
 def test_anthropic_multimodal_encodes_remote_image_and_local_pdf(
-    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     image_calls: list[str] = []
     image = SimpleNamespace(
@@ -184,17 +185,11 @@ def test_anthropic_multimodal_encodes_remote_image_and_local_pdf(
     assert image_calls == ["https://example.test/diagram.png"]
     assert image.data == "aW1hZ2U="
 
-    requests: list[tuple[str, int]] = []
-
-    def fake_get(url: str, *, timeout: int) -> Any:
-        requests.append((url, timeout))
-        return SimpleNamespace(content=b"%PDF-1.7\nexample")
-
-    monkeypatch.setattr(multimodal.requests, "get", fake_get)
-    pdf = SimpleNamespace(
-        source=Path("/tmp/example.pdf"), media_type="application/pdf", data=None
-    )
-    expected = base64.b64encode(b"%PDF-1.7\nexample").decode()
+    pdf_bytes = b"%PDF-1.7\nexample"
+    pdf_path = tmp_path / "example.pdf"
+    pdf_path.write_bytes(pdf_bytes)
+    pdf = SimpleNamespace(source=pdf_path, media_type="application/pdf", data=None)
+    expected = base64.b64encode(pdf_bytes).decode()
     assert multimodal.pdf_to_anthropic(pdf) == {
         "type": "document",
         "source": {
@@ -203,8 +198,43 @@ def test_anthropic_multimodal_encodes_remote_image_and_local_pdf(
             "data": expected,
         },
     }
-    assert requests == [("/tmp/example.pdf", 30)]
     assert pdf.data == expected
+
+
+def test_anthropic_pdf_reads_local_path_without_network(tmp_path: Path) -> None:
+    """Local PDF sources are read from disk, not fetched over HTTP.
+
+    ``PDF`` accepts a filesystem path as its source, and ``data`` is only
+    pre-populated by the ``from_path``/``autodetect`` constructors. A ``PDF``
+    built directly from a path therefore reaches the encoder with no data and
+    must be read from disk.
+    """
+    pdf_bytes = b"%PDF-1.7\nlocal\n%%EOF\n"
+    pdf_path = tmp_path / "local.pdf"
+    pdf_path.write_bytes(pdf_bytes)
+
+    pdf = PDF(source=pdf_path, media_type="application/pdf")
+    assert pdf.data is None
+
+    assert multimodal.pdf_to_anthropic(pdf) == {
+        "type": "document",
+        "source": {
+            "type": "base64",
+            "media_type": "application/pdf",
+            "data": base64.b64encode(pdf_bytes).decode(),
+        },
+    }
+
+
+def test_anthropic_pdf_without_data_raises_clear_error(tmp_path: Path) -> None:
+    """A source that is neither data, a URL, nor a readable file errors clearly."""
+    missing = SimpleNamespace(
+        source=tmp_path / "does-not-exist.pdf",
+        media_type="application/pdf",
+        data=None,
+    )
+    with pytest.raises(ValueError, match="PDF data is missing"):
+        multimodal.pdf_to_anthropic(missing)
 
 
 def test_anthropic_multimodal_handles_pdf_urls_cache_control_and_audio() -> None:


### PR DESCRIPTION
## Describe your changes

`pdf_to_anthropic` encoded any PDF whose `data` was unset by calling
`requests.get(str(pdf.source))`.

That branch is only reachable for **non-HTTP** sources, because a remote `http(s)`
URL returns earlier as a URL document block:

```python
if isinstance(pdf.source, str) and pdf.source.startswith(("http://", "https://")) and not pdf.data:
    return {"type": "document", "source": {"type": "url", "url": pdf.source}}
if not pdf.data:
    pdf.data = requests.get(str(pdf.source), timeout=30).content   # only non-HTTP sources get here
```

So every source that could actually reach the `requests.get` call (a local path,
`gs://`, `s3://`) is one `requests` cannot resolve. It raised `MissingSchema` /
`InvalidSchema` instead of encoding the document.

`PDF.source` is documented as *"URL, file path, or base64 data of the PDF"*, and
constructing `PDF(source=Path(...))` directly leaves `data` unset — only the
`from_path` / `autodetect` constructors pre-populate it. Building a PDF from a
local path and sending it to Anthropic therefore always failed, even with a
perfectly readable file on disk:

```python
pdf = PDF(source=Path("invoice.pdf"), media_type="application/pdf")
pdf_to_anthropic(pdf)
# requests.exceptions.InvalidSchema: No connection adapters were found for 'invoice.pdf'
```

### Changes

- Read local files from disk when `data` is unset.
- Raise the same clear `ValueError("PDF data is missing for base64 encoding.")`
  that `pdf_to_openai` already raises when no usable source is present, instead
  of surfacing an opaque `requests` error.
- This removes the last raw `requests` call left in a provider multimodal module
  after remote media fetching was centralized in #2569 (which updated the
  `openai`, `genai`, and `bedrock` multimodal paths but not `anthropic`).

`image_to_anthropic` is deliberately left alone — it has a different shape and no
fetch call, so it is out of scope here.

### Tests

`test_anthropic_multimodal_encodes_remote_image_and_local_pdf` asserted the broken
behaviour by mocking `requests.get`, and separately failed on Windows because it
compared a `Path` against a hardcoded POSIX string:

```
AssertionError: assert [('\tmp\example.pdf', 30)] == [('/tmp/example.pdf', 30)]
```

It now writes a real file to `tmp_path`, which fixes the Windows failure too. Two
regression tests were added:

- `test_anthropic_pdf_reads_local_path_without_network` — a `PDF` built from a
  local path encodes from disk (uses the real `PDF` model, not a stub).
- `test_anthropic_pdf_without_data_raises_clear_error` — an unusable source
  raises the clear `ValueError`.

All three fail on `main` and pass with this change.

## Issue ticket number and link

No existing issue — found while reviewing provider multimodal code after #2569.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation. *(bug fix, no doc change needed)*

### Verification

- `pytest tests/coverage/test_anthropic_support_coverage.py` — 13 passed
- `pytest tests/ --ignore=tests/llm --ignore=tests/docs` — 2979 passed, 195 skipped.
  The 6 remaining failures are pre-existing `tests/providers/test_auto_client.py`
  cases that require live `GROQ_API_KEY` / `WRITER_API_KEY` / `CEREBRAS_API_KEY`.
- `ruff check` and `ruff format --check` pass
- `ty check` passes
- `git diff --check` clean
