### PR TITLE
fix(genai): omit request fields with cached content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **GenAI cached content**: Omit request-level system instructions, tools, and tool configuration when v2 structured requests use cached content, avoiding Google GenAI `INVALID_ARGUMENT` responses. ([#2580](https://github.com/567-labs/instructor/issues/2580))
+
 ## [1.16.1] - 2026-08-28
 
 ### Changed

--- a/instructor/v2/providers/genai/handlers.py
+++ b/instructor/v2/providers/genai/handlers.py
@@ -173,6 +173,16 @@ class GenAIHandlerBase(ModeHandler):
             )
         return None
 
+    def _get_user_config_field(
+        self,
+        kwargs: dict[str, Any],
+        field: str,
+    ) -> Any:
+        user_config = kwargs.get("config")
+        if isinstance(user_config, dict):
+            return user_config.get(field)
+        return getattr(user_config, field, None)
+
     def extract_streaming_json(self, completion: Any) -> Generator[str, None, None]:
         """Extract JSON chunks from GenAI streaming responses."""
         for chunk in completion:
@@ -385,18 +395,18 @@ class GenAIToolsHandler(GenAIHandlerBase):
             if key in new_kwargs:
                 generation_config_dict[key] = new_kwargs.pop(key)
 
-        base_config = {
-            "system_instruction": system_instruction,
-            "tools": [types.Tool(function_declarations=[function_decl])],
-            "tool_config": types.ToolConfig(
+        base_config: dict[str, Any] = {}
+        if self._get_user_config_field(new_kwargs, "cached_content") is None:
+            base_config["system_instruction"] = system_instruction
+            base_config["tools"] = [types.Tool(function_declarations=[function_decl])]
+            base_config["tool_config"] = types.ToolConfig(
                 function_calling_config=types.FunctionCallingConfig(
                     mode=types.FunctionCallingConfigMode.ANY,
                     allowed_function_names=[
                         gemini_utils._get_model_name(prepared_model)
                     ],
                 ),
-            ),
-        }
+            )
         # Temporarily put generation_config back for update_genai_kwargs to process
         new_kwargs["generation_config"] = generation_config_dict
         generation_config = gemini_utils.update_genai_kwargs(new_kwargs, base_config)
@@ -464,10 +474,11 @@ class GenAIStructuredOutputsHandler(GenAIHandlerBase):
                 generation_config_dict[key] = new_kwargs.pop(key)
 
         base_config = {
-            "system_instruction": system_instruction,
             "response_mime_type": "application/json",
             "response_schema": prepared_model,
         }
+        if self._get_user_config_field(new_kwargs, "cached_content") is None:
+            base_config["system_instruction"] = system_instruction
         # Temporarily put generation_config back for update_genai_kwargs to process
         new_kwargs["generation_config"] = generation_config_dict
         generation_config = gemini_utils.update_genai_kwargs(new_kwargs, base_config)

--- a/tests/v2/test_genai_handlers_deterministic.py
+++ b/tests/v2/test_genai_handlers_deterministic.py
@@ -26,12 +26,21 @@ class FakeGenerateContentConfig:
         self.kwargs = kwargs
 
 
+class CachedResponse(BaseModel):
+    value: str
+
+
 def _install_fake_genai_types(monkeypatch: pytest.MonkeyPatch) -> None:
     install_fake_genai(
         monkeypatch,
         extra_types={
             "ModelContent": FakeModelContent,
             "GenerateContentConfig": FakeGenerateContentConfig,
+            "FunctionDeclaration": SimpleNamespace,
+            "Tool": SimpleNamespace,
+            "FunctionCallingConfigMode": SimpleNamespace(ANY="ANY"),
+            "FunctionCallingConfig": SimpleNamespace,
+            "ToolConfig": SimpleNamespace,
         },
     )
 
@@ -113,6 +122,89 @@ def test_tools_handler_prepare_request_without_response_model(
     ]
     assert kwargs["config"].kwargs["system_instruction"] == "system note"
     assert "temperature" not in kwargs
+
+
+@pytest.mark.parametrize(
+    ("handler", "forbidden_fields"),
+    [
+        (
+            GenAIToolsHandler(mode=Mode.TOOLS),
+            {"system_instruction", "tools", "tool_config"},
+        ),
+        (
+            GenAIStructuredOutputsHandler(mode=Mode.JSON),
+            {"system_instruction"},
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"cached_content": "cachedContents/test"},
+        SimpleNamespace(cached_content="cachedContents/test"),
+    ],
+    ids=["dict-config", "object-config"],
+)
+def test_genai_handlers_omit_cached_content_request_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: GenAIToolsHandler | GenAIStructuredOutputsHandler,
+    forbidden_fields: set[str],
+    config: dict[str, str] | SimpleNamespace,
+) -> None:
+    _install_fake_genai_types(monkeypatch)
+
+    def merge_cached_content(
+        kwargs: dict[str, Any], base_config: dict[str, Any]
+    ) -> dict[str, Any]:
+        user_config = kwargs["config"]
+        cached_content = (
+            user_config["cached_content"]
+            if isinstance(user_config, dict)
+            else user_config.cached_content
+        )
+        return {**base_config, "cached_content": cached_content}
+
+    monkeypatch.setattr(
+        "instructor.v2.providers.gemini.utils.map_to_genai_schema",
+        lambda schema: schema,
+    )
+    monkeypatch.setattr(
+        "instructor.v2.providers.gemini.utils.map_to_gemini_function_schema",
+        lambda schema: schema,
+    )
+    monkeypatch.setattr(
+        "instructor.v2.providers.gemini.utils.update_genai_kwargs",
+        merge_cached_content,
+    )
+    monkeypatch.setattr(
+        "instructor.v2.providers.gemini.utils.convert_to_genai_messages",
+        lambda messages: messages,
+    )
+    monkeypatch.setattr(
+        "instructor.v2.providers.genai.handlers.extract_genai_multimodal_content",
+        lambda contents, _autodetect_images: contents,
+    )
+
+    prepared_model, prepared = handler.prepare_request(
+        CachedResponse,
+        {
+            "messages": [
+                {"role": "system", "content": "cached instruction"},
+                {"role": "user", "content": "hello"},
+            ],
+            "config": config,
+        },
+    )
+
+    prepared_config = prepared["config"].kwargs
+    assert prepared_config["cached_content"] == "cachedContents/test"
+    assert forbidden_fields.isdisjoint(prepared_config)
+    if handler.mode == Mode.JSON:
+        assert prepared_config["response_mime_type"] == "application/json"
+        assert prepared_config["response_schema"] is prepared_model
+    else:
+        assert "response_mime_type" not in prepared_config
+        assert "response_schema" not in prepared_config
 
 
 def test_structured_outputs_parse_response_unwraps_adapter(


### PR DESCRIPTION
## Describe your changes

When v2 structured GenAI requests use cached content, omit the request fields that Google rejects alongside the cache. TOOLS mode now leaves out `system_instruction`, `tools`, and `tool_config`; JSON mode leaves out `system_instruction` while keeping its JSON response configuration.

This handles both dict and object-style configs. Non-cached requests are unchanged.

Tested with the focused GenAI handler suite and related GenAI/Gemini tests. Ruff, formatting, type checks, and diff checks pass for the changed files.

This PR was written with assistance from [OpenAI Codex](https://openai.com/codex/).

## Issue ticket number and link

Fixes #2580

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.