### PR TITLE
docs: fix typos across docs and examples

### DIFF
--- a/docs/blog/posts/chain-of-density.md
+++ b/docs/blog/posts/chain-of-density.md
@@ -388,7 +388,7 @@ In this section, we'll look into how to fine-tune a GPT 3.5 model so that it is 
 
 ### Creating a Training Set
 
-In order to prevent any contamination of data during testing, we randomly sampled 120 articles from the `griffin/chain-of-density` dataset and split these articles into a `train.csv` and a `test.csv` file which we uploaded to [Hugging Face](https://huggingface.co/datasets/ivanleomk/gpt4-chain-of-density). Now, we just neeed to import the `Instructions` module from the `Instructor` package which allows you to generate a nicely formatted `.jsonl` file to be used for fine-tuning
+In order to prevent any contamination of data during testing, we randomly sampled 120 articles from the `griffin/chain-of-density` dataset and split these articles into a `train.csv` and a `test.csv` file which we uploaded to [Hugging Face](https://huggingface.co/datasets/ivanleomk/gpt4-chain-of-density). Now, we just need to import the `Instructions` module from the `Instructor` package which allows you to generate a nicely formatted `.jsonl` file to be used for fine-tuning
 
 ```py hl_lines="2 9 11 13-21 40 43"
 from typing import List

--- a/docs/blog/posts/extracting-model-metadata.md
+++ b/docs/blog/posts/extracting-model-metadata.md
@@ -53,7 +53,7 @@ colors:
   - brown
 ```
 
-By using this taxonomy, we can ensure that our model is able to extract metadata that is consistent with the products we sell. In this example, we'll analyze style photos from a fitness influencer to understand their fashion preferences and possibily see what products we can recommend from our own catalog to him.
+By using this taxonomy, we can ensure that our model is able to extract metadata that is consistent with the products we sell. In this example, we'll analyze style photos from a fitness influencer to understand their fashion preferences and possibly see what products we can recommend from our own catalog to him.
 
 We're using some photos from a fitness influencer called [Jpgeez](https://www.instagram.com/jpgeez/) which you can see below.
 

--- a/docs/blog/posts/multimodal-gemini.md
+++ b/docs/blog/posts/multimodal-gemini.md
@@ -82,7 +82,7 @@ print(resp)
 ??? note "Expand to see Raw Results"
 
     ```python
-    Recomendations(
+    Recommendations(
         chain_of_thought='The video recommends visiting Takayama city, in the Hida Region, Gifu Prefecture. The
     video suggests visiting the Miyagawa Morning Market, to try the Sarubobo good luck charms, and to enjoy the
     cookie cup espresso, made by Koma Coffee. Then, the video suggests visiting a traditional Japanese Cafe,

--- a/docs/concepts/distillation.md
+++ b/docs/concepts/distillation.md
@@ -196,4 +196,4 @@ def fn(a: int, b: int) -> Multiply:
     return Multiply(a=a, b=b, result=resp)
 ```
 
-With this, you can swap the function implementation, making it backward compatible. You can even imagine using the different models for different tasks or validating and runnign evals by using the original function and comparing it to the distillation.
+With this, you can swap the function implementation, making it backward compatible. You can even imagine using the different models for different tasks or validating and running evals by using the original function and comparing it to the distillation.

--- a/docs/concepts/multimodal.md
+++ b/docs/concepts/multimodal.md
@@ -449,7 +449,7 @@ print(completion.usage.cache_creation_input_tokens)
 
 ### Using Files
 
-We also provide a convinient wrapper around the Files API - allowing you to use both uploaded files and to block the main thread while your file is uploading.
+We also provide a convenient wrapper around the Files API - allowing you to use both uploaded files and to block the main thread while your file is uploading.
 
 In this example below, we download the sample PDF and then upload it using the `Files` api provided by the `google.genai` sdk.
 

--- a/docs/concepts/partial.md
+++ b/docs/concepts/partial.md
@@ -26,7 +26,7 @@ description: Learn to utilize field-level streaming with Instructor and OpenAI f
 
     This is because `jiter` throws an error otherwise if it encounters a incomplete Literal value while it's being streamed in
 
-Field level streaming provides incremental snapshots of the current state of the response model that are immediately useable. This approach is particularly relevant in contexts like rendering UI components.
+Field level streaming provides incremental snapshots of the current state of the response model that are immediately usable. This approach is particularly relevant in contexts like rendering UI components.
 
 Instructor supports this pattern by making use of `create_partial`. This lets us dynamically create a new class that treats all of the original model's fields as `Optional`.
 

--- a/docs/examples/entity_resolution.md
+++ b/docs/examples/entity_resolution.md
@@ -296,7 +296,7 @@ The Service Provider will deliver the software product to the Client 30 days aft
 Article 2: Payment Terms
 
 The total payment for the service is $50,000.
-An initial payment of $10,000 will be made within 7 days of the the signed date.
+An initial payment of $10,000 will be made within 7 days of the signed date.
 The final payment will be due 45 days after [SignDate].
 
 Article 3: Confidentiality

--- a/docs/examples/knowledge_graph.md
+++ b/docs/examples/knowledge_graph.md
@@ -288,7 +288,7 @@ def generate_graph(input: List[str]) -> KnowledgeGraph:
                     "role": "system",
                     "content": """You are an iterative knowledge graph builder.
                     You are given the current state of the graph, and you must append the nodes and edges
-                    to it Do not procide any duplcates and try to reuse nodes as much as possible.""",
+                    to it Do not provide any duplicates and try to reuse nodes as much as possible.""",
                 },
                 {
                     "role": "user",
@@ -379,7 +379,7 @@ def generate_graph(input: List[str]) -> KnowledgeGraph:
                     "role": "system",
                     "content": """You are an iterative knowledge graph builder.
                     You are given the current state of the graph, and you must append the nodes and edges
-                    to it Do not procide any duplcates and try to reuse nodes as much as possible.""",
+                    to it Do not provide any duplicates and try to reuse nodes as much as possible.""",
                 },
                 {
                     "role": "user",

--- a/docs/examples/partial_streaming.md
+++ b/docs/examples/partial_streaming.md
@@ -5,7 +5,7 @@ description: Stream partial responses with Instructor for real-time UI updates. 
 
 # Streaming Partial Responses
 
-Field level streaming provides incremental snapshots of the current state of the response model that are immediately useable. This approach is particularly relevant in contexts like rendering UI components.
+Field level streaming provides incremental snapshots of the current state of the response model that are immediately usable. This approach is particularly relevant in contexts like rendering UI components.
 
 Instructor supports this pattern by making use of `Partial[T]`. This lets us dynamically create a new class that treats all of the original model's fields as `Optional`.
 

--- a/docs/integrations/cerebras.md
+++ b/docs/integrations/cerebras.md
@@ -236,7 +236,7 @@ resp = client.create_iterable(
     messages=[
         {
             "role": "user",
-            "content": "Extract all users from this sentence : Chris is 27 and lives in San Francisco, John is 30 and lives in New York while their college roomate Jessica is 26 and lives in London",
+            "content": "Extract all users from this sentence : Chris is 27 and lives in San Francisco, John is 30 and lives in New York while their college roommate Jessica is 26 and lives in London",
         }
     ],
     response_model=Person,
@@ -269,7 +269,7 @@ instructor.patch(client, validation_hook=validation_hook)
 
 ## Instructor Modes
 
-We provide serveral modes to make it easy to work with the different response models that Cerebras Supports
+We provide several modes to make it easy to work with the different response models that Cerebras Supports
 
 1. `instructor.Mode.MD_JSON` : This parses the raw completions as a valid JSON object.
 2. `instructor.Mode.TOOLS` : This uses Cerebras's tool calling mode to return structured outputs to the client.

--- a/docs/integrations/google.md
+++ b/docs/integrations/google.md
@@ -362,7 +362,7 @@ Google offers several Gemini models:
 
 We've written an extensive list of guides on how to use gemini's multimodal capabilities with instructor.
 
-- [Using Geminin To Extract Travel Video Recomendations](../blog/posts/multimodal-gemini.md)
+- [Using Gemini To Extract Travel Video Recommendations](../blog/posts/multimodal-gemini.md)
 - [Parsing PDFs with Gemini](../blog/posts/chat-with-your-pdf-with-gemini.md)
 - [Generating Citations with Gemini](../blog/posts/generating-pdf-citations.md)
 

--- a/docs/integrations/openai-responses.md
+++ b/docs/integrations/openai-responses.md
@@ -163,7 +163,7 @@ If you need the original completion object from OpenAI, you can do so with the `
 
 ### Iterable Creation
 
-If you're interested in extracting multiple instances of the same object, we provide a convinient wrapper to be able to do so.
+If you're interested in extracting multiple instances of the same object, we provide a convenient wrapper to be able to do so.
 
 === "Sync"
 

--- a/docs/integrations/openai.md
+++ b/docs/integrations/openai.md
@@ -441,7 +441,7 @@ Read more about how to use it [here](../examples/batch_job_oai.md)
 
 ## Best Practices
 
-1. **Model Selection** : We recommend using gpt-4o-mini for simpler use cases because it's cheap and works well with a clearly defined objective for structured outputs. When the task is more ambigious, consider upgrading to `4o` or even `O1` depending on your needs
+1. **Model Selection** : We recommend using gpt-4o-mini for simpler use cases because it's cheap and works well with a clearly defined objective for structured outputs. When the task is more ambiguous, consider upgrading to `4o` or even `O1` depending on your needs
 
 2. **Performance Optimization** : Streaming a response model is faster and should be done from the get-go. This is especially true if you're using a simple response model.
 

--- a/docs/prompting/ensembling/diverse.md
+++ b/docs/prompting/ensembling/diverse.md
@@ -49,7 +49,7 @@ async def generate_response(query: str, examples: list[str]):
                 "content": dedent(
                     f"""
                 You are a world class AI that excels at answering
-                user queries in a succint and accurate manner.
+                user queries in a succinct and accurate manner.
 
                 <query>
                 {query}
@@ -77,7 +77,7 @@ async def score_response(query: str, response: Response) -> tuple[Response, Grad
                     "content": dedent(
                         f"""
                 You are a world class AI that excels at grading
-                responses to a user query in a succint and clear
+                responses to a user query in a succinct and clear
                 manner.
 
                 <query>

--- a/docs/prompting/ensembling/max_mutual_information.md
+++ b/docs/prompting/ensembling/max_mutual_information.md
@@ -8,7 +8,7 @@ Max Mutual Information Method is a method of prompting that aims to find the bes
 
 ### Entropy
 
-When a language model recieves a prompt as input, it outputs a series of token probabilities sequentially until it reaches the `<EOS>` token. In the paper, they take the final probability distribution as $P(Y|X)$ where $Y$ is the final prediction of the model and $X$ the prompt.
+When a language model receives a prompt as input, it outputs a series of token probabilities sequentially until it reaches the `<EOS>` token. In the paper, they take the final probability distribution as $P(Y|X)$ where $Y$ is the final prediction of the model and $X$ the prompt.
 
 When we have a probability distribution, we can calculate a probability known as entropy. The lower this value is, the better. This is because a lower entropy value means that the model is more confident in its prediction.
 
@@ -52,7 +52,7 @@ We can then use this new mutual information metric to compare the effectiveness 
 
 ## Implementation
 
-Since we don't have access to the raw log probabilites of specific tokens we want in the OpenAI API, we'll instead get the language model to generate a final score from 1 - 10 of its confidence in it's prediction.
+Since we don't have access to the raw log probabilities of specific tokens we want in the OpenAI API, we'll instead get the language model to generate a final score from 1 - 10 of its confidence in it's prediction.
 
 We'll then convert this to a probability distribution with two outcomes and calculate a value for the entropy off of that.
 

--- a/docs/prompting/ensembling/more.md
+++ b/docs/prompting/ensembling/more.md
@@ -6,7 +6,7 @@ Language Models struggle to generalize across question types that require distin
 
 In the original paper, they utilise four different experts
 
-1. Factual Expert : This is a model that is augmented by a RAG prompting pipeline. WHen it recieves a query, it retrieves the top 10 most relevant passages from Wikipedia and appends them to the prompt right before the question.
+1. Factual Expert : This is a model that is augmented by a RAG prompting pipeline. WHen it receives a query, it retrieves the top 10 most relevant passages from Wikipedia and appends them to the prompt right before the question.
 
 2. Multihop Expert : This is an expert that has manually written rationales after each demo to elicit multi-step reasoning processes for the questions
 
@@ -16,7 +16,7 @@ In the original paper, they utilise four different experts
 
 ![](../../img/more.png)
 
-Once each expert has genearted a response, they then use a random forest classifier to score it from 0 to 1. This is then used for selecting the final answer and determining if we've generated a sufficiently good answer ( Since we have the option to abstain at each point )
+Once each expert has generated a response, they then use a random forest classifier to score it from 0 to 1. This is then used for selecting the final answer and determining if we've generated a sufficiently good answer ( Since we have the option to abstain at each point )
 
 We can implement a simplified version of MoRE with `instructor` with a few modifications.
 

--- a/docs/prompting/ensembling/universal_self_consistency.md
+++ b/docs/prompting/ensembling/universal_self_consistency.md
@@ -2,7 +2,7 @@
 description: "Universal Self Consistency aims to extend Self-Consistency by using Large Language Models themselves to select the most consistent answer among multiple candidates"
 ---
 
-Universal Self Consistency<sup><a href="https://arxiv.org/pdf/2311.17311">1</a></sup> aims to extend self-consistency by using a second LLM model to judge the quality of individual responses. Therefore instead of choosing the final answer based on the most frequently occuring value among each reasoning chain, we instead prompt the model to choose the most consistent answer for us relative to the prompt.
+Universal Self Consistency<sup><a href="https://arxiv.org/pdf/2311.17311">1</a></sup> aims to extend self-consistency by using a second LLM model to judge the quality of individual responses. Therefore instead of choosing the final answer based on the most frequently occurring value among each reasoning chain, we instead prompt the model to choose the most consistent answer for us relative to the prompt.
 
 ![](../../img/universal_self_consistency.png)
 

--- a/docs/prompting/self_criticism/reversecot.md
+++ b/docs/prompting/self_criticism/reversecot.md
@@ -2,7 +2,7 @@
 description: "Reverse Chain Of Thought is a method to help identify logical inconsistencies in the reasoning steps of a large language model's response"
 ---
 
-We can use a method called Reverse Chain Of Thought<sup><a href="https://arxiv.org/pdf/2305.11499">1</a></sup> to reverse engineer a problem given a solution. This helps us to find specific inconsistencies in the reasoning steps taken by our model and to give targetted feedback which can improve the quality of the solution.
+We can use a method called Reverse Chain Of Thought<sup><a href="https://arxiv.org/pdf/2305.11499">1</a></sup> to reverse engineer a problem given a solution. This helps us to find specific inconsistencies in the reasoning steps taken by our model and to give targeted feedback which can improve the quality of the solution.
 
 This is done through a 3 step process
 
@@ -115,7 +115,7 @@ def deconstruct_prompt_into_condition_list(prompt: str):
                 Please list the conditions of the problem given
                 below. There might be multiple conditions in the
                 problem so make sure to navigate through the
-                prompt incrementally, indentifying and extracting
+                prompt incrementally, identifying and extracting
                 the conditions necessary to answer the question
                 in your final response.
                 """,
@@ -147,7 +147,7 @@ def generate_feedback(
                 {formatted_final_conditions}
 
                 Determine if the two condition lists are roughly
-                equivalent. If they are not, give targetted
+                equivalent. If they are not, give targeted
                 feedback on what is missing from the reconstructed
                 condition list as compared to the original condition
                 list and how it can be fixed.

--- a/docs/prompting/self_criticism/self_verification.md
+++ b/docs/prompting/self_criticism/self_verification.md
@@ -20,7 +20,7 @@ Backward verification involves three steps.
 
 Rewrite the original question and its solution as a declarative.
 
-!!! example "Rewritten Declaritive Example"
+!!! example "Rewritten Declarative Example"
     **original question**: Jackie has 10 apples. Adam has 8 apples. How many more apples does Jackie have than Adam?
     **response candidate**: Jackie has 10 apples. so Jackie has 10-8=2 more apples than Adam, and the answer is 2.
     **rewritten declarative**: Jackie has 10 apples. Adam has 8 apples. Jackie has 2 more apples than Adam.

--- a/docs/prompting/thought_generation/chain_of_thought_few_shot/uncertainty_routed_cot.md
+++ b/docs/prompting/thought_generation/chain_of_thought_few_shot/uncertainty_routed_cot.md
@@ -35,7 +35,7 @@ async def generate_response(query: str, options: dict[str, str]):
                 "role": "system",
                 "content": dedent(
                     f"""
-                You are a a world class AI who excels at answering
+                You are a world class AI who excels at answering
                 complex questions. Choose one of the options below
                 that best answers the question you are about to be
                 asked

--- a/docs/prompting/zero_shot/rar.md
+++ b/docs/prompting/zero_shot/rar.md
@@ -1,22 +1,22 @@
 ---
-description: "To help the model better infer human intention from ambigious prompts, we can ask the model to rephrase and respond (RaR)."
+description: "To help the model better infer human intention from ambiguous prompts, we can ask the model to rephrase and respond (RaR)."
 ---
 
-How can we identify and clarify ambigious information in the prompt?
+How can we identify and clarify ambiguous information in the prompt?
 
 Let's say we are given the query: *Was Ed Sheeran born on an odd month?*
 
 There are many ways a model might interpret an *odd month*:
 
-- Februray is *odd* because of an irregular number of days.
+- February is *odd* because of an irregular number of days.
 - A month is *odd* if it has an odd number of days.
-- A month is *odd* if its numberical order in the year is odd (i.e. Janurary is the 1st month).
+- A month is *odd* if its numerical order in the year is odd (i.e. January is the 1st month).
 
 !!! note
 
     Ambiguities might not always be so obvious!
 
-To help the model better infer human intention from ambigious prompts, we can ask the model to rephrase and respond (RaR).
+To help the model better infer human intention from ambiguous prompts, we can ask the model to rephrase and respond (RaR).
 
 ## Implementation
 
@@ -45,7 +45,7 @@ def rephrase_and_respond(query):
 
 
 if __name__ == "__main__":
-    query = "Take the last letters of the words in 'Edgar Bob' and concatinate them."
+    query = "Take the last letters of the words in 'Edgar Bob' and concatenate them."
 
     response = rephrase_and_respond(query)
 

--- a/docs/prompting/zero_shot/role_prompting.md
+++ b/docs/prompting/zero_shot/role_prompting.md
@@ -65,6 +65,6 @@ if __name__ == "__main__":
 
 ## References
 
-<sup id="ref-1">1</sup>: [RoleLLM: Benchmarking, Eliciting, and Enhancing Role-Playing Abilities of Large Lanuage Models](https://arxiv.org/abs/2310.00746)
+<sup id="ref-1">1</sup>: [RoleLLM: Benchmarking, Eliciting, and Enhancing Role-Playing Abilities of Large Language Models](https://arxiv.org/abs/2310.00746)
 <sup id="ref-2">2</sup>: [Is "A Helpful Assistant" the Best Role for Large Language Models? A Systematic Evaluation of Social Roles in System Prompts ](https://arxiv.org/abs/2311.10054)
-<sup id="ref-4">3</sup>: [Unleashing the Emergent Cognitive Synergy in Large Lanuage Models: A Task-Solving Agent through Multi-Persona Self-Collaboration ](https://arxiv.org/abs/2307.05300)
+<sup id="ref-4">3</sup>: [Unleashing the Emergent Cognitive Synergy in Large Language Models: A Task-Solving Agent through Multi-Persona Self-Collaboration ](https://arxiv.org/abs/2307.05300)

--- a/docs/prompting/zero_shot/style_prompting.md
+++ b/docs/prompting/zero_shot/style_prompting.md
@@ -1,11 +1,11 @@
 ---
 title: "Style Prompting"
-description: "To contrain a model's response to fit the boundaries of our task, we can specify a style."
+description: "To constrain a model's response to fit the boundaries of our task, we can specify a style."
 ---
 
 How can we constrain model outputs through prompting alone?
 
-To contrain a model's response to fit the boundaries of our task, we can specify a style.
+To constrain a model's response to fit the boundaries of our task, we can specify a style.
 
 Stylistic constraints can include:
 

--- a/examples/citation_with_extraction/README.md
+++ b/examples/citation_with_extraction/README.md
@@ -29,7 +29,7 @@ Replace `http://localhost:8000` with the actual URL of your FastAPI app if it's 
 ## Bring your own API key
 
 If you have your own api key but dont want to try deploying it yourself you're welcome to use my 
-modal isntance here, this code is public and I do not store your key.
+modal instance here, this code is public and I do not store your key.
 
 ```bash
 curl -X 'POST' \


### PR DESCRIPTION
The Gemini multimodal post shows its sample output as `Recomendations(`, but the model class is defined and passed as `Recommendations` — so the snippet does not match the code directly above it. The Gemini integration page also links to that post as "Using Geminin To Extract Travel Video Recomendations".

The rest are spelling corrections in prose and in example prompts: `ambigious`, `convinient`, `useable`, `recieves`, `targetted`, `succint`, `contrain` (→ `constrain`, matching the wording already used a couple of lines above), `Lanuage`, `Declaritive`, `occuring`, `probabilites`, `genearted`, `indentifying`, `numberical`, `Janurary`, `Februray`, `concatinate`, `procide`, `duplcates`, `runnign`, `serveral`, `roomate`, `isntance`, `neeed` and `possibily`.

Two doubled words as well: "You are a a world class AI" and "within 7 days of the the signed date".

Documentation only — 38 lines across 24 Markdown files, no code changes.