### PR TITLE
fix(gemini): omit cache-owned config from cached requests

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -19,6 +19,7 @@
 - **Factory pattern**: `from_provider()` for automatic provider detection
 - **DSL**: `dsl/` directory with Partial, Iterable, Maybe, Citation extensions
 - **Key modules**: `patch.py` (patching), `process_response.py` (parsing), `function_calls.py` (schemas)
+- **GenAI cached content**: Shared configuration assembly in `v2/providers/gemini/utils.py` must omit cache-owned `system_instruction`, `tools`, and `tool_config` when `cached_content` is set. Regression tests use actual SDK configuration objects in `tests/v2/test_genai_cached_content.py`.
 
 ## Code Style
 - **Typing**: Strict type annotations, use `BaseModel` for structured outputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Gemini context caching**: Omit cache-owned system instructions, tools, and tool configuration from structured requests using cached content. ([#2580](https://github.com/567-labs/instructor/issues/2580))
+
 ## [1.16.1] - 2026-08-28
 
 ### Changed

--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -315,6 +315,11 @@ def update_genai_kwargs(
             if field_value is not None and field not in base_config:
                 base_config[field] = field_value
 
+    if base_config.get("cached_content") is not None:
+        # These fields belong to the cache; Gemini rejects them on cached requests.
+        for field in ("system_instruction", "tools", "tool_config"):
+            base_config.pop(field, None)
+
     return base_config
 
 

--- a/tests/v2/test_genai_cached_content.py
+++ b/tests/v2/test_genai_cached_content.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from instructor.mode import Mode
+from instructor.utils.providers import Provider
+from instructor.v2.core.registry import mode_registry
+
+genai = pytest.importorskip("google.genai")
+
+
+class Answer(BaseModel):
+    value: int
+
+
+@pytest.mark.parametrize("mode", [Mode.TOOLS, Mode.JSON])
+@pytest.mark.parametrize("config_object", [False, True])
+@pytest.mark.parametrize("cached_content", ["cachedContents/example", None])
+def test_cached_content_omits_cache_owned_config(
+    mode: Mode, config_object: bool, cached_content: str | None
+) -> None:
+    config: Any = {"cached_content": cached_content, "labels": {"test": "cache"}}
+    if config_object:
+        config = genai.types.GenerateContentConfig(**config)
+    kwargs: dict[str, Any] = {
+        "messages": [
+            {"role": "system", "content": "Extract the answer."},
+            {"role": "user", "content": "The answer is 42."},
+        ],
+        "config": config,
+        "temperature": 0.25,
+    }
+    original = deepcopy(kwargs)
+
+    prepare = mode_registry.get_handlers(Provider.GENAI, mode).request_handler
+    prepared_model, prepared = prepare(Answer, kwargs)
+    prepared_config = prepared["config"]
+
+    assert kwargs == original
+    assert prepared_model is not None
+    assert prepared_config.cached_content == cached_content
+    assert prepared_config.temperature == 0.25
+    assert prepared_config.labels == {"test": "cache"}
+    assert prepared["contents"][0].parts[0].text == "The answer is 42."
+    if cached_content is not None:
+        assert prepared_config.system_instruction is None
+        assert prepared_config.tools is None
+        assert prepared_config.tool_config is None
+    else:
+        assert prepared_config.system_instruction == "Extract the answer.\n\n"
+        if mode == Mode.TOOLS:
+            assert prepared_config.tools[0].function_declarations[0].name == "Answer"
+            assert (
+                prepared_config.tool_config.function_calling_config.allowed_function_names
+                == ["Answer"]
+            )
+    if mode == Mode.JSON:
+        assert prepared_config.response_mime_type == "application/json"
+        assert prepared_config.response_schema is prepared_model


### PR DESCRIPTION
## Describe your changes

Structured GenAI requests with `config.cached_content` currently include system instructions and, in tools mode, tool declarations and tool configuration. Gemini rejects these fields alongside cached content, regressing the pre-v2 request handlers.

Remove the cache-owned fields after merging the shared GenAI configuration, so both JSON and tools mode keep their output schema, sampling settings and cache reference without sending conflicting fields. Requests without cached content retain their current behavior.

- Add eight regression cases using real `google.genai` configuration objects through the registered request handlers: dictionary and SDK-object configs, JSON and tools mode, cached and non-cached requests.
- Check that caller-owned inputs remain unchanged, and preserve JSON schema, temperature, labels and user content.
- Update the changelog and the existing GenAI development note.

## Issue ticket number and link

Fixes #2580.

## Validation

- Before the fix: 4 new cached-request cases failed; 4 non-cached controls passed.
- Related GenAI tests: 58 passed on Python 3.13.14 with the repository's locked dependencies.
- `ruff check instructor examples tests` passed.
- Ruff formatting and `ty check` passed for the changed Python files.
- The full `ruff check .` also reports 36 pre-existing findings in untouched notebook/script files. Full `ty check` requires additional optional provider SDKs not installed in this environment.

The local commands above were executed; no live Gemini API request was made.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.