### PR TITLE
fix(cache): include sampling parameters (temperature, seed, ...) in the cache key

### DIFF
--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -85,6 +85,7 @@ Components that influence the key:
 | `messages` / `contents`     | The full chat history is hashed              |
 | `mode`                      | JSON vs. TOOLS vs. RESPONSES changes formatting |
 | `response_model` schema     | The entire `model_json_schema()` is included so **any** change in field names, types or *descriptions* busts the cache automatically |
+| sampling parameters (`temperature`, `top_p`, `seed`, `max_tokens`, …) | Calls that only differ in these must not collide — otherwise a higher-`temperature` call would silently be served a lower-`temperature` call's cached answer |
 
 The function returns a SHA-256 hex digest; its length is constant regardless
 of prompt size, so it is safe to use as a Redis key, file path, etc.

--- a/instructor/cache/__init__.py
+++ b/instructor/cache/__init__.py
@@ -37,6 +37,7 @@ __all__ = [
     "AutoCache",
     "DiskCache",
     "make_cache_key",
+    "extract_generation_kwargs",
 ]
 
 
@@ -141,6 +142,36 @@ class DiskCache(BaseCache):
 # Cache-key helper
 # -------------------------------------------------------------------------
 
+# Sampling/generation parameters that affect the model's output and must
+# therefore be part of the cache key -- otherwise two calls that differ only
+# in, say, ``temperature`` collide and the second call silently returns the
+# first call's cached (and differently-sampled) response.
+_GENERATION_PARAM_KEYS: tuple[str, ...] = (
+    "temperature",
+    "top_p",
+    "top_k",
+    "seed",
+    "max_tokens",
+    "max_completion_tokens",
+    "max_output_tokens",
+    "frequency_penalty",
+    "presence_penalty",
+    "n",
+    "stop",
+    "stop_sequences",
+    "logit_bias",
+)
+
+
+def extract_generation_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Pull the sampling parameters relevant to :func:`make_cache_key` out of
+    a provider call's kwargs dict, dropping anything unset."""
+    return {
+        key: kwargs[key]
+        for key in _GENERATION_PARAM_KEYS
+        if key in kwargs and kwargs[key] is not None
+    }
+
 
 def make_cache_key(
     *,
@@ -149,6 +180,7 @@ def make_cache_key(
     response_model: type[BaseModel] | None,
     mode: str | None = None,
     system: Any = None,
+    generation_kwargs: dict[str, Any] | None = None,
 ) -> str:  # noqa: ANN401
     """Compute a *deterministic* cache key.
 
@@ -165,6 +197,10 @@ def make_cache_key(
         • *mode* (Tools, JSON, …) – helps when users change Instructor mode
         • *response_model* schema – so edits to field definitions or
           descriptions invalidate prior cache entries (critical!).
+        • *generation_kwargs* – sampling parameters such as ``temperature``,
+          ``top_p`` or ``seed``. Two calls that are otherwise identical but
+          request different sampling behavior must not collide (see
+          :func:`extract_generation_kwargs`).
     """
 
     payload: dict[str, Any] = {
@@ -177,6 +213,9 @@ def make_cache_key(
     # prompt inside ``messages`` (OpenAI & friends) stay unchanged.
     if system is not None:
         payload["system"] = system
+
+    if generation_kwargs:
+        payload["generation_kwargs"] = generation_kwargs
 
     if response_model is not None:
         # Include the entire JSON schema – guarantees busting when either

--- a/instructor/v2/core/patch.py
+++ b/instructor/v2/core/patch.py
@@ -245,7 +245,12 @@ def _create_sync_wrapper(
 
         # Attempt cache lookup before retry layer
         if cache is not None and response_model is not None:
-            from instructor.cache import BaseCache, make_cache_key, load_cached_response
+            from instructor.cache import (
+                BaseCache,
+                make_cache_key,
+                load_cached_response,
+                extract_generation_kwargs,
+            )
 
             if isinstance(cache, BaseCache):
                 key = make_cache_key(
@@ -256,6 +261,7 @@ def _create_sync_wrapper(
                     response_model=response_model,
                     mode=str(mode.value),
                     system=new_kwargs.get("system"),
+                    generation_kwargs=extract_generation_kwargs(new_kwargs),
                 )
                 cached = load_cached_response(cache, key, response_model)
                 if cached is not None:
@@ -285,6 +291,7 @@ def _create_sync_wrapper(
                     BaseCache,
                     make_cache_key,
                     store_cached_response,
+                    extract_generation_kwargs,
                 )
                 from pydantic import BaseModel as _BM  # type: ignore[import-not-found]
 
@@ -297,6 +304,7 @@ def _create_sync_wrapper(
                         response_model=response_model,
                         mode=str(mode.value),
                         system=new_kwargs.get("system"),
+                        generation_kwargs=extract_generation_kwargs(new_kwargs),
                     )
                     store_cached_response(cache, key, response, ttl=cache_ttl)
             except ModuleNotFoundError:
@@ -370,7 +378,12 @@ def _create_async_wrapper(
 
         # Attempt cache lookup before retry layer
         if cache is not None and response_model is not None:
-            from instructor.cache import BaseCache, make_cache_key, load_cached_response
+            from instructor.cache import (
+                BaseCache,
+                make_cache_key,
+                load_cached_response,
+                extract_generation_kwargs,
+            )
 
             if isinstance(cache, BaseCache):
                 key = make_cache_key(
@@ -381,6 +394,7 @@ def _create_async_wrapper(
                     response_model=response_model,
                     mode=str(mode.value),
                     system=new_kwargs.get("system"),
+                    generation_kwargs=extract_generation_kwargs(new_kwargs),
                 )
                 cached = load_cached_response(cache, key, response_model)
                 if cached is not None:
@@ -410,6 +424,7 @@ def _create_async_wrapper(
                     BaseCache,
                     make_cache_key,
                     store_cached_response,
+                    extract_generation_kwargs,
                 )
                 from pydantic import BaseModel as _BM  # type: ignore[import-not-found]
 
@@ -422,6 +437,7 @@ def _create_async_wrapper(
                         response_model=response_model,
                         mode=str(mode.value),
                         system=new_kwargs.get("system"),
+                        generation_kwargs=extract_generation_kwargs(new_kwargs),
                     )
                     store_cached_response(cache, key, response, ttl=cache_ttl)
             except ModuleNotFoundError:

--- a/tests/cache/test_cache_integration.py
+++ b/tests/cache/test_cache_integration.py
@@ -166,3 +166,67 @@ def test_cache_key_accounts_for_hoisted_system_prompt():
     repeat = ask("Always answer in French.")
     assert call_counter["n"] == 2, "Identical request should still be served from cache"
     assert repeat.value == "call-1"
+
+
+def test_cache_key_accounts_for_temperature(monkeypatch):
+    """Regression test: sampling parameters must be part of the cache key.
+
+    Two otherwise-identical calls that differ only in ``temperature`` (or any
+    other sampling parameter) must not collide -- the second call has to hit
+    the provider again, not silently receive the first call's response.
+    """
+    _ = monkeypatch
+
+    class Answer(BaseModel):
+        value: str
+
+    call_counter = {"n": 0}
+
+    def fake_completion(*_args, **_kwargs):
+        call_counter["n"] += 1
+        content = Answer(value=f"call-{call_counter['n']}").model_dump_json()
+        return types.SimpleNamespace(
+            choices=[
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(content=content),
+                    finish_reason="stop",
+                )
+            ],
+            usage={},
+        )
+
+    cache = AutoCache(maxsize=10)
+    client = instructor.from_litellm(fake_completion, mode=instructor.Mode.JSON)
+    messages: list[ChatCompletionMessageParam] = [
+        {"role": "user", "content": "roll a random number"}
+    ]
+
+    first = client.create(
+        messages=list(messages),
+        response_model=Answer,
+        cache=cache,
+        temperature=0.0,
+    )
+    assert call_counter["n"] == 1
+    assert first.value == "call-1"
+
+    second = client.create(
+        messages=list(messages),
+        response_model=Answer,
+        cache=cache,
+        temperature=1.9,
+    )
+    assert call_counter["n"] == 2, (
+        "A different temperature must not reuse the cached response"
+    )
+    assert second.value == "call-2"
+
+    # Repeating the very first request (same temperature) must still hit cache.
+    repeat = client.create(
+        messages=list(messages),
+        response_model=Answer,
+        cache=cache,
+        temperature=0.0,
+    )
+    assert call_counter["n"] == 2, "Identical request should still be served from cache"
+    assert repeat.value == "call-1"

--- a/tests/cache/test_cache_key.py
+++ b/tests/cache/test_cache_key.py
@@ -85,3 +85,63 @@ def test_cache_key_unchanged_when_no_system_prompt():
     assert without == explicit_none, (
         "Keys must stay stable for providers without a hoisted system prompt"
     )
+
+
+def test_cache_key_changes_on_temperature_change():
+    k1 = make_cache_key(
+        messages=messages,
+        model=model_name,
+        response_model=UserV1,
+        generation_kwargs={"temperature": 0.0},
+    )
+    k2 = make_cache_key(
+        messages=messages,
+        model=model_name,
+        response_model=UserV1,
+        generation_kwargs={"temperature": 1.9},
+    )
+    assert k1 != k2, (
+        "Calls that differ only in temperature must not collide in the cache"
+    )
+
+
+def test_cache_key_changes_on_seed_change():
+    k1 = make_cache_key(
+        messages=messages,
+        model=model_name,
+        response_model=UserV1,
+        generation_kwargs={"seed": 1},
+    )
+    k2 = make_cache_key(
+        messages=messages,
+        model=model_name,
+        response_model=UserV1,
+        generation_kwargs={"seed": 2},
+    )
+    assert k1 != k2, "Calls that differ only in seed must not collide in the cache"
+
+
+def test_cache_key_unchanged_when_no_generation_kwargs():
+    without = make_cache_key(messages=messages, model=model_name, response_model=UserV1)
+    explicit_empty = make_cache_key(
+        messages=messages,
+        model=model_name,
+        response_model=UserV1,
+        generation_kwargs={},
+    )
+    assert without == explicit_empty, (
+        "Keys must stay stable when no generation kwargs are supplied"
+    )
+
+
+def test_extract_generation_kwargs_drops_unset_and_irrelevant_keys():
+    from instructor.cache import extract_generation_kwargs
+
+    new_kwargs = {
+        "model": model_name,
+        "messages": messages,
+        "temperature": 0.7,
+        "seed": None,  # unset -> must be dropped
+        "tools": [{"type": "function"}],  # not a sampling param -> must be dropped
+    }
+    assert extract_generation_kwargs(new_kwargs) == {"temperature": 0.7}


### PR DESCRIPTION
## Describe your changes

Fixes #2585.

`make_cache_key` never looked at `temperature`, `top_p`, `seed`,
`max_tokens`, or any other sampling parameter, even though `patch.py`'s
cache lookup/store sites have them available in `new_kwargs`. Two calls
identical except for sampling parameters produced the same cache key, so
the second call silently received the first call's cached response instead
of hitting the provider.

Added `extract_generation_kwargs()` in `instructor/cache/__init__.py`,
which pulls a fixed allowlist of sampling-affecting keys (`temperature`,
`top_p`, `top_k`, `seed`, `max_tokens`, `max_completion_tokens`,
`max_output_tokens`, `frequency_penalty`, `presence_penalty`, `n`, `stop`,
`stop_sequences`, `logit_bias`) out of a kwargs dict, dropping anything
unset. `make_cache_key` gained an optional `generation_kwargs` parameter
that folds these into the hashed payload when present, so keys are
unchanged when no sampling parameters are passed. Wired
`generation_kwargs=extract_generation_kwargs(new_kwargs)` into all four
`make_cache_key` call sites (sync lookup/store, async lookup/store) in
`patch.py`.

Also updated the "Cache-key design" table in `docs/concepts/caching.md`.

## Issue ticket number and link

Fixes #2585

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.

## Proof of fix

Added:
- `tests/cache/test_cache_key.py`: unit tests on `make_cache_key`/`extract_generation_kwargs` (temperature/seed change the key; no-generation-kwargs keys are unchanged; irrelevant/unset keys are dropped).
- `tests/cache/test_cache_integration.py::test_cache_key_accounts_for_temperature`: end-to-end through the real client (`instructor.from_litellm`) — a `temperature=1.9` call after a cached `temperature=0.0` call must re-hit the provider.

Verified the regression tests actually catch the bug: reverted just the fix (kept the tests) and 5 of the 14 cache tests failed, including the integration test with `assert call_counter["n"] == 2` failing as `1 == 2` (the second call never reached the provider). Restored the fix — all 14 pass again.

```
tests/cache/test_cache_key.py::test_cache_key_changes_on_temperature_change PASSED
tests/cache/test_cache_key.py::test_cache_key_changes_on_seed_change PASSED
tests/cache/test_cache_key.py::test_cache_key_unchanged_when_no_generation_kwargs PASSED
tests/cache/test_cache_key.py::test_extract_generation_kwargs_drops_unset_and_irrelevant_keys PASSED
tests/cache/test_cache_integration.py::test_cache_key_accounts_for_temperature PASSED
============================== 14 passed in 0.59s ===============================
```

Ran the broader offline test suite (`tests/core`, `tests/dsl`, `tests/v2`, `tests/cache`, `tests/processing`): 2018 passed, 178 skipped, 6 failed. Confirmed all 6 failures are pre-existing on unmodified `main` too (missing optional `vertexai`/`mistralai`/`google-genai` SDKs in this environment), unrelated to this change.

`ruff check` and `ruff format --check` pass on all changed files.

## Scope

Two-file logic change (`instructor/cache/__init__.py`, `instructor/v2/core/patch.py`) plus tests and a one-line doc update. No other caching behavior changed.