### PR TITLE
fix(partial): preserve model instances in nullable list streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Partial streaming**: Preserve model instances inside nullable list fields while the response is incomplete, including sync/async streams and both Optional and union annotations.
+
 ### Security
 - Route Anthropic PDF downloads through the bounded public-network fetcher and pin each media connection to a validated IP before sending HTTP.
 - Key cached responses by the complete prepared request, provider, validation context and strictness. Clients have isolated cache namespaces by default; `cache_namespace` explicitly enables sharing and must identify the endpoint and tenant. Revalidate cache hits with the current context and strictness.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
-- **Partial streaming**: Preserve model instances inside nullable list fields while the response is incomplete, including sync/async streams and both Optional and union annotations.
+- **Partial streaming**: Preserve model instances inside nullable list fields while the response is incomplete, including sync/async streams and both Optional and union annotations. ([#2600](https://github.com/567-labs/instructor/pull/2600))
 
 ### Security
 - Route Anthropic PDF downloads through the bounded public-network fetcher and pin each media connection to a validated IP before sending HTTP.

--- a/instructor/v2/dsl/partial.py
+++ b/instructor/v2/dsl/partial.py
@@ -231,6 +231,13 @@ def _build_partial_list(
         field_info = original_model.model_fields.get(field_name)
         if field_info:
             field_type = field_info.annotation
+            if get_origin(field_type) in UNION_ORIGINS:
+                non_none_args = [
+                    arg for arg in get_args(field_type) if arg is not type(None)
+                ]
+                # Only unwrap a nullable container with one unambiguous type.
+                if len(non_none_args) == 1:
+                    field_type = non_none_args[0]
             if get_origin(field_type) in (list, List):  # noqa: UP006
                 args = get_args(field_type)
                 if args:

--- a/tests/dsl/test_partial_optional_lists.py
+++ b/tests/dsl/test_partial_optional_lists.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any, List, Optional, Union, cast  # noqa: UP035
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError, ValidationInfo, field_validator
+
+from instructor.v2.dsl.partial import Partial
+
+
+class Item(BaseModel):
+    name: str
+    age: int
+
+    @field_validator("name")
+    @classmethod
+    def uppercase_name(cls, value: str, info: ValidationInfo) -> str:
+        return (
+            value.upper() if info.context and info.context.get("uppercase") else value
+        )
+
+
+class PlainEnvelope(BaseModel):
+    items: list[Item]
+    note: str
+
+
+class OptionalEnvelope(BaseModel):
+    items: Optional[list[Item]] = None  # noqa: UP007, UP045
+    note: str
+
+
+class LegacyEnvelope(BaseModel):
+    items: Optional[List[Item]] = None  # noqa: UP006, UP007, UP045
+    note: str
+
+
+class UnionEnvelope(BaseModel):
+    items: list[Item] | None = None
+    note: str
+
+
+ENVELOPES = [PlainEnvelope, OptionalEnvelope, LegacyEnvelope, UnionEnvelope]
+NULLABLE_ENVELOPES = ENVELOPES[1:]
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.parametrize("asynchronous", [False, True], ids=["sync", "async"]),
+]
+
+
+async def stream(
+    schema: type[BaseModel],
+    chunks: list[str],
+    asynchronous: bool,
+    **kwargs: Any,
+) -> AsyncGenerator[Any, None]:
+    # Partial adds these streaming methods dynamically.
+    api = cast(Any, Partial[schema])
+    if asynchronous:
+
+        async def source() -> AsyncGenerator[str, None]:
+            for chunk in chunks:
+                yield chunk
+
+        async for obj in api.model_from_chunks_async(source(), **kwargs):
+            yield obj
+    else:
+        for obj in api.model_from_chunks(iter(chunks), **kwargs):
+            yield obj
+
+
+@pytest.mark.parametrize("schema", ENVELOPES)
+async def test_incremental_items_remain_models(
+    schema: type[BaseModel], asynchronous: bool
+) -> None:
+    chunks = [
+        '{"items":[{"name":"Alice","age":30},',
+        '{"name":"Bo',
+        'b","age":40}]',
+        ',"note":"done"}',
+    ]
+    outputs = [obj async for obj in stream(schema, chunks, asynchronous)]
+    assert len(outputs) == len(chunks)
+    assert isinstance(outputs[0].items[0], Item)
+    assert outputs[0].items[0].name == "Alice"
+    assert outputs[0].note is None
+    assert isinstance(outputs[1].items[1], Item)
+    assert outputs[1].items[1].name == "Bo"
+    assert outputs[1].items[1].age is None
+    assert isinstance(outputs[2].items[1], Item)
+    assert outputs[2].items[1].name == "Bob"
+    assert outputs[2].note is None
+    assert outputs[-1] == schema.model_validate_json("".join(chunks))
+
+
+@pytest.mark.parametrize("schema", NULLABLE_ENVELOPES)
+@pytest.mark.parametrize(
+    ("start", "expected"),
+    [('{"items":null,', None), ('{"items":[],', []), ("{", None)],
+)
+async def test_null_empty_and_missing(
+    schema: type[BaseModel], start: str, expected: Any, asynchronous: bool
+) -> None:
+    outputs = [
+        obj async for obj in stream(schema, [start, '"note":"done"}'], asynchronous)
+    ]
+    assert outputs[0].items == expected
+    assert outputs[-1].items == expected
+
+
+async def test_missing_default_factory(asynchronous: bool) -> None:
+    class Envelope(BaseModel):
+        items: Optional[list[Item]] = Field(default_factory=list)  # noqa: UP007, UP045
+        note: str
+
+    outputs = [
+        obj async for obj in stream(Envelope, ["{", '"note":"done"}'], asynchronous)
+    ]
+    assert outputs[0].items == []
+    assert outputs[-1].items == []
+
+
+@pytest.mark.parametrize("schema", ENVELOPES)
+async def test_validation_context_reaches_complete_item(
+    schema: type[BaseModel], asynchronous: bool
+) -> None:
+    # The tracker marks items complete once the next field starts.
+    chunks = ['{"items":[{"name":"Alice","age":30}],"note":"d', 'one"}']
+    outputs = [
+        obj
+        async for obj in stream(
+            schema, chunks, asynchronous, context={"uppercase": True}
+        )
+    ]
+    assert outputs[0].items[0].name == "ALICE"
+    assert outputs[0].note == "d"
+    assert outputs[-1].items[0].name == "ALICE"
+
+
+@pytest.mark.parametrize("schema", ENVELOPES)
+async def test_complete_item_is_validated_before_root(
+    schema: type[BaseModel], asynchronous: bool
+) -> None:
+    with pytest.raises(ValidationError, match="age"):
+        async for _ in stream(
+            schema, ['{"items":[{"name":"Alice"}],"note":"d'], asynchronous
+        ):
+            pass
+
+
+@pytest.mark.parametrize("schema", ENVELOPES)
+async def test_final_validation_still_requires_note(
+    schema: type[BaseModel], asynchronous: bool
+) -> None:
+    with pytest.raises(ValidationError, match="note"):
+        async for _ in stream(
+            schema, ['{"items":[{"name":"Alice","age":30}]}'], asynchronous
+        ):
+            pass
+
+
+async def test_optional_items_and_ambiguous_collections(asynchronous: bool) -> None:
+    class OptionalItems(BaseModel):
+        items: Optional[list[Optional[Item]]] = None  # noqa: UP007, UP045
+        note: str
+
+    chunks = ['{"items":[null,{"name":"Alice","age":30}],', '"note":"done"}']
+    outputs = [obj async for obj in stream(OptionalItems, chunks, asynchronous)]
+    assert outputs[0].items[0] is None
+    assert isinstance(outputs[0].items[1], Item)
+    assert outputs[-1].items[0] is None
+
+    class OtherItem(BaseModel):
+        label: str
+
+    class AmbiguousEnvelope(BaseModel):
+        items: Union[list[Item], list[OtherItem], None] = None  # noqa: UP007
+        note: str
+
+    chunks = ['{"items":[{"label":"other"}],', '"note":"done"}']
+    outputs = [obj async for obj in stream(AmbiguousEnvelope, chunks, asynchronous)]
+    assert outputs[0].items == [{"label": "other"}]
+    assert isinstance(outputs[-1].items[0], OtherItem)


### PR DESCRIPTION
## Describe your changes

During partial streaming, `items: Optional[list[Item]]` (including `list[Item] | None`) returns raw dictionaries while the outer JSON object is still open. For example, after `{"items":[{"name":"Alice","age":30}],`, `chunk.items[0].name` raises `AttributeError` even though a plain `list[Item]` already provides a model instance.

Unwrap a nullable list container only when it has a single non-None member, then use the existing list-item construction and validation paths. Ambiguous unions retain their current behavior. This extends the related Optional-model and partial-list-item handling from #2434 and #2495 to nullable list containers.

Added 54 deterministic tests using the real sync/async parsers, including incomplete items, both Optional spellings and PEP 604 syntax, null/empty/missing fields, default factories, validation context, final validation, optional elements, and ambiguous collection unions. Added an Unreleased changelog entry.

Validation on Python 3.11.15 with the repository's locked dependencies (Pydantic 2.11.7, jiter 0.10.0):
- `pytest tests/dsl/ tests/coverage/test_dsl_partial_coverage.py --asyncio-mode=auto -k 'not summary_extraction' -q`: main 20 failed / 126 passed; patched 146 passed. Two existing live-service tests deselected in each run.
- Broader DSL/v2/processing and related coverage tests: 2078 passed, 169 skipped, 2 deselected.
- Ruff lint/format, strict source and new-test ty checks, Python 3.9 static compatibility checks, and applicable commit hooks passed.

No live model service was used, and the full project/provider suite was not run. Codex was used for investigation, implementation, test execution, and review.

## Issue ticket number and link

No separate issue. Related merged changes: #2434 and #2495.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation. (Unreleased changelog)
