### PR TITLE
fix(genai): omit tools and system instruction when cached_content is provided

### DIFF
--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -315,6 +315,10 @@ def update_genai_kwargs(
             if field_value is not None and field not in base_config:
                 base_config[field] = field_value
 
+    cached_content = new_kwargs.pop("cached_content", None)
+    if cached_content is not None and "cached_content" not in base_config:
+        base_config["cached_content"] = cached_content
+
     return base_config
 
 

--- a/instructor/v2/providers/genai/handlers.py
+++ b/instructor/v2/providers/genai/handlers.py
@@ -173,6 +173,14 @@ class GenAIHandlerBase(ModeHandler):
             )
         return None
 
+    def _extract_cached_content(self, kwargs: dict[str, Any]) -> Any | None:
+        user_config = kwargs.get("config")
+        if isinstance(user_config, dict):
+            return user_config.get("cached_content")
+        if user_config is not None and hasattr(user_config, "cached_content"):
+            return user_config.cached_content
+        return kwargs.get("cached_content")
+
     def extract_streaming_json(self, completion: Any) -> Generator[str, None, None]:
         """Extract JSON chunks from GenAI streaming responses."""
         for chunk in completion:
@@ -244,6 +252,7 @@ class GenAIHandlerBase(ModeHandler):
             "seed",
             "presence_penalty",
             "frequency_penalty",
+            "cached_content",
             "kwargs",  # Remove any nested kwargs key
         ):
             kwargs.pop(key, None)
@@ -256,9 +265,10 @@ class GenAIHandlerBase(ModeHandler):
     ) -> dict[str, Any]:
         from google.genai import types
 
+        cached_content = self._extract_cached_content(kwargs)
         system_instruction = self._extract_system_instruction(kwargs)
         kwargs = self._convert_messages_to_contents(kwargs, autodetect_images)
-        if system_instruction:
+        if system_instruction and cached_content is None:
             kwargs["config"] = types.GenerateContentConfig(
                 system_instruction=system_instruction
             )
@@ -368,6 +378,7 @@ class GenAIToolsHandler(GenAIHandlerBase):
             parameters=schema,
         )
 
+        cached_content = self._extract_cached_content(new_kwargs)
         system_instruction = self._extract_system_instruction(new_kwargs)
 
         # Move OpenAI-style params to generation_config for conversion
@@ -385,18 +396,21 @@ class GenAIToolsHandler(GenAIHandlerBase):
             if key in new_kwargs:
                 generation_config_dict[key] = new_kwargs.pop(key)
 
-        base_config = {
-            "system_instruction": system_instruction,
-            "tools": [types.Tool(function_declarations=[function_decl])],
-            "tool_config": types.ToolConfig(
+        base_config: dict[str, Any] = {}
+        # When cached_content is used, do NOT add tools, tool_config, or system_instruction.
+        # These must live in the cache. Adding them causes 400 INVALID_ARGUMENT.
+        # See: https://ai.google.dev/gemini-api/docs/caching
+        if cached_content is None:
+            base_config["system_instruction"] = system_instruction
+            base_config["tools"] = [types.Tool(function_declarations=[function_decl])]
+            base_config["tool_config"] = types.ToolConfig(
                 function_calling_config=types.FunctionCallingConfig(
                     mode=types.FunctionCallingConfigMode.ANY,
                     allowed_function_names=[
                         gemini_utils._get_model_name(prepared_model)
                     ],
                 ),
-            ),
-        }
+            )
         # Temporarily put generation_config back for update_genai_kwargs to process
         new_kwargs["generation_config"] = generation_config_dict
         generation_config = gemini_utils.update_genai_kwargs(new_kwargs, base_config)
@@ -446,6 +460,7 @@ class GenAIStructuredOutputsHandler(GenAIHandlerBase):
             gemini_utils._get_model_schema(prepared_model)
         )
 
+        cached_content = self._extract_cached_content(new_kwargs)
         system_instruction = self._extract_system_instruction(new_kwargs)
 
         # Move OpenAI-style params to generation_config for conversion
@@ -463,11 +478,15 @@ class GenAIStructuredOutputsHandler(GenAIHandlerBase):
             if key in new_kwargs:
                 generation_config_dict[key] = new_kwargs.pop(key)
 
-        base_config = {
-            "system_instruction": system_instruction,
+        base_config: dict[str, Any] = {
             "response_mime_type": "application/json",
             "response_schema": prepared_model,
         }
+        # When cached_content is used, do NOT add system_instruction.
+        # It must live in the cache. Adding it causes 400 INVALID_ARGUMENT.
+        # See: https://ai.google.dev/gemini-api/docs/caching
+        if cached_content is None:
+            base_config["system_instruction"] = system_instruction
         # Temporarily put generation_config back for update_genai_kwargs to process
         new_kwargs["generation_config"] = generation_config_dict
         generation_config = gemini_utils.update_genai_kwargs(new_kwargs, base_config)

--- a/tests/v2/test_genai_integration.py
+++ b/tests/v2/test_genai_integration.py
@@ -174,3 +174,92 @@ def test_from_genai_json_legacy_mode_normalized(monkeypatch):
         response_model=None,
     )
     assert client.models.called
