### PR TITLE
fix(genai): preserve reusable generation configuration

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -19,6 +19,7 @@
 - **Factory pattern**: `from_provider()` for automatic provider detection
 - **DSL**: `dsl/` directory with Partial, Iterable, Maybe, Citation extensions
 - **Key modules**: `patch.py` (patching), `process_response.py` (parsing), `function_calls.py` (schemas)
+- **GenAI request ownership**: `_clone_kwargs` copies nested `generation_config` before either mode handler merges and translates sampling options. Keep caller-owned configurations reusable; regression tests are in `tests/v2/test_genai_config_reuse.py`.
 
 ## Code Style
 - **Typing**: Strict type annotations, use `BaseModel` for structured outputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
-- **GenAI request configuration**: Preserve caller-owned `generation_config` dictionaries when preparing tools and JSON requests, so repeated requests retain their sampling settings and token limits.
+- **GenAI request configuration**: Preserve caller-owned `generation_config` dictionaries when preparing tools and JSON requests, so repeated requests retain their sampling settings and token limits. ([#2596](https://github.com/567-labs/instructor/pull/2596))
 
 ## [1.16.1] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **GenAI request configuration**: Preserve caller-owned `generation_config` dictionaries when preparing tools and JSON requests, so repeated requests retain their sampling settings and token limits.
+
 ## [1.16.1] - 2026-08-28
 
 ### Changed

--- a/instructor/v2/providers/genai/handlers.py
+++ b/instructor/v2/providers/genai/handlers.py
@@ -159,7 +159,11 @@ class GenAIHandlerBase(ModeHandler):
         self.mode = mode
 
     def _clone_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
-        return kwargs.copy()
+        new_kwargs = kwargs.copy()
+        generation_config = new_kwargs.get("generation_config")
+        if isinstance(generation_config, dict):
+            new_kwargs["generation_config"] = generation_config.copy()
+        return new_kwargs
 
     def _pop_autodetect_images(self, kwargs: dict[str, Any]) -> bool:
         return bool(kwargs.pop("autodetect_images", False))

--- a/tests/v2/test_genai_config_reuse.py
+++ b/tests/v2/test_genai_config_reuse.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from instructor.mode import Mode
+from instructor.utils.providers import Provider
+from instructor.v2.core.registry import mode_registry
+
+pytest.importorskip("google.genai")
+
+
+class Answer(BaseModel):
+    value: int
+
+
+@pytest.mark.parametrize("mode", [Mode.TOOLS, Mode.JSON])
+@pytest.mark.parametrize("override_temperature", [False, True])
+def test_reusing_generation_config_preserves_caller_options(
+    mode: Mode, override_temperature: bool
+) -> None:
+    generation_config = {
+        "max_tokens": 64,
+        "temperature": 0.25,
+        "top_p": 0.9,
+        "seed": 42,
+        "stop": ["END"],
+    }
+    original = deepcopy(generation_config)
+    kwargs: dict[str, Any] = {
+        "messages": [{"role": "user", "content": "The answer is 42."}],
+        "generation_config": generation_config,
+    }
+    if override_temperature:
+        kwargs["temperature"] = 0.75
+    prepare = mode_registry.get_handlers(Provider.GENAI, mode).request_handler
+
+    for _ in range(2):
+        _, prepared = prepare(Answer, kwargs)
+        config = prepared["config"]
+        assert config.max_output_tokens == 64
+        assert config.temperature == (0.75 if override_temperature else 0.25)
+        assert config.top_p == 0.9
+        assert config.seed == 42
+        assert config.stop_sequences == ["END"]
+        assert generation_config == original
+
+    _, prepared = prepare(
+        Answer,
+        {
+            "messages": [{"role": "user", "content": "The answer is 43."}],
+            "generation_config": generation_config,
+        },
+    )
+    assert prepared["config"].temperature == 0.25


### PR DESCRIPTION
## Describe your changes

Preparing a v2 GenAI request empties the caller's `generation_config` dictionary: the mode handlers shallow-copy kwargs, then the shared configuration mapper consumes its entries with `pop`. A second call using the same dictionary silently loses its token limit and sampling settings. Per-call overrides also write into that caller-owned dictionary before it is consumed.

Copy `generation_config` at the shared GenAI request boundary before either mode handler processes it. Four real-SDK regression cases cover tools/JSON modes, repeated preparation, preservation of all original options, and a one-call temperature override that must not affect a later request.

## Issue ticket number and link

Related to #2465, whose fix covers `update_gemini_kwargs`. This PR covers the separate v2 GenAI path through `GenAIHandlerBase._clone_kwargs` and `update_genai_kwargs`, which still reproduces on main at `2b64e49`. It does not change the cached-content behavior addressed in #2582.

## Validation

- Before the fix: all 4 new regression cases fail because the original configuration becomes `{}`.
- After the fix: 54 related GenAI tests pass (Python 3.13.14, locked dependencies).
- `ruff check instructor examples tests` passes.
- Ruff formatting and `ty check` pass for the changed Python files.

Tests use the real Google SDK's request/configuration objects; no live provider request was made.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.