### PR TITLE
docs: fix concept code blocks failing the docs lint (12 Weekly Tests failures)

### DIFF
--- a/docs/concepts/batch.md
+++ b/docs/concepts/batch.md
@@ -54,8 +54,8 @@ print(f"Batch job submitted: {batch_id}")
 
 # Check status and retrieve results
 status = processor.get_batch_status(batch_id)
-if status['status'] in ['completed', 'ended', 'JOB_STATE_SUCCEEDED']:
-    from instructor.batch import filter_successful, extract_results
+if status["status"] in ["completed", "ended", "JOB_STATE_SUCCEEDED"]:
+    from instructor.batch import extract_results
 
     all_results = processor.retrieve_results(batch_id)
     for user in extract_results(all_results):
@@ -158,7 +158,6 @@ Results use a Maybe/Result pattern for type-safe handling:
 
 ```python
 from instructor.batch import (
-    BatchProcessor,
     filter_successful,
     filter_errors,
     extract_results,
@@ -169,8 +168,8 @@ all_results = processor.retrieve_results(batch_id)
 
 # Filter by type
 successful = filter_successful(all_results)  # List[BatchSuccess[T]]
-errors = filter_errors(all_results)           # List[BatchError]
-objects = extract_results(all_results)        # List[T]
+errors = filter_errors(all_results)  # List[BatchError]
+objects = extract_results(all_results)  # List[T]
 
 # Access by custom_id
 by_id = get_results_by_custom_id(all_results)

--- a/docs/concepts/distillation.md
+++ b/docs/concepts/distillation.md
@@ -161,7 +161,7 @@ For RAW format, the output would look like:
     "fn_repr": "def fn(a: int, b: int) -> Multiply:\n    ...",
     "args": [133],
     "kwargs": {"b": 539},
-    "response": {"a": 133, "b": 539, "result": 89509}
+    "response": {"a": 133, "b": 539, "result": 89509},
 }
 ```
 

--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -51,7 +51,7 @@ import instructor
 client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
-def log_kwargs(*args, **kwargs):
+def log_kwargs(**kwargs):
     print(f"Model: {kwargs.get('model')}")
 
 
@@ -85,7 +85,7 @@ You can use enum values or strings for hook names:
 from instructor.hooks import HookName
 
 client.on(HookName.COMPLETION_KWARGS, log_kwargs)  # Using enum
-client.on("completion:kwargs", log_kwargs)          # Using string
+client.on("completion:kwargs", log_kwargs)  # Using string
 ```
 
 ## Retry Metadata
@@ -98,7 +98,13 @@ import instructor
 client = instructor.from_provider("openai/gpt-4.1-mini")
 
 
-def on_error(error: Exception, *, attempt_number: int, max_attempts: int | None, is_last_attempt: bool):
+def on_error(
+    error: Exception,
+    *,
+    attempt_number: int,
+    max_attempts: int | None,
+    is_last_attempt: bool,
+):
     print(f"Attempt {attempt_number}/{max_attempts or '?'} failed: {error}")
     if is_last_attempt:
         print("No more retries.")
@@ -194,10 +200,10 @@ from instructor.core.hooks import Hooks
 
 # Create specialized hook sets
 logging_hooks = Hooks()
-logging_hooks.on("completion:kwargs", lambda **kw: print("Logging kwargs"))
+logging_hooks.on("completion:kwargs", lambda **_kw: print("Logging kwargs"))
 
 metrics_hooks = Hooks()
-metrics_hooks.on("completion:response", lambda resp: print("Recording metrics"))
+metrics_hooks.on("completion:response", lambda _resp: print("Recording metrics"))
 
 # Combine hooks
 combined = logging_hooks + metrics_hooks
@@ -225,13 +231,13 @@ class User(BaseModel):
 
 # Client with standard hooks
 client_hooks = Hooks()
-client_hooks.on("completion:kwargs", lambda **kw: print("Standard logging"))
+client_hooks.on("completion:kwargs", lambda **_kw: print("Standard logging"))
 
 client = instructor.from_provider("openai/gpt-4.1-mini", hooks=client_hooks)
 
 # Debug hooks for specific calls
 debug_hooks = Hooks()
-debug_hooks.on("parse:error", lambda err: print(f"Debug: {err}"))
+debug_hooks.on("parse:error", lambda _err: print(f"Debug: {_err}"))
 
 # Per-call hooks combine with client hooks
 user = client.create(

--- a/docs/concepts/logging.md
+++ b/docs/concepts/logging.md
@@ -11,7 +11,6 @@ import logging
 
 from pydantic import BaseModel
 
-
 # Set logging to DEBUG
 logging.basicConfig(level=logging.DEBUG)
 

--- a/docs/concepts/reask_validation.md
+++ b/docs/concepts/reask_validation.md
@@ -68,8 +68,7 @@ LLM-based validation can also be plugged into the same Pydantic model. Here, if 
 import instructor
 from instructor import llm_validator
 from pydantic import BaseModel, ValidationError, BeforeValidator
-from typing_extensions import Annotated
-
+from typing import Annotated
 
 # Apply the patch to the OpenAI client
 client = instructor.from_provider("openai/gpt-4.1-mini")
@@ -183,7 +182,6 @@ Behind the scenes, the `instructor.from_provider()` method adds a `max_retries` 
 
 ```python
 from pydantic import ValidationError
-
 
 try:
     ...

--- a/docs/concepts/validation.md
+++ b/docs/concepts/validation.md
@@ -157,14 +157,14 @@ Handle validation failures with appropriate error types:
 
 ```python
 import instructor
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, field_validator
 
 
 class User(BaseModel):
     name: str
     age: int
 
-    @field_validator('age')
+    @field_validator("age")
     @classmethod
     def validate_age(cls, v):
         if v < 0:


### PR DESCRIPTION
## Problem

The scheduled `Weekly Tests` job has been failing on main for weeks with 12 `test_format_concepts_*` failures — every one a `black failed:`/`ruff failed:` on a concept-docs code block:

```
FAILED tests/docs/test_concepts.py::test_format_concepts_core[docs/concepts/distillation.md:158-166] - black failed
FAILED tests/docs/test_concepts.py::test_format_concepts_core[docs/concepts/logging.md:8-43] - black failed
FAILED tests/docs/test_concepts.py::test_format_concepts_core[docs/concepts/validation.md:158-186] - ruff failed (F401 Field unused)
FAILED tests/docs/test_concepts_advanced.py::...[batch.md:20-63|159-183], [hooks.md:48-80|84-89|95-108|191-209|215-242], [reask_validation.md:67-99|184-198]
```

## Fix (docs-only, 6 files)

- **validation.md** — drop unused `Field` import; double-quote `'age'`
- **distillation.md** — trailing comma in the RAW-format dict literal (black)
- **logging.md** — collapse the extra blank line after imports
- **reask_validation.md** — `typing_extensions.Annotated` → `typing.Annotated` (3.10+ stdlib); blank-line
- **batch.md** — remove unused `extract_results`/`BatchProcessor` imports; quote style; black comment alignment
- **hooks.md** — drop unused `*args`; black-wrap `on_error` signature; underline unused lambda args (`_kw`, `_resp`, `_err`) for ruff ARG005

No behavior changes — docs code blocks only. All 141 tests in `tests/docs/test_concepts.py` + `tests/docs/test_concepts_advanced.py` pass locally.