### PR TITLE
fix(genai): omit system instruction and tools when cached_content is set

### DIFF
--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -298,6 +298,10 @@ def update_genai_kwargs(
     if thinking_config is not None:
         base_config["thinking_config"] = thinking_config
 
+    cached_content = new_kwargs.pop("cached_content", None)
+    if cached_content is not None and "cached_content" not in base_config:
+        base_config["cached_content"] = cached_content
+
     if user_config is not None:
         config_fields_to_merge = [
             "automatic_function_calling",

--- a/instructor/v2/providers/genai/handlers.py
+++ b/instructor/v2/providers/genai/handlers.py
@@ -228,6 +228,30 @@ class GenAIHandlerBase(ModeHandler):
         kwargs.pop("messages", None)
         return kwargs
 
+    def _extract_cached_content(self, kwargs: dict[str, Any]) -> Any | None:
+        user_config = kwargs.get("config")
+        if isinstance(user_config, dict):
+            if user_config.get("cached_content") is not None:
+                return user_config.get("cached_content")
+        elif user_config is not None and hasattr(user_config, "cached_content"):
+            if user_config.cached_content is not None:
+                return user_config.cached_content
+
+        if kwargs.get("cached_content") is not None:
+            return kwargs.get("cached_content")
+
+        generation_config = kwargs.get("generation_config")
+        if isinstance(generation_config, dict):
+            if generation_config.get("cached_content") is not None:
+                return generation_config.get("cached_content")
+        elif generation_config is not None and hasattr(
+            generation_config, "cached_content"
+        ):
+            if generation_config.cached_content is not None:
+                return generation_config.cached_content
+
+        return None
+
     def _cleanup_provider_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
         # Keep 'model' as it's required by GenAI API
         # Remove other OpenAI-specific params that should be in config
@@ -236,6 +260,7 @@ class GenAIHandlerBase(ModeHandler):
             "generation_config",
             "safety_settings",
             "thinking_config",
+            "cached_content",
             "max_tokens",
             "temperature",
             "top_p",
@@ -257,6 +282,10 @@ class GenAIHandlerBase(ModeHandler):
         from google.genai import types
 
         system_instruction = self._extract_system_instruction(kwargs)
+        cached_content = self._extract_cached_content(kwargs)
+        if cached_content is not None:
+            system_instruction = None
+
         kwargs = self._convert_messages_to_contents(kwargs, autodetect_images)
         if system_instruction:
             kwargs["config"] = types.GenerateContentConfig(
@@ -385,18 +414,20 @@ class GenAIToolsHandler(GenAIHandlerBase):
             if key in new_kwargs:
                 generation_config_dict[key] = new_kwargs.pop(key)
 
-        base_config = {
-            "system_instruction": system_instruction,
-            "tools": [types.Tool(function_declarations=[function_decl])],
-            "tool_config": types.ToolConfig(
+        user_cached_content = self._extract_cached_content(new_kwargs)
+
+        base_config: dict[str, Any] = {}
+        if user_cached_content is None:
+            base_config["system_instruction"] = system_instruction
+            base_config["tools"] = [types.Tool(function_declarations=[function_decl])]
+            base_config["tool_config"] = types.ToolConfig(
                 function_calling_config=types.FunctionCallingConfig(
                     mode=types.FunctionCallingConfigMode.ANY,
                     allowed_function_names=[
                         gemini_utils._get_model_name(prepared_model)
                     ],
                 ),
-            ),
-        }
+            )
         # Temporarily put generation_config back for update_genai_kwargs to process
         new_kwargs["generation_config"] = generation_config_dict
         generation_config = gemini_utils.update_genai_kwargs(new_kwargs, base_config)
@@ -463,11 +494,14 @@ class GenAIStructuredOutputsHandler(GenAIHandlerBase):
             if key in new_kwargs:
                 generation_config_dict[key] = new_kwargs.pop(key)
 
-        base_config = {
-            "system_instruction": system_instruction,
+        user_cached_content = self._extract_cached_content(new_kwargs)
+
+        base_config: dict[str, Any] = {
             "response_mime_type": "application/json",
             "response_schema": prepared_model,
         }
+        if user_cached_content is None:
+            base_config["system_instruction"] = system_instruction
         # Temporarily put generation_config back for update_genai_kwargs to process
         new_kwargs["generation_config"] = generation_config_dict
         generation_config = gemini_utils.update_genai_kwargs(new_kwargs, base_config)

--- a/tests/test_genai_config_merging.py
+++ b/tests/test_genai_config_merging.py
@@ -518,3 +518,99 @@ def test_handle_genai_tools_skips_tools_and_system_instruction_with_cached_conte
     assert result_config.system_instruction is None
     assert result_config.tools is None
     assert result_config.tool_config is None
+
+
+def test_v2_genai_tools_handler_skips_tools_and_system_instruction_with_cached_content():
+    """Test that GenAIToolsHandler omits tools, tool_config, and system_instruction with cached_content (issue #2580)."""
+    from pydantic import BaseModel
+    from google.genai import types
+    from instructor.v2.providers.genai.handlers import GenAIToolsHandler
+    from instructor.v2.core.mode import Mode
+
+    class TestModel(BaseModel):
+        name: str
+
+    handler = GenAIToolsHandler(mode=Mode.TOOLS)
+
+    # 1. With config as types.GenerateContentConfig
+    config = types.GenerateContentConfig(cached_content="caches/test-tool-123")
+    _, result_kwargs = handler.prepare_request(
+        TestModel,
+        {
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello"},
+            ],
+            "config": config,
+        },
+    )
+    result_config = result_kwargs["config"]
+    assert result_config.cached_content == "caches/test-tool-123"
+    assert result_config.system_instruction is None
+    assert result_config.tools is None
+    assert result_config.tool_config is None
+
+    # 2. With config as dict
+    _, result_kwargs_dict = handler.prepare_request(
+        TestModel,
+        {
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello"},
+            ],
+            "config": {"cached_content": "caches/test-tool-dict"},
+        },
+    )
+    result_config_dict = result_kwargs_dict["config"]
+    assert result_config_dict.cached_content == "caches/test-tool-dict"
+    assert result_config_dict.system_instruction is None
+    assert result_config_dict.tools is None
+    assert result_config_dict.tool_config is None
+
+
+def test_v2_genai_structured_outputs_handler_skips_system_instruction_with_cached_content():
+    """Test that GenAIStructuredOutputsHandler omits system_instruction with cached_content (issue #2580)."""
+    from pydantic import BaseModel
+    from google.genai import types
+    from instructor.v2.providers.genai.handlers import GenAIStructuredOutputsHandler
+    from instructor.v2.core.mode import Mode
+
+    class TestModel(BaseModel):
+        name: str
+
+    handler = GenAIStructuredOutputsHandler(mode=Mode.JSON)
+
+    # 1. With config as types.GenerateContentConfig
+    config = types.GenerateContentConfig(cached_content="caches/test-json-123")
+    _, result_kwargs = handler.prepare_request(
+        TestModel,
+        {
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello"},
+            ],
+            "config": config,
+        },
+    )
+    result_config = result_kwargs["config"]
+    assert result_config.cached_content == "caches/test-json-123"
+    assert result_config.system_instruction is None
+    assert result_config.response_mime_type == "application/json"
+    assert result_config.response_schema is not None
+
+    # 2. With config as dict
+    _, result_kwargs_dict = handler.prepare_request(
+        TestModel,
+        {
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello"},
+            ],
+            "config": {"cached_content": "caches/test-json-dict"},
+        },
+    )
+    result_config_dict = result_kwargs_dict["config"]
+    assert result_config_dict.cached_content == "caches/test-json-dict"
+    assert result_config_dict.system_instruction is None
+    assert result_config_dict.response_mime_type == "application/json"
+    assert result_config_dict.response_schema is not None

