### PR TITLE
docs: fix broken internal anchor links

### DIFF
--- a/docs/concepts/citation.md
+++ b/docs/concepts/citation.md
@@ -185,6 +185,6 @@ Use CitationMixin when:
 ## See Also
 
 - [Validation](./validation.md) - Learn about validation in Instructor
-- [Context-Based Validation](./validation.md#context-based-validation) - Using context for validation
+- [Context-Based Validation](./reask_validation.md#using-context-for-dynamic-validation) - Using context for validation
 - [Citation Examples](../examples/exact_citations.md) - More citation examples
 - [RAG Patterns](../blog/posts/rag-and-beyond.md) - Building RAG systems with Instructor

--- a/docs/integrations/bedrock.md
+++ b/docs/integrations/bedrock.md
@@ -21,7 +21,7 @@ pip install "instructor[bedrock]"
 - [from_provider Guide](../concepts/from_provider.md) - Detailed client configuration
 - [Mode Migration Guide](../concepts/mode-migration.md) - Move to core modes
 - [Provider Examples](../index.md#provider-examples) - Quick examples for all providers
-- [AWS Integration Guide](../examples/index.md#aws-integration) - More AWS examples
+- [AWS Integration Guide](../examples/index.md) - More AWS examples
 
 # AWS Bedrock
 

--- a/docs/integrations/sambanova.md
+++ b/docs/integrations/sambanova.md
@@ -8,7 +8,7 @@ description: Use Instructor with SambaNova's LLM API for structured outputs.
 - [Getting Started](../getting-started.md) - Quick start guide
 - [from_provider Guide](../concepts/from_provider.md) - Detailed client configuration
 - [Provider Examples](../index.md#provider-examples) - Quick examples for all providers
-- [Enterprise Integration](../examples/index.md#enterprise-integration) - More enterprise examples
+- [Enterprise Integration](../examples/index.md) - More enterprise examples
 
 # SambaNova Integration
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -234,4 +234,4 @@ Let's be clear - you might not need Instructor if:
 
 For everyone else building production LLM applications, Instructor is the obvious choice.
 
-[Get Started →](index.md#quick-start-extract-structured-data-in-3-lines){ .md-button .md-button--primary }
+[Get Started →](index.md#quick-start){ .md-button .md-button--primary }


### PR DESCRIPTION
## Describe your changes

Fix 4 broken internal anchor links in the docs:

- `docs/why.md` — the "Get Started" button linked to `index.md#quick-start-extract-structured-data-in-3-lines`, but that heading's generated slug is `#quick-start` (mkdocs lowercases and strips punctuation). Now points to `index.md#quick-start`.
- `docs/integrations/bedrock.md` — removed the `#aws-integration` fragment from the link to `../examples/index.md`; no such heading exists on that page.
- `docs/integrations/sambanova.md` — removed the `#enterprise-integration` fragment from the link to `../examples/index.md`; no such heading exists on that page.
- `docs/concepts/citation.md` — the "Context-Based Validation" link pointed at `./validation.md#context-based-validation`, but that section lives in `./reask_validation.md` under the slug `#using-context-for-dynamic-validation`.

## How this was checked

Every internal anchor in `docs/` was resolved against the mkdocs slugging rules (lowercase, punctuation stripped, spaces → dashes) and the docs' explicit `{#id}` anchors: 4 broken links before this change, 0 after.

## Issue ticket number and link

N/A — docs-only fix, no open issue.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. (N/A — docs-only change)
- [x] If it is a core feature, I have added documentation. (this PR is the documentation)

This PR was written with the assistance of Claude Code and reviewed by a human.
