### PR TITLE
feat(providers): add Atlas Cloud

### DIFF
--- a/docs/integrations/atlascloud.md
+++ b/docs/integrations/atlascloud.md
@@ -1,0 +1,124 @@
+---
+title: "Structured outputs with Atlas Cloud, a complete guide with instructor"
+description: "Learn how to use Instructor with Atlas Cloud to get type-safe, validated structured outputs from DeepSeek, GLM, Kimi, Qwen and MiniMax models through one OpenAI-compatible API."
+---
+
+# Structured outputs with Atlas Cloud, a complete guide with instructor
+
+[Atlas Cloud](https://www.atlascloud.ai/) serves DeepSeek, GLM, Kimi, Qwen and MiniMax models behind
+a single OpenAI-compatible API. This guide shows you how to use Instructor with Atlas Cloud for
+type-safe, validated responses.
+
+## Quick Start
+
+Instructor works with Atlas Cloud through the OpenAI client, so you don't need to install anything
+extra beyond the base package.
+
+```bash
+export ATLASCLOUD_API_KEY=<your-api-key>
+```
+
+## Simple User Example (Sync)
+
+```python
+import instructor
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+client = instructor.from_provider("atlascloud/deepseek-ai/deepseek-v4-pro")
+
+resp = client.create(
+    messages=[
+        {
+            "role": "user",
+            "content": "Ivan is 28 years old",
+        },
+    ],
+    response_model=User,
+)
+
+print(resp)
+#> name='Ivan' age=28
+```
+
+## Simple User Example (Async)
+
+```python
+import asyncio
+
+import instructor
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+client = instructor.from_provider(
+    "atlascloud/zai-org/glm-5",
+    async_client=True,
+)
+
+
+async def extract_user():
+    return await client.create(
+        messages=[
+            {
+                "role": "user",
+                "content": "Ivan is 28 years old",
+            },
+        ],
+        response_model=User,
+    )
+
+
+print(asyncio.run(extract_user()))
+#> name='Ivan' age=28
+```
+
+## Modes
+
+Atlas Cloud supports the OpenAI-compatible modes:
+
+| Mode | Notes |
+|---|---|
+| `Mode.TOOLS` | Default. Tool calling. |
+| `Mode.JSON_SCHEMA` | `response_format` with a strict JSON schema. |
+| `Mode.MD_JSON` | Markdown-fenced JSON, for models without tool calling. |
+| `Mode.PARALLEL_TOOLS` | Multiple tool calls in one response. |
+
+```python
+import instructor
+
+client = instructor.from_provider(
+    "atlascloud/deepseek-ai/deepseek-v4-pro",
+    mode=instructor.Mode.JSON_SCHEMA,
+)
+```
+
+## A note on reasoning models
+
+Some Atlas models — `deepseek-ai/deepseek-v4-pro` among them — are reasoning models that spend
+completion tokens on a hidden chain of thought before the answer. If you pass a small
+`max_tokens`, the response can come back empty with `finish_reason="length"`. Leave `max_tokens`
+unset or give it room. Non-reasoning ids such as `deepseek-ai/DeepSeek-V3.1` are unaffected.
+
+## Custom base URL
+
+The default base URL is `https://api.atlascloud.ai/v1`. Override it with `base_url` if you are
+pointed at a different endpoint:
+
+```python
+import instructor
+
+client = instructor.from_provider(
+    "atlascloud/deepseek-ai/deepseek-v4-pro",
+    base_url="https://api.atlascloud.ai/v1",
+)
+```

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -50,7 +50,8 @@ Learn how to integrate Instructor with various AI model providers. These compreh
     Unified interfaces for multiple providers
 
     [:octicons-arrow-right-16: LiteLLM](./litellm.md)
-    [:octicons-arrow-right-16: OpenRouter](./openrouter.md)
+    [:octicons-arrow-right-16: OpenRouter](./openrouter.md)                  ·
+    [:octicons-arrow-right-16: Atlas Cloud](./atlascloud.md)
 
 </div>
 

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
         from_together as from_together,
     )
     from .v2.providers.openrouter.client import from_openrouter as from_openrouter
+    from .v2.providers.atlascloud.client import from_atlascloud as from_atlascloud
     from .v2.providers.perplexity.client import from_perplexity as from_perplexity
     from .v2.providers.vertexai.client import from_vertexai as from_vertexai
     from .v2.providers.writer.client import from_writer as from_writer
