### PR TITLE
docs(openai): explain compatible JSON endpoints

### DIFF
--- a/docs/integrations/openai.md
+++ b/docs/integrations/openai.md
@@ -34,6 +34,44 @@ client = instructor.from_provider(
 )
 ```
 
+## OpenAI-compatible Chat Completions endpoints
+
+For a server that exposes an OpenAI-compatible Chat Completions API, pass the
+server's `/v1` URL through `base_url`. Choose a mode the server supports. For
+example, use `Mode.JSON` when the server supports JSON mode but not OpenAI tool
+calling:
+
+```python
+import os
+
+import instructor
+
+client = instructor.from_provider(
+    "openai/your-model-name",
+    api_key=os.environ["OPENAI_COMPATIBLE_API_KEY"],
+    base_url="https://your-server.example/v1",
+    mode=instructor.Mode.JSON,
+)
+```
+
+If you already have a configured OpenAI client, wrap it directly instead:
+
+```python
+import os
+
+import instructor
+from openai import OpenAI
+
+openai_client = OpenAI(
+    api_key=os.environ["OPENAI_COMPATIBLE_API_KEY"],
+    base_url="https://your-server.example/v1",
+)
+client = instructor.from_openai(openai_client, mode=instructor.Mode.JSON)
+```
+
+`Mode.RESPONSES_TOOLS` uses OpenAI's Responses API. Do not select it unless the
+compatible server implements that API as well as Chat Completions.
+
 ## Simple User Example (Sync)
 
 ```python


### PR DESCRIPTION
## Describe your changes

Document how to connect Instructor to an OpenAI-compatible Chat Completions server whose API is rooted at `/v1`.

The new section shows both supported setup paths:

- `from_provider(..., base_url=..., mode=Mode.JSON)`
- wrapping an existing `OpenAI(base_url=...)` client with `from_openai`

It also clarifies that `Mode.RESPONSES_TOOLS` should only be selected when the compatible server implements the Responses API, and that users should choose `Mode.JSON` for JSON-capable servers that do not implement OpenAI tool calling.

Closes #2576.

AI assistance was used to prepare the documentation; the examples and current client construction paths were checked against the source.

## Issue ticket number and link

#2576 — https://github.com/567-labs/instructor/issues/2576

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. Not applicable; this is documentation only.
- [x] If it is a core feature, I have added documentation.