--- a/tests/v2/test_genai_handlers_deterministic.py
+++ b/tests/v2/test_genai_handlers_deterministic.py
@@ -146,3 +146,39 @@ def test_structured_outputs_parse_response_unwraps_adapter(
     )
 
     assert result == "done"
+
+
+def test_tools_handler_prepare_request_without_response_model_with_cached_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_genai_types(monkeypatch)
+    monkeypatch.setattr(
+        "instructor.v2.providers.gemini.utils.convert_to_genai_messages",
+        lambda messages: ["converted", *messages],
+    )
+    monkeypatch.setattr(
+        "instructor.v2.providers.genai.handlers.extract_genai_multimodal_content",
+        lambda contents, autodetect_images: [*contents, autodetect_images],
+    )
+
+    handler = GenAIToolsHandler(mode=Mode.TOOLS)
+    model, kwargs = handler.prepare_request(
+        None,
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "system": "system note",
+            "autodetect_images": True,
+            "config": {"cached_content": "caches/test123"},
+        },
+    )
+
+    assert model is None
+    assert kwargs["contents"] == [
+        "converted",
+        {"role": "user", "content": "hello"},
+        True,
+    ]
+    # system_instruction should NOT be created when cached_content is present
+    assert "config" not in kwargs or "system_instruction" not in getattr(
+        kwargs["config"], "kwargs", {}
+    )


### PR DESCRIPTION
## Describe your changes

In 1.16.0 with the v2 handler architecture, `GenAIToolsHandler.prepare_request` and `GenAIStructuredOutputsHandler.prepare_request` in `instructor/v2/providers/genai/handlers.py` constructed `base_config` unconditionally without checking whether `cached_content` is passed.

When calling Google Gemini with `cached_content` (context caching), the Gemini API rejects requests that also specify `tools`, `tool_config`, or `system_instruction` in the request config with:
```
400 INVALID_ARGUMENT: Tool config, tools and system instruction should not be set in the request when using cached content.
```

This PR restores the 1.15.1 behavior:
1. `GenAIToolsHandler.prepare_request` checks for `cached_content` (in `config`, `kwargs`, or `generation_config`) and omits `system_instruction`, `tools`, and `tool_config` from the request config when present.
2. `GenAIStructuredOutputsHandler.prepare_request` checks for `cached_content` and omits `system_instruction` from the request config when present.
3. `_prepare_without_response_model` ensures `system_instruction` is not injected when `cached_content` is present.
4. Added unit tests for both `GenAIToolsHandler` and `GenAIStructuredOutputsHandler` with `cached_content` passed as `types.GenerateContentConfig` objects and as configuration dictionaries.

## Issue ticket number and link

Fixes #2580
Fixes OSS-3

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.