+
+
+def test_genai_cached_content_omits_tools_and_system_instruction():
+    from pydantic import BaseModel
+
+    class OutputModel(BaseModel):
+        val: int
+
+    tools_prepare = mode_registry.get_handler(Provider.GENAI, Mode.TOOLS)
+    _, tools_prepared = tools_prepare(
+        OutputModel,
+        {
+            "messages": [
+                {"role": "system", "content": "system instruction"},
+                {"role": "user", "content": "hello"},
+            ],
+            "config": types.GenerateContentConfig(
+                cached_content="cachedContents/session-123",
+            ),
+        },
+    )
+
+    tools_config = tools_prepared["config"]
+    assert tools_config.cached_content == "cachedContents/session-123"
+    assert tools_config.tools is None
+    assert tools_config.tool_config is None
+    assert tools_config.system_instruction is None
+
+    json_prepare = mode_registry.get_handler(Provider.GENAI, Mode.JSON)
+    _, json_prepared = json_prepare(
+        OutputModel,
+        {
+            "messages": [
+                {"role": "system", "content": "system instruction"},
+                {"role": "user", "content": "hello"},
+            ],
+            "config": {"cached_content": "cachedContents/session-123"},
+        },
+    )
+
+    json_config = json_prepared["config"]
+    assert json_config.cached_content == "cachedContents/session-123"
+    assert json_config.response_mime_type == "application/json"
+    assert json_config.response_schema is not None
+    assert json_config.system_instruction is None
+
+
+def test_genai_cached_content_top_level_kwarg():
+    from pydantic import BaseModel
+
+    class OutputModel(BaseModel):
+        val: int
+
+    tools_prepare = mode_registry.get_handler(Provider.GENAI, Mode.TOOLS)
+    _, tools_prepared = tools_prepare(
+        OutputModel,
+        {
+            "messages": [
+                {"role": "system", "content": "system instruction"},
+                {"role": "user", "content": "hello"},
+            ],
+            "cached_content": "cachedContents/top-level-xyz",
+        },
+    )
+
+    tools_config = tools_prepared["config"]
+    assert tools_config.cached_content == "cachedContents/top-level-xyz"
+    assert tools_config.tools is None
+    assert tools_config.tool_config is None
+    assert tools_config.system_instruction is None
+
+
+def test_genai_prepare_without_response_model_with_cached_content():
+    tools_prepare = mode_registry.get_handler(Provider.GENAI, Mode.TOOLS)
+    _, prepared = tools_prepare(
+        None,
+        {
+            "messages": [
+                {"role": "system", "content": "system instruction"},
+                {"role": "user", "content": "hello"},
+            ],
+            "config": {"cached_content": "cachedContents/no-model-123"},
+        },
+    )
+
+    assert (
+        "config" not in prepared
+        or getattr(prepared["config"], "system_instruction", None) is None
+    )


### PR DESCRIPTION
## Summary

In Google GenAI, passing `system_instruction`, `tools`, or `tool_config` in requests when using `cached_content` is rejected by the Gemini API with:
```
400 INVALID_ARGUMENT: Tool config, tools and system instruction should not be set in the request when using cached content.
```
because those parameters must be defined inside the cache itself (per https://ai.google.dev/gemini-api/docs/caching).

In v2 handlers (`instructor/v2/providers/genai/handlers.py`), `GenAIToolsHandler.prepare_request` and `GenAIStructuredOutputsHandler.prepare_request` previously built `base_config` unconditionally, including `system_instruction`, `tools`, and `tool_config` even when the caller specified `cached_content`.

This change:
1. Adds `_extract_cached_content` on `GenAIHandlerBase` to detect `cached_content` from `config` (as a dict or `GenerateContentConfig` instance) or top-level `kwargs`.
2. Omits `system_instruction`, `tools`, and `tool_config` from `base_config` in `GenAIToolsHandler.prepare_request` when `cached_content` is present.
3. Omits `system_instruction` from `base_config` in `GenAIStructuredOutputsHandler.prepare_request` when `cached_content` is present (preserving `response_mime_type` and `response_schema`).
4. Omits `system_instruction` in `_prepare_without_response_model` when `cached_content` is present.
5. Ensures top-level `cached_content` kwargs are merged into `config` in `update_genai_kwargs`.
6. Adds unit tests in `tests/v2/test_genai_integration.py` verifying that `tools`, `tool_config`, and `system_instruction` are omitted when `cached_content` is supplied in both `Mode.TOOLS` and `Mode.JSON`.

## Issue ticket number and link

Fixes #2580

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.
