### PR TITLE
fix(validation): run declared async validators in the v2 retry path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Async validators**: `@async_field_validator` and `@async_model_validator` are now actually awaited during response parsing (including on nested models) instead of being silently ignored; a sync client given a `response_model` that declares async validators now raises a clear `ConfigurationError` instead of returning an unvalidated model. ([#2528](https://github.com/567-labs/instructor/issues/2528))
+
 ## [1.16.1] - 2026-08-28
 
 ### Changed

--- a/instructor/v2/core/errors.py
+++ b/instructor/v2/core/errors.py
@@ -506,7 +506,15 @@ class AsyncValidationError(ValueError, InstructorError):
         ```
     """
 
-    errors: list[ValueError]
+    def __init__(
+        self,
+        message: str,
+        *args: Any,
+        errors: list[ValueError] | None = None,
+        **kwargs: Any,
+    ):
+        self.errors = errors if errors is not None else []
+        super().__init__(message, *args, **kwargs)
 
 
 class ResponseParsingError(ValueError, InstructorError):

--- a/instructor/v2/core/retry.py
+++ b/instructor/v2/core/retry.py
@@ -25,6 +25,7 @@ from instructor.v2.core.mode import Mode
 from instructor.v2.core.providers import Provider
 from instructor.v2.core.errors import (
     AsyncValidationError,
+    ConfigurationError,
     FailedAttempt,
     IncompleteOutputException,
     InstructorRetryException,
@@ -262,6 +263,21 @@ def retry_sync_v2(
     if response_model is None:
         # No structured output, just call the API
         return func(*args, **kwargs)
+
+    # response_model declares @async_field_validator/@async_model_validator, but a
+    # sync client can never await them. Fail loudly instead of silently returning
+    # an unvalidated model (see GitHub issue #2528).
+    from instructor.v2.validation.async_validators import (
+        model_declares_async_validators,
+    )
+
+    if model_declares_async_validators(response_model):
+        raise ConfigurationError(
+            f"{response_model.__name__} declares async validators "
+            "(@async_field_validator/@async_model_validator), which require an "
+            "async client. Use an AsyncOpenAI-backed client "
+            "(`await client.chat.completions.create(...)`) instead."
+        )
 
     # Validate and get handlers from registry
     RegistryValidationMixin.validate_mode_registration(provider, mode)
@@ -636,6 +652,12 @@ async def retry_async_v2(
                         stream=stream,
                         is_async=True,
                     )
+                    if isinstance(parsed, (BaseModel, list)) and not stream:
+                        from instructor.v2.validation.async_validators import (
+                            run_async_validators,
+                        )
+
+                        parsed = await run_async_validators(parsed, context=context)
                     logger.debug(
                         f"Successfully parsed response on attempt "
                         f"{attempt.retry_state.attempt_number}"

--- a/instructor/v2/validation/__init__.py
+++ b/instructor/v2/validation/__init__.py
@@ -8,6 +8,8 @@ from instructor.v2.validation.async_validators import (
     AsyncValidationContext,
     async_field_validator,
     async_model_validator,
+    model_declares_async_validators,
+    run_async_validators,
 )
 from instructor.v2.validation.llm_validators import llm_validator, openai_moderation
 
@@ -16,6 +18,8 @@ __all__ = [
     "AsyncValidationError",
     "async_field_validator",
     "async_model_validator",
+    "model_declares_async_validators",
+    "run_async_validators",
     "ASYNC_VALIDATOR_KEY",
     "ASYNC_MODEL_VALIDATOR_KEY",
     "Validator",

--- a/instructor/v2/validation/async_validators.py
+++ b/instructor/v2/validation/async_validators.py
@@ -3,7 +3,9 @@
 from inspect import signature
 from typing import Any, Callable, TypeVar
 
-from pydantic import ValidationInfo
+from pydantic import BaseModel, ValidationInfo
+
+from instructor.v2.core.errors import AsyncValidationError
 
 ASYNC_VALIDATOR_KEY = "__async_validator__"
 ASYNC_MODEL_VALIDATOR_KEY = "__async_model_validator__"
@@ -73,3 +75,115 @@ def async_model_validator() -> Callable[[T], T]:
         return func
 
     return decorator
+
+
+def _collect_markers(model_cls: type[BaseModel], key: str) -> list[Any]:
+    """Walk the MRO (base classes first) collecting distinct decorator markers.
+
+    A subclass redefining a validator under the same attribute name overrides
+    the base class's version, matching normal Python method-override semantics.
+    """
+    markers: dict[str, Any] = {}
+    for klass in reversed(model_cls.__mro__):
+        for name, member in vars(klass).items():
+            marker = getattr(member, key, None)
+            if marker is not None:
+                markers[name] = marker
+    return list(markers.values())
+
+
+def model_declares_async_validators(model_cls: Any) -> bool:
+    """Return True if `model_cls` (or a base class) declares any async validator."""
+    if not isinstance(model_cls, type) or not issubclass(model_cls, BaseModel):
+        return False
+    return bool(
+        _collect_markers(model_cls, ASYNC_VALIDATOR_KEY)
+        or _collect_markers(model_cls, ASYNC_MODEL_VALIDATOR_KEY)
+    )
+
+
+async def run_async_validators(value: Any, *, context: dict[str, Any] | None) -> Any:
+    """Recursively run declared async field/model validators over a parsed value.
+
+    Nested `BaseModel` instances (directly, or inside lists/tuples/dicts) are
+    validated depth-first so a parent model's async validators see already
+    -validated children. Returns the (possibly updated) value; raises
+    `AsyncValidationError` aggregating every failure found in the subtree.
+    """
+    if isinstance(value, BaseModel):
+        return await _run_on_model(value, context=context)
+    if isinstance(value, list):
+        return [await run_async_validators(item, context=context) for item in value]
+    if isinstance(value, tuple):
+        return tuple(
+            [await run_async_validators(item, context=context) for item in value]
+        )
+    if isinstance(value, dict):
+        return {
+            key: await run_async_validators(item, context=context)
+            for key, item in value.items()
+        }
+    return value
+
+
+async def _run_on_model(
+    model: BaseModel, *, context: dict[str, Any] | None
+) -> BaseModel:
+    model_cls = type(model)
+    info = AsyncValidationContext(context or {})
+    errors: list[ValueError] = []
+    updates: dict[str, Any] = {}
+
+    for field_name in model_cls.model_fields:
+        current = getattr(model, field_name)
+        try:
+            new_value = await run_async_validators(current, context=context)
+        except AsyncValidationError as exc:
+            errors.extend(exc.errors)
+            continue
+        if new_value is not current:
+            updates[field_name] = new_value
+    if updates:
+        model = model.model_copy(update=updates)
+        updates = {}
+
+    for field_names, validator, needs_info in _collect_markers(
+        model_cls, ASYNC_VALIDATOR_KEY
+    ):
+        for field_name in field_names:
+            if field_name not in model_cls.model_fields:
+                continue
+            current = getattr(model, field_name)
+            try:
+                new_value = (
+                    await validator(model_cls, current, info)
+                    if needs_info
+                    else await validator(model_cls, current)
+                )
+            except ValueError as exc:
+                errors.append(exc)
+                continue
+            if new_value is not current:
+                updates[field_name] = new_value
+    if updates:
+        model = model.model_copy(update=updates)
+
+    for validator, needs_info in _collect_markers(model_cls, ASYNC_MODEL_VALIDATOR_KEY):
+        try:
+            result = (
+                await validator(model, info) if needs_info else await validator(model)
+            )
+        except ValueError as exc:
+            errors.append(exc)
+            continue
+        if result is not None:
+            model = result
+
+    if errors:
+        summary = "; ".join(str(error) for error in errors)
+        raise AsyncValidationError(
+            f"Async validation failed for {model_cls.__name__}: {summary}",
+            errors=errors,
+        )
+
+    return model

--- a/tests/v2/test_async_validators_execution.py
+++ b/tests/v2/test_async_validators_execution.py
@@ -1,0 +1,250 @@
+"""Regression tests for GitHub issue #2528: @async_field_validator and
+@async_model_validator were decorator-only -- nothing in the retry path ever
+awaited them, so declared async validators silently never ran.
+
+These drive the real v2 retry functions (`retry_async_v2` / `retry_sync_v2`)
+against fake completions, the same pattern used in test_messages_not_mutated.py,
+so the fix is verified end-to-end rather than by calling the validator helpers
+directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+from openai.types.completion_usage import CompletionUsage
+from pydantic import BaseModel
+
+from instructor.v2.core.errors import (
+    AsyncValidationError,
+    ConfigurationError,
+    InstructorRetryException,
+)
+from instructor.v2.core.mode import Mode
+from instructor.v2.core.providers import Provider
+from instructor.v2.core.registry import mode_registry
+from instructor.v2.core.retry import retry_async_v2, retry_sync_v2
+from instructor.v2.validation import async_field_validator, async_model_validator
+
+
+def _tool_call_response(arguments: str, call_id: str = "call_1") -> ChatCompletion:
+    tool_call = ChatCompletionMessageToolCall(
+        id=call_id,
+        type="function",
+        function=Function(name="Answer", arguments=arguments),
+    )
+    message = ChatCompletionMessage(
+        role="assistant", content=None, tool_calls=[tool_call]
+    )
+    choice = Choice(index=0, message=message, finish_reason="tool_calls", logprobs=None)
+    return ChatCompletion(
+        id="chatcmpl-test",
+        choices=[choice],
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        usage=CompletionUsage(completion_tokens=5, prompt_tokens=10, total_tokens=15),
+    )
+
+
+def _build_kwargs(response_model: type[BaseModel]) -> tuple[Any, dict[str, Any]]:
+    handlers = mode_registry.get_handlers(Provider.OPENAI, Mode.TOOLS)
+    return handlers.request_handler(
+        response_model=response_model,
+        kwargs={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "go"}],
+        },
+    )
+
+
+class Email(BaseModel):
+    address: str
+
+    @async_field_validator("address")
+    async def must_contain_at(cls, value: str) -> str:
+        if "@" not in value:
+            raise ValueError(f"{value!r} is not a valid email address")
+        return value.lower()
+
+
+@pytest.mark.asyncio
+async def test_async_field_validator_transforms_value_on_success():
+    calls = {"n": 0}
+
+    async def fake_create(*_a: Any, **_k: Any) -> ChatCompletion:
+        calls["n"] += 1
+        return _tool_call_response('{"address": "Jane@Example.com"}')
+
+    response_model, kwargs = _build_kwargs(Email)
+    result = await retry_async_v2(
+        func=fake_create,
+        response_model=response_model,
+        provider=Provider.OPENAI,
+        mode=Mode.TOOLS,
+        context=None,
+        max_retries=2,
+        args=(),
+        kwargs=kwargs,
+        strict=True,
+        hooks=None,
+    )
+
+    assert calls["n"] == 1
+    assert isinstance(result, Email)
+    assert result.address == "jane@example.com"
+
+
+@pytest.mark.asyncio
+async def test_async_field_validator_failure_triggers_reask_then_succeeds():
+    calls = {"n": 0}
+
+    async def fake_create(*_a: Any, **_k: Any) -> ChatCompletion:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _tool_call_response('{"address": "not-an-email"}', call_id="call_1")
+        return _tool_call_response('{"address": "jane@example.com"}', call_id="call_2")
+
+    response_model, kwargs = _build_kwargs(Email)
+    result = await retry_async_v2(
+        func=fake_create,
+        response_model=response_model,
+        provider=Provider.OPENAI,
+        mode=Mode.TOOLS,
+        context=None,
+        max_retries=2,
+        args=(),
+        kwargs=kwargs,
+        strict=True,
+        hooks=None,
+    )
+
+    assert calls["n"] == 2, "validator failure must trigger exactly one reask"
+    assert result.address == "jane@example.com"
+
+
+@pytest.mark.asyncio
+async def test_async_field_validator_exhausting_retries_raises_instructor_retry_exception():
+    calls = {"n": 0}
+
+    async def fake_create(*_a: Any, **_k: Any) -> ChatCompletion:
+        calls["n"] += 1
+        return _tool_call_response(
+            '{"address": "not-an-email"}', call_id=f"call_{calls['n']}"
+        )
+
+    response_model, kwargs = _build_kwargs(Email)
+    with pytest.raises(InstructorRetryException) as exc_info:
+        await retry_async_v2(
+            func=fake_create,
+            response_model=response_model,
+            provider=Provider.OPENAI,
+            mode=Mode.TOOLS,
+            context=None,
+            max_retries=1,
+            args=(),
+            kwargs=kwargs,
+            strict=True,
+            hooks=None,
+        )
+
+    assert calls["n"] == 2  # initial attempt + 1 retry
+    assert isinstance(
+        exc_info.value.failed_attempts[-1].exception, AsyncValidationError
+    )
+
+
+class Account(BaseModel):
+    email: Email
+
+    @async_model_validator()
+    async def normalize(self) -> Account:
+        return self.model_copy(update={"email": self.email})
+
+
+@pytest.mark.asyncio
+async def test_async_validators_recurse_into_nested_models():
+    """A nested BaseModel field's async validator must run too, and its
+    failure must surface through the parent's validation error."""
+    calls = {"n": 0}
+
+    async def fake_create(*_a: Any, **_k: Any) -> ChatCompletion:
+        calls["n"] += 1
+        return _tool_call_response('{"email": {"address": "still-invalid"}}')
+
+    response_model, kwargs = _build_kwargs(Account)
+    with pytest.raises(InstructorRetryException) as exc_info:
+        await retry_async_v2(
+            func=fake_create,
+            response_model=response_model,
+            provider=Provider.OPENAI,
+            mode=Mode.TOOLS,
+            context=None,
+            max_retries=0,
+            args=(),
+            kwargs=kwargs,
+            strict=True,
+            hooks=None,
+        )
+
+    error = exc_info.value.failed_attempts[-1].exception
+    assert isinstance(error, AsyncValidationError)
+    assert "still-invalid" in str(error)
+
+
+def test_sync_client_fails_fast_for_response_model_with_async_validators():
+    """A sync client can never await an async validator; it must raise a
+    clear ConfigurationError instead of silently skipping validation."""
+    calls = {"n": 0}
+
+    def fake_create(*_a: Any, **_k: Any) -> ChatCompletion:
+        calls["n"] += 1
+        return _tool_call_response('{"address": "not-an-email"}')
+
+    response_model, kwargs = _build_kwargs(Email)
+    with pytest.raises(ConfigurationError, match="async client"):
+        retry_sync_v2(
+            func=fake_create,
+            response_model=response_model,
+            provider=Provider.OPENAI,
+            mode=Mode.TOOLS,
+            context=None,
+            max_retries=2,
+            args=(),
+            kwargs=kwargs,
+            strict=True,
+            hooks=None,
+        )
+
+    assert calls["n"] == 0, "must fail before ever calling the API"
+
+
+def test_sync_client_unaffected_when_model_has_no_async_validators():
+    class Plain(BaseModel):
+        name: str
+
+    def fake_create(*_a: Any, **_k: Any) -> ChatCompletion:
+        return _tool_call_response('{"name": "Ada"}')
+
+    response_model, kwargs = _build_kwargs(Plain)
+    result = retry_sync_v2(
+        func=fake_create,
+        response_model=response_model,
+        provider=Provider.OPENAI,
+        mode=Mode.TOOLS,
+        context=None,
+        max_retries=2,
+        args=(),
+        kwargs=kwargs,
+        strict=True,
+        hooks=None,
+    )
+
+    assert result.name == "Ada"


### PR DESCRIPTION
## Problem

`@async_field_validator` and `@async_model_validator` declared on a `response_model` are silently never run. An LLM response that violates an async validator's rule is returned to the caller as a normal, "validated" model — no exception, no retry/reask, nothing. See #2528.

## Root cause

`async_field_validator`/`async_model_validator` (`instructor/v2/validation/async_validators.py`) only `setattr` metadata onto the decorated function. Nothing in the retry path (`instructor/v2/core/retry.py`) ever reads `ASYNC_VALIDATOR_KEY`/`ASYNC_MODEL_VALIDATOR_KEY` or awaits the validators. `AsyncValidationError` already existed and was already registered as a retryable error, so the reask machinery was ready — it just never got triggered.

Reproduced directly against `retry_async_v2` with a fake completion (bypassing the network):

```python
class Answer(BaseModel):
    email: str

    @async_field_validator("email")
    async def must_contain_at(cls, value: str) -> str:
        if "@" not in value:
            raise ValueError(f"{value!r} is not a valid email address")
        return value

# fake completion always returns {"email": "not-an-email"}
result = await retry_async_v2(func=fake_openai_create, response_model=Answer, ...)
# before fix: Answer(email='not-an-email'), validator invoked 0 times
```

## What changed

- **`instructor/v2/validation/async_validators.py`**: added `run_async_validators()`, which recursively awaits declared field/model validators over an already-parsed model tree (depth-first through nested `BaseModel`s inside fields, lists, tuples, and dicts), aggregating every failure into one `AsyncValidationError`. Added `model_declares_async_validators()` for a fast up-front check.
- **`instructor/v2/core/retry.py`**:
  - `retry_async_v2` now runs `run_async_validators` on the parsed result (when it's a `BaseModel` or `list`, and not a streaming response) right after a successful parse, before finalizing. A failure raises `AsyncValidationError`, which is already in `_RETRYABLE_PARSE_ERRORS`, so it flows straight into the existing reask path.
  - `retry_sync_v2` now raises `ConfigurationError` immediately if `response_model` declares async validators, instead of silently returning an unvalidated model — a sync client can never `await` them. (This was an open question in the issue thread; I went with "fail loudly," which is what the two commenters there converged on too.)
  - Both imports are **local to the functions**, not module-level. `instructor.v2.validation` eagerly imports the OpenAI SDK (via `llm_validators.py`'s `from openai import OpenAI`), and `retry.py` is on the import path of `instructor.Instructor`/`instructor.from_provider`. A module-level import would have broken the lazy-import guarantee covered by `tests/test_import_lazy_openai.py` — this is what tripped up the previous attempt at this issue (#2559). Confirmed `tests/test_import_lazy_openai.py` still passes.
- **`instructor/v2/core/errors.py`**: gave `AsyncValidationError` a real `__init__` (it previously had `errors: list[ValueError]` as a bare type annotation with no way to actually set it).
- **`tests/v2/test_async_validators_execution.py`** (new): end-to-end tests against the real retry functions with fake completions — success + value transformation, failure → reask → success, retries exhausted → `InstructorRetryException`, nested-model validation and error aggregation, sync client fails fast, sync client unaffected when no async validators are declared.
- **`CHANGELOG.md`**: entry under `[Unreleased]`.

### Explicitly out of scope

Streaming responses and the `Iterable[Model]`/parallel-tool-calls path (`IterableBase`) are not covered — validators only run against non-streaming `BaseModel`/`list` results. The issue's own repro and discussion were about the single-response-model case; extending to streaming/parallel tool calls raises its own design questions (validating partial state mid-stream) that felt separate from this fix.

## How it was verified

- Reproduced the bug against `main` first (validator invoked 0 times, invalid value returned), then confirmed the fix turns that into a raised `InstructorRetryException` wrapping `AsyncValidationError`.
- `uv run ruff check instructor examples tests` — clean.
- `uv run ruff format instructor examples tests` — clean (already applied).
- `uv run ty check` — 52 diagnostics, identical count and content to `main` before this change (0 new).
- `uv run pytest tests/ -k 'not llm and not openai'` (all extras installed): **3175 passed, 35 failed**. Ran the identical command against unmodified `main` for comparison: also 35 failed with the exact same test IDs (pre-existing doc/blog-example tests that need network/API keys) and 3170 passed. So: 0 regressions, and the 5-test delta is exactly the new regression tests going from failing (against unpatched code) to passing.
- `tests/test_import_lazy_openai.py` — all 11 pass, confirming the lazy-openai-import invariant holds.
