### PR TITLE
docs: fix blog code blocks that fail the docs lint

### DIFF
--- a/docs/blog/posts/anthropic-prompt-caching.md
+++ b/docs/blog/posts/anthropic-prompt-caching.md
@@ -188,7 +188,6 @@ Let's first initialize our Anthropic client, this will be the same as what we've
 from instructor import Instructor, Mode, patch
 from anthropic import Anthropic
 
-
 client = Instructor(
     client=Anthropic(),
     create=patch(

--- a/docs/blog/posts/anthropic-web-search-structured.md
+++ b/docs/blog/posts/anthropic-web-search-structured.md
@@ -38,7 +38,6 @@ Now, let's define our Pydantic model for the response:
 import instructor
 from pydantic import BaseModel
 
-
 # Noticed thhat we use JSON not TOOLS mode
 client = instructor.from_provider(
     "anthropic/claude-3-7-sonnet-latest",

--- a/docs/blog/posts/bad-schemas-could-break-llms.md
+++ b/docs/blog/posts/bad-schemas-could-break-llms.md
@@ -169,17 +169,20 @@ class AssumptionBasedAnswer(BaseModel):
     logic_flow: str
     answer: int
 
+
 class ErrorAwareCalculation(BaseModel):
     key_steps: list[str]
     potential_pitfalls: list[str]
     intermediate_results: list[str]
     answer: int
 
- lass AnswerWithIntermediateCalculations(BaseModel):
+
+class AnswerWithIntermediateCalculations(BaseModel):
     assumptions: list[str]
     intermediate_calculations: list[str]
     chain_of_thought: str
     final_answer: int
+
 
 class AssumptionBasedAnswerWithExtraFields(BaseModel):
     assumptions: list[str]

--- a/docs/blog/posts/jinja-proposal.md
+++ b/docs/blog/posts/jinja-proposal.md
@@ -119,6 +119,7 @@ Here's an example demonstrating this concept using Pydantic validators:
 ```python
 from pydantic import BaseModel, ValidationInfo, field_validator
 
+
 class Response(BaseModel):
     text: str
 
@@ -128,9 +129,13 @@ class Response(BaseModel):
         context = info.context
         if context:
             banned_words = context.get('banned_words', set())
-            banned_words_found = [word for word in banned_words if word.lower() in v.lower()]
+            banned_words_found = [
+                word for word in banned_words if word.lower() in v.lower()
+            ]
             if banned_words_found:
-                raise ValueError(f"Banned words found in text: {', '.join(banned_words_found)}, rewrite it but just without the banned words")
+                raise ValueError(
+                    f"Banned words found in text: {', '.join(banned_words_found)}, rewrite it but just without the banned words"
+                )
         return v
 
     @field_validator('text')
@@ -142,6 +147,7 @@ class Response(BaseModel):
             for pattern in redact_patterns:
                 v = re.sub(pattern, '****', v)
         return v
+
 
 response = client.create(
     model="gpt-4o",
@@ -161,22 +167,22 @@ response = client.create(
                 {% endfor %}
                 </banned_words>
                 {% endif %}
-              """
+              """,
         },
     ],
     context={
-        "topic": "jason and now his phone number is 123-456-7890"
+        "topic": "jason and now his phone number is 123-456-7890",
         "banned_words": ["jason"],
         "redact_patterns": [
             r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b",  # Phone number pattern
-            r"\b\d{3}-\d{2}-\d{4}\b",          # SSN pattern
+            r"\b\d{3}-\d{2}-\d{4}\b",  # SSN pattern
         ],
     },
     max_retries=3,
 )
 
 print(response.text)
-# > While i can't say his name anymore, his phone number is ****
+#> While i can't say his name anymore, his phone number is ****
 ```
 
 ## Better Versioning and Logging

--- a/docs/blog/posts/logfire.md
+++ b/docs/blog/posts/logfire.md
@@ -58,7 +58,6 @@ from openai import OpenAI
 import instructor
 import logfire
 
-
 openai_client = OpenAI()
 logfire.configure(pydantic_plugin=logfire.PydanticPlugin(record="all"))  # (1)!
 logfire.instrument_openai(openai_client)  # (2)!
@@ -243,7 +242,6 @@ We can then use this in a normal instructor call
 ```python
 import instructor
 import logfire
-
 
 client = instructor.from_provider("openai/gpt-4o", mode=instructor.Mode.MD_JSON)
 logfire.configure(pydantic_plugin=logfire.PydanticPlugin(record="all"))

--- a/docs/blog/posts/matching-language.md
+++ b/docs/blog/posts/matching-language.md
@@ -208,9 +208,7 @@ In den letzten Jahren sind Sprachmodelle immer ausgefeilter geworden und können
 ---
 
 近年、言語モデルは非常に洗練され、自然で流暢なテキストを生成できるようになり、機械翻訳、質問応答、クリエイティブなテキスト生成など、様々なタスクで優れたパフォーマンスを発揮しています。これらのモデルは膨大なテキストデータセットで学習され、自然言語の構造とニュアンスを捉えることができます。言語モデルの改善により、コンピューターと人間のコミュニケーションに革命が起こる可能性があり、将来のさらなる進歩が期待されています。
-""".split(
-        "---"
-    ),
+""".split("---"),
 )
 
 # Patch the OpenAI client to enable response_model

--- a/docs/blog/posts/open_source.md
+++ b/docs/blog/posts/open_source.md
@@ -97,7 +97,6 @@ import instructor
 from llama_cpp.llama_speculative import LlamaPromptLookupDecoding
 from pydantic import BaseModel
 
-
 llama = llama_cpp.Llama(
     model_path="../../models/OpenHermes-2.5-Mistral-7B-GGUF/openhermes-2.5-mistral-7b.Q4_K_M.gguf",
     n_gpu_layers=-1,
@@ -151,7 +150,6 @@ from pydantic import BaseModel
 import groq
 import instructor
 
-
 client = groq.Groq(
     api_key=os.environ.get("GROQ_API_KEY"),
 )
@@ -196,7 +194,6 @@ from pydantic import BaseModel
 
 import instructor
 import openai
-
 
 client = openai.OpenAI(
     base_url="https://api.together.xyz/v1",

--- a/docs/blog/posts/string-based-init.md
+++ b/docs/blog/posts/string-based-init.md
@@ -95,19 +95,13 @@ import instructor
 from instructor import Mode
 
 # Override the default mode for a provider
-client = instructor.from_provider(
-    "anthropic/claude-3-sonnet", mode=Mode.TOOLS
-)
+client = instructor.from_provider("anthropic/claude-3-sonnet", mode=Mode.TOOLS)
 
 # Use JSON mode instead of the default tools mode
-client = instructor.from_provider(
-    "mistral/mistral-large", mode=Mode.JSON_SCHEMA
-)
+client = instructor.from_provider("mistral/mistral-large", mode=Mode.JSON_SCHEMA)
 
 # Use reasoning tools instead of regular tools for Anthropic
-client = instructor.from_provider(
-    "anthropic/claude-3-opus", mode=Mode.TOOLS
-)
+client = instructor.from_provider("anthropic/claude-3-opus", mode=Mode.TOOLS)
 ```
 
 If not specified, each provider will use its recommended default mode:

--- a/docs/blog/posts/version-1.md
+++ b/docs/blog/posts/version-1.md
@@ -49,9 +49,7 @@ IF you know you want to pass in temperature, seed, or model, you can do so.
 import openai
 import instructor
 
-client = instructor.from_openai(
-    openai.OpenAI(), model="gpt-5.4-mini", temperature=0.2
-)
+client = instructor.from_openai(openai.OpenAI(), model="gpt-5.4-mini", temperature=0.2)
 ```
 
 Now, whenever you call `client.chat.completions.create` the `model` and `temperature` will be passed to the openai client!
@@ -120,7 +118,6 @@ This will also work correctly with asynchronous clients.
 import instructor
 from pydantic import BaseModel
 
-
 client = instructor.from_provider("openai/gpt-5-nano", async_client=True)
 
 
@@ -151,7 +148,6 @@ You can also return the original completion object
 import instructor
 from pydantic import BaseModel
 
-
 client = instructor.from_provider("openai/gpt-5-nano")
 
 
@@ -179,7 +175,6 @@ In order to handle streams, we still support `Iterable[T]` and `Partial[T]` but 
 ```python
 import instructor
 from pydantic import BaseModel
-
 
 client = instructor.from_provider("openai/gpt-5-nano")
 
@@ -227,7 +222,6 @@ We get an iterable of objects when we want to extract multiple objects.
 ```python
 import instructor
 from pydantic import BaseModel
-
 
 client = instructor.from_provider("openai/gpt-5-nano")
 


### PR DESCRIPTION
## Why

`tests/docs/test_posts.py` lints every code block under `docs/blog/posts` with black via pytest-examples. **34 of them fail on `main`**, which is why `weekly-tests` and the `release` job's test step are both red:

```
34 failed, 228 passed
```

This fixes **16 of the 34**, taking it to `18 failed, 244 passed`.

## Two were genuinely broken Python

A reader copying either of these gets a `SyntaxError`:

**`bad-schemas-could-break-llms.md`** — missing the `c`:

```diff
- lass AnswerWithIntermediateCalculations(BaseModel):
+class AnswerWithIntermediateCalculations(BaseModel):
```

**`jinja-proposal.md`** — missing comma, so the two strings concatenate and the following dict key is a syntax error:

```diff
-        "topic": "jason and now his phone number is 123-456-7890"
+        "topic": "jason and now his phone number is 123-456-7890",
         "banned_words": ["jason"],
```

## The rest is the formatter's own output

Once those two parse, black can format them. Everything else here is what pytest-examples' formatter produces — joined lines that now fit the width, and blank lines black adds or removes between definitions. I ran only the `format` step, not `--update-examples`: the latter also calls `run_print_update`, which executes the examples and fails without provider API keys (it takes the suite to 240 failures).

In `jinja-proposal.md` the formatter also restored `#> ` on an output comment that had drifted to `# >`. `#> ` — with the trailing space — is pytest-examples' `comment_prefix`; `# >` isn't matched as an output marker, so this is a repair.

## One file deliberately left alone

`introducing-structured-outputs.md` is excluded. Its block has a bare `#> ` marker standing for an empty printed line, and that form can't survive formatting: black strips the trailing space, the result no longer matches `comment_prefix`, and black then rewrites it to `# >` — which breaks the marker *and* leaves it inconsistent with the `#> ...` lines directly beneath it:

```
            # >          <- rewritten
            #> {"
            #> {"name
```

Writing `# >` into the docs to satisfy the linter seemed worse than leaving the block failing, so it's in the group below.

## The remaining 18 need a decision I didn't want to make alone

These are published posts, and each needs a judgement about intent:

- **empty ` ```python ` blocks** where install instructions appear to have been lost — `multimodal-gemini.md` and `generating-pdf-citations.md` both introduce a snippet with prose ("let's set up our environment with the necessary libraries:") and then show an empty block
- **pseudo-code fenced as python** — e.g. `client.create(..., response_model=type[T]) -> T` in `version-1.md`, a type signature rather than a statement
- **fragments that were never standalone modules** — e.g. a bare `@field_validator` in `chain-of-density.md`

The options are to complete the snippet, re-fence as ` ```text ` (only fences starting with `py`/`{.py` are collected by `find_examples`), or exclude older posts from the lint entirely. Happy to follow up with whichever you'd prefer — I didn't want to rewrite published posts on my own judgement.

## Verification

```console
$ pytest tests/docs/test_posts.py -q
before:  34 failed, 228 passed
after:   18 failed, 244 passed
```

No source code touched — docs only.