@@ -78,6 +79,7 @@ __all__ = [
     "from_databricks",
     "from_deepseek",
     "from_openrouter",
+    "from_atlascloud",
     "from_litellm",
     "from_vertexai",
     "from_provider",
@@ -117,6 +119,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
     "from_databricks": (".v2.providers.openai.client", "from_databricks"),
     "from_deepseek": (".v2.providers.openai.client", "from_deepseek"),
     "from_openrouter": (".v2.providers.openrouter.client", "from_openrouter"),
+    "from_atlascloud": (".v2.providers.atlascloud.client", "from_atlascloud"),
     "from_litellm": (".v2.providers.litellm.client", "from_litellm"),
     "Mode": (".mode", "Mode"),
     "patch": (".core.patch", "patch"),
@@ -188,4 +191,5 @@ _add_optional_export("from_bedrock", "boto3")
 _add_optional_export("from_writer", "writerai")
 _add_optional_export("from_xai", "xai_sdk")
 _add_optional_export("from_perplexity", "openai")
+_add_optional_export("from_atlascloud", "openai")
 _add_optional_export("from_genai", "google", "google.genai")

--- a/instructor/v2/auto_client.py
+++ b/instructor/v2/auto_client.py
@@ -1550,6 +1550,70 @@ def _build_openrouter(
         raise
 
 
+def _build_atlascloud(
+    *,
+    provider: str,
+    model_name: str,
+    async_client: bool,
+    mode: Mode | None,
+    api_key: str | None,
+    kwargs: dict[str, Any],
+    provider_info: dict[str, str],
+) -> InstructorType:
+    try:
+        import openai
+        from instructor.v2.providers.atlascloud.client import from_atlascloud
+        import os
+
+        # Get API key from kwargs or environment
+        api_key = api_key or os.environ.get("ATLASCLOUD_API_KEY")
+
+        if not api_key:
+            from instructor.v2.core.errors import ConfigurationError
+
+            raise ConfigurationError(
+                "ATLASCLOUD_API_KEY is not set. "
+                "Set it with `export ATLASCLOUD_API_KEY=<your-api-key>` or pass it as kwarg api_key=<your-api-key>"
+            )
+
+        # Atlas Cloud uses an OpenAI-compatible API
+        base_url = kwargs.pop("base_url", "https://api.atlascloud.ai/v1")
+
+        client = (
+            openai.AsyncOpenAI(api_key=api_key, base_url=base_url)
+            if async_client
+            else openai.OpenAI(api_key=api_key, base_url=base_url)
+        )
+
+        result = from_atlascloud(
+            client,
+            model=model_name,
+            mode=mode if mode else Mode.TOOLS,
+            **kwargs,
+        )
+        logger.info(
+            "Client initialized",
+            extra={**provider_info, "status": "success"},
+        )
+        return result
+    except ImportError:
+        from instructor.v2.core.errors import ConfigurationError
+
+        raise ConfigurationError(
+            "The openai package is required to use the OpenRouter provider. "
+            "Install it with `pip install openai`."
+        ) from None
+    except Exception as e:
+        logger.error(
+            "Error initializing %s client: %s",
+            provider,
+            e,
+            exc_info=True,
+            extra={**provider_info, "status": "error"},
+        )
+        raise
+
+
 def _build_litellm(
     *,
     provider: str,
@@ -1618,5 +1682,6 @@ _PROVIDER_BUILDERS: dict[str, ProviderBuilder] = {
     "deepseek": _build_deepseek,
     "xai": _build_xai,
     "openrouter": _build_openrouter,
+    "atlascloud": _build_atlascloud,
     "litellm": _build_litellm,
 }

--- a/instructor/v2/core/provider_specs.py
+++ b/instructor/v2/core/provider_specs.py
@@ -166,6 +166,25 @@ PROVIDER_SPECS: Mapping[Provider, ProviderSpec] = MappingProxyType(
             client_module="instructor.v2.providers.openrouter.client",
             sdk_module="openai",
         ),
+        Provider.ATLASCLOUD: _spec(
+            Provider.ATLASCLOUD,
+            aliases=("atlascloud",),
+            handler_module="instructor.v2.providers.openai.handlers",
+            supported_modes=(
+                Mode.TOOLS,
+                Mode.JSON_SCHEMA,
+                Mode.MD_JSON,
+                Mode.PARALLEL_TOOLS,
+            ),
+            unsupported_modes=(Mode.RESPONSES_TOOLS,),
+            legacy_modes={
+                Mode.FUNCTIONS: Mode.TOOLS,
+                Mode.TOOLS_STRICT: Mode.TOOLS,
+            },
+            from_function="from_atlascloud",
+            client_module="instructor.v2.providers.atlascloud.client",
+            sdk_module="openai",
+        ),
         Provider.ANTHROPIC: _spec(
             Provider.ANTHROPIC,
             aliases=("anthropic",),

--- a/instructor/v2/core/providers.py
+++ b/instructor/v2/core/providers.py
@@ -36,6 +36,7 @@ class Provider(Enum):
     BEDROCK = "bedrock"
     PERPLEXITY = "perplexity"
     OPENROUTER = "openrouter"
+    ATLASCLOUD = "atlascloud"
 
 
 def provider_from_mode(mode: Mode, default: Provider = Provider.OPENAI) -> Provider:
@@ -117,6 +118,7 @@ def get_provider(base_url: str) -> Provider:
         ("localhost:11434", Provider.OLLAMA),
         ("litellm", Provider.LITELLM),
         ("openrouter", Provider.OPENROUTER),
+        ("atlascloud", Provider.ATLASCLOUD),
         ("x.ai", Provider.XAI),
         ("xai", Provider.XAI),
     )

--- a/instructor/v2/providers/atlascloud/__init__.py
+++ b/instructor/v2/providers/atlascloud/__init__.py
@@ -1,0 +1,5 @@
+"""Atlas Cloud v2 provider client."""
+
+from .client import from_atlascloud
+
+__all__ = ["from_atlascloud"]

--- a/instructor/v2/providers/atlascloud/client.py
+++ b/instructor/v2/providers/atlascloud/client.py
@@ -1,0 +1,48 @@
+"""v2 Atlas Cloud client factory."""
+
+from __future__ import annotations
+
+from typing import Any, overload
+
+import openai
+
+from instructor.v2.core.client import AsyncInstructor, Instructor
+from instructor.v2.core.mode import Mode
+from instructor.v2.core.providers import Provider
+from instructor.v2.providers.openai.client import _from_openai_compat
+
+
+@overload
+def from_atlascloud(
+    client: openai.OpenAI,
+    mode: Mode = Mode.TOOLS,
+    model: str | None = None,
+    **kwargs: Any,
+) -> Instructor: ...
+
+
+@overload
+def from_atlascloud(
+    client: openai.AsyncOpenAI,
+    mode: Mode = Mode.TOOLS,
+    model: str | None = None,
+    **kwargs: Any,
+) -> AsyncInstructor: ...
+
+
+def from_atlascloud(
+    client: openai.OpenAI | openai.AsyncOpenAI,
+    mode: Mode = Mode.TOOLS,
+    model: str | None = None,
+    **kwargs: Any,
+) -> Instructor | AsyncInstructor:
+    return _from_openai_compat(
+        client=client,
+        provider=Provider.ATLASCLOUD,
+        mode=mode,
+        model=model,
+        **kwargs,
+    )
+
+
+__all__ = ["from_atlascloud"]

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -63,6 +63,7 @@ OPENAI_COMPAT_PROVIDERS = [
     Provider.GROQ,
     Provider.FIREWORKS,
     Provider.CEREBRAS,
+    Provider.ATLASCLOUD,
 ]
 
 OPENAI_PARALLEL_TOOL_PROVIDERS = [
@@ -73,6 +74,7 @@ OPENAI_PARALLEL_TOOL_PROVIDERS = [
     Provider.DEEPSEEK,
     Provider.OPENROUTER,
     Provider.CEREBRAS,
+    Provider.ATLASCLOUD,
 ]
 
 OPENAI_JSON_SCHEMA_PROVIDERS = [
@@ -84,6 +86,7 @@ OPENAI_JSON_SCHEMA_PROVIDERS = [
     Provider.GROQ,
     Provider.FIREWORKS,
     Provider.CEREBRAS,
+    Provider.ATLASCLOUD,
 ]
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -194,6 +194,7 @@ nav:
     - Perplexity: 'integrations/perplexity.md'
     - Writer: 'integrations/writer.md'
     - OpenRouter: 'integrations/openrouter.md'
+    - Atlas Cloud: 'integrations/atlascloud.md'
     - SambaNova: 'integrations/sambanova.md'
     - TrueFoundry: 'integrations/truefoundry.md'
   - Cookbook:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -459,6 +459,7 @@ def test_get_provider_matches_supported_providers():
         "xai": Provider.XAI,
         "litellm": Provider.LITELLM,
         "together": Provider.TOGETHER,
+        "atlascloud": Provider.ATLASCLOUD,
     }
     provider_urls = {
         "openai": "https://api.openai.com/v1",
@@ -484,6 +485,7 @@ def test_get_provider_matches_supported_providers():
         "xai": "https://api.x.ai",
         "litellm": "https://litellm.ai",
         "together": "https://api.together.xyz/v1",
+        "atlascloud": "https://api.atlascloud.ai/v1",
     }
     assert set(supported_providers) == set(provider_mapping)
     assert set(provider_mapping) == set(provider_urls)

--- a/tests/v2/test_client_unified.py
+++ b/tests/v2/test_client_unified.py
@@ -36,6 +36,7 @@ _HANDLER_MODULE_PATHS: dict[Provider, Path] = {
     Provider.MISTRAL: _PROJECT_ROOT / "instructor/v2/providers/mistral/handlers.py",
     Provider.FIREWORKS: _PROJECT_ROOT / "instructor/v2/providers/openai/handlers.py",
     Provider.CEREBRAS: _PROJECT_ROOT / "instructor/v2/providers/openai/handlers.py",
+    Provider.ATLASCLOUD: _PROJECT_ROOT / "instructor/v2/providers/openai/handlers.py",
     Provider.WRITER: _PROJECT_ROOT / "instructor/v2/providers/writer/handlers.py",
     Provider.BEDROCK: _PROJECT_ROOT / "instructor/v2/providers/bedrock/handlers.py",
     Provider.VERTEXAI: _PROJECT_ROOT / "instructor/v2/providers/vertexai/handlers.py",


### PR DESCRIPTION
## Summary

Adds **Atlas Cloud** — an OpenAI-compatible platform serving DeepSeek, GLM, Kimi, Qwen and MiniMax:

```python
client = instructor.from_provider("atlascloud/deepseek-ai/deepseek-v4-pro")
```

It follows the OpenRouter shape: a thin client delegating to `_from_openai_compat`, plus
registration. No new dependency — it uses the `openai` SDK that's already optional-installed.

## Registration points

Each one was found by a **failing test or a real error**, not guessed:

| Where | What |
|---|---|
| `v2/core/providers.py` | `Provider.ATLASCLOUD` + prefix mapping |
| `v2/providers/atlascloud/` | `from_atlascloud` |
| `v2/auto_client.py` | `_build_atlascloud` + `_PROVIDER_BUILDERS`, reads `ATLASCLOUD_API_KEY`, defaults `base_url` |
| `instructor/__init__.py` | eager import, `__all__`, lazy map, `_add_optional_export` |
| `v2/providers/openai/handlers.py` | the three `OPENAI_*` provider lists. Without this, `from_provider` raised **`Invalid mode 'tool_call' for provider 'atlascloud'. Valid modes:`** — with an empty list |
| `v2/core/provider_specs.py` | `ProviderSpec`, which drives the parametrised handler tests |
| `tests/v2/test_client_unified.py`, `tests/test_utils.py` | the two test-side registries every provider extends (handler module path; provider mapping + base URL) |

## Modes were verified, not copied

Rather than mirroring OpenRouter's mode list, I checked each against the live API first:

- tool calling → returns `tool_calls` ✅
- `response_format: json_schema` (strict) → returns valid JSON ✅
- `parallel_tool_calls` → returned **2** tool calls ✅

So `TOOLS`, `JSON_SCHEMA`, `MD_JSON` and `PARALLEL_TOOLS` are registered, and `RESPONSES_TOOLS` is
listed unsupported.

End to end through `from_provider`, all three usable modes return a parsed model, plus an async run
against `atlascloud/zai-org/glm-5`.

## Test suite

Ignoring `tests/llm`, `tests/docs`, `tests/coverage`, `tests/processing` (live keys / uninstalled
extras):

- **this branch: 2121 passed / 67 failed**
- **clean checkout baseline: 2089 passed / 67 failed**

The 32 extra passes are this provider's parametrised cases, and **no failure is new** — I compared
by stashing the branch and re-running.

## One pre-existing observation (not changed here)

`get_provider()` matches provider tokens by substring, so a relay model string resolves to the
underlying lab: `openrouter/deepseek/deepseek-chat` → `Provider.DEEPSEEK`,
`openrouter/google/gemini-2.0-flash-lite-001` → `Provider.GEMINI`,
`litellm/deepseek-chat` → `Provider.DEEPSEEK`. `from_provider` splits on the first `/` so routing is
unaffected, and I left the ordering alone rather than changing behaviour for existing providers —
flagging it in case it matters elsewhere.

## Docs

`docs/integrations/atlascloud.md` + mkdocs nav + integrations index, including a note that
`deepseek-v4-pro` is a reasoning model and a small `max_tokens` can return an empty response with
`finish_reason="length"`.

<!-- atlas-partnership-start -->
---

### 🤝 Partnership & contact

This PR comes from the **Atlas Cloud** team. Beyond the integration above, we'd love to explore a closer collaboration with **instructor** — for example **co-marketing** or a featured integration.

If that sounds interesting, reach out anytime:
- 📧 **marketing@atlascloud.ai**
- 🌐 https://www.atlascloud.ai
- 📚 Docs: https://www.atlascloud.ai/docs

And of course, happy to revise this PR to match your project's conventions — just leave a comment. 🙌
<!-- atlas-partnership-end -->
