### PR TITLE
fix(genai): restore MAX_TOKENS truncation check lost in v2 refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Gemini truncation detection**: Restore the `finish_reason=MAX_TOKENS` check for the Google GenAI provider and extend it to `Mode.TOOLS`, so a truncated response raises `IncompleteOutputException` instead of parsing into schema defaults. The check shipped in v1.15.0 ([#2232](https://github.com/567-labs/instructor/pull/2232)) and was dropped during the v2 migration.
+
 ### Security
 - Route Anthropic PDF downloads through the bounded public-network fetcher and pin each media connection to a validated IP before sending HTTP.
 - Key cached responses by the complete prepared request, provider, validation context and strictness. Clients have isolated cache namespaces by default; `cache_namespace` explicitly enables sharing and must identify the endpoint and tenant. Revalidate cache hits with the current context and strictness.

--- a/instructor/v2/providers/genai/handlers.py
+++ b/instructor/v2/providers/genai/handlers.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 from pydantic import BaseModel
 
 from instructor.v2.core.decorators import register_mode_handler
+from instructor.v2.core.errors import IncompleteOutputException
 from instructor.v2.core.handler import ModeHandler
 from instructor.v2.core.mode import Mode
 from instructor.v2.core.multimodal import extract_genai_multimodal_content
@@ -300,6 +301,19 @@ class GenAIHandlerBase(ModeHandler):
             if issubclass(response_model, IterableBase):
                 return generator
             return list(generator)
+
+        # A response truncated at max_tokens is not evaluable: the model never
+        # emitted the remaining fields, so parsing it yields schema defaults that
+        # are indistinguishable from values the model actually chose.
+        # Restores the check shipped in v1.15.0 (#2232), dropped by 60cc815.
+        from google.genai import types as genai_types
+
+        candidates = getattr(response, "candidates", None)
+        if (
+            candidates
+            and candidates[0].finish_reason == genai_types.FinishReason.MAX_TOKENS
+        ):
+            raise IncompleteOutputException(last_completion=response)
 
         if self.mode == Mode.TOOLS:
             model = parse_genai_tools(

--- a/tests/test_genai_truncation.py
+++ b/tests/test_genai_truncation.py
@@ -1,0 +1,136 @@
+from typing import Optional
+
+import pytest
+
+
+pytest.importorskip("google.genai")
+
+
+from google.genai import types
+from pydantic import BaseModel
+
+from instructor.v2.core.errors import IncompleteOutputException
+from instructor.v2.core.mode import Mode
+from instructor.v2.providers.genai.handlers import (
+    GenAIStructuredOutputsHandler,
+    GenAIToolsHandler,
+)
+
+
+class Order(BaseModel):
+    drug: str
+    dose_mg: int
+    contraindications: Optional[str] = None
+
+
+def _response(
+    finish_reason: types.FinishReason, *, tools: bool
+) -> types.GenerateContentResponse:
+    """A response whose payload parses cleanly but may have been truncated."""
+    if tools:
+        part = types.Part.from_function_call(
+            name="Order", args={"drug": "warfarin", "dose_mg": 10}
+        )
+    else:
+        part = types.Part(text='{"drug": "warfarin", "dose_mg": 10}')
+    return types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(role="model", parts=[part]),
+                finish_reason=finish_reason,
+            )
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "handler_cls, mode, tools",
+    [
+        (GenAIToolsHandler, Mode.TOOLS, True),
+        (GenAIStructuredOutputsHandler, Mode.JSON, False),
+    ],
+)
+def test_truncated_response_raises(handler_cls, mode, tools):
+    """A response cut off at max_tokens is unevaluable and must not be parsed.
+
+    The remaining fields were never emitted, so parsing yields schema defaults
+    indistinguishable from values the model actually chose.
+    """
+    handler = handler_cls(mode=mode)
+    with pytest.raises(IncompleteOutputException):
+        handler.parse_response(
+            response_model=Order,
+            response=_response(types.FinishReason.MAX_TOKENS, tools=tools),
+        )
+
+
+@pytest.mark.parametrize(
+    "handler_cls, mode, tools",
+    [
+        (GenAIToolsHandler, Mode.TOOLS, True),
+        (GenAIStructuredOutputsHandler, Mode.JSON, False),
+    ],
+)
+def test_complete_response_still_parses(handler_cls, mode, tools):
+    """A response that finished normally is unaffected."""
+    handler = handler_cls(mode=mode)
+    result = handler.parse_response(
+        response_model=Order,
+        response=_response(types.FinishReason.STOP, tools=tools),
+    )
+    assert result.drug == "warfarin"
+    assert result.dose_mg == 10
+
+
+@pytest.mark.parametrize(
+    "handler_cls, mode, tools",
+    [
+        (GenAIToolsHandler, Mode.TOOLS, True),
+        (GenAIStructuredOutputsHandler, Mode.JSON, False),
+    ],
+)
+@pytest.mark.parametrize(
+    "finish_reason",
+    [types.FinishReason.SAFETY, None],
+    ids=["safety", "unset"],
+)
+def test_non_truncation_finish_reasons_are_not_incomplete(
+    handler_cls, mode, tools, finish_reason
+):
+    """Only MAX_TOKENS means truncation.
+
+    A SAFETY block and an unset finish_reason are different conditions and must
+    not be reported as incomplete output, or callers lose the ability to tell
+    them apart.
+    """
+    handler = handler_cls(mode=mode)
+    result = handler.parse_response(
+        response_model=Order,
+        response=_response(finish_reason, tools=tools),
+    )
+    assert result.drug == "warfarin"
+
+
+@pytest.mark.parametrize(
+    "handler_cls, mode",
+    [
+        (GenAIToolsHandler, Mode.TOOLS),
+        (GenAIStructuredOutputsHandler, Mode.JSON),
+    ],
+)
+def test_empty_candidates_does_not_raise_incomplete_output(handler_cls, mode):
+    """An empty candidate list is not a truncated response.
+
+    The guard must tolerate it rather than indexing into it; whatever the
+    downstream parser already did with this input is unchanged.
+    """
+    handler = handler_cls(mode=mode)
+    empty = types.GenerateContentResponse(candidates=[])
+    with pytest.raises(Exception) as excinfo:
+        handler.parse_response(response_model=Order, response=empty)
+    assert not isinstance(excinfo.value, IncompleteOutputException), (
+        f"empty candidates reported as truncation: {excinfo.value!r}"
+    )
+    assert not isinstance(excinfo.value, IndexError), (
+        f"guard indexed into an empty candidate list: {excinfo.value!r}"
+    )


### PR DESCRIPTION
## Describe your changes

**What.** On the Google GenAI path, a response truncated at `max_tokens` parses
as if it were complete, so the caller receives a confident object whose missing
fields are schema defaults. This restores the `finish_reason == MAX_TOKENS`
check and extends it to `Mode.TOOLS`.

**Why.** The value is indistinguishable from a real one:

```python
# finish_reason on the wire: FinishReason.MAX_TOKENS
Order(drug='warfarin', dose_mg=10, contraindications=None)
```

Here `contraindications=None` does not mean "none". It means the model was cut
off before it could say. Three things make this a regression rather than a
feature request:

1. **The docs already promise the fixed behaviour.**
   `docs/concepts/error_handling.md` lists `IncompleteOutputException` as
   "Output truncated due to token limit", with no provider carve out.
2. **The same truncation on the OpenAI path raises.** So the inconsistency sits
   inside instructor rather than in Gemini.
3. **The check shipped once and was then lost.** From the v1.15.0 changelog:

   > **Gemini**: Detect truncated responses (`finish_reason=MAX_TOKENS`) in
   > `GENAI_STRUCTURED_OUTPUTS` mode and raise `IncompleteOutputException`
   > immediately instead of retrying with malformed JSON (#2232)

   `60cc815` (*refactor(v2): complete migration cleanup and typing coverage*)
   moved the parser from `instructor/processing/function_calls.py` to the new
   `instructor/v2/core/function_calls.py`, and the guard did not come with it.
   That commit's diff carries the `finish_reason == MAX_TOKENS` comparison as
   removed lines. The method name survives as a deprecated shim, so nothing
   looked missing. At `5ea35cdb` there are zero occurrences of
   `FinishReason.MAX_TOKENS` left in the package. #2232 was closed as already
   applied, which was correct when it was written. The regression came
   afterwards.

**Changes.**

- Restore the truncation guard in `GenAIHandlerBase.parse_response`, at the
  single shared caller of `parse_genai_tools` and
  `parse_genai_structured_outputs`, using the same condition the deleted code
  used.
- Cover `Mode.TOOLS` as well. That mode never had the check and has the same
  defect. Both parse functions share this one caller, so splitting them would
  leave a known hole.
- Place the guard after the streaming early return, since `finish_reason` is not
  known until a stream finishes.
- Add `tests/test_genai_truncation.py` with 10 cases across both modes.
- Add a `CHANGELOG.md` entry under Unreleased.

The deprecated `ResponseSchema.parse_genai_structured_outputs` and
`.parse_genai_tools` shims delegate into this same handler, so they are covered
by the restored guard too. That is the entry point #2232's closing comment was
about.

**Out of scope.** The legacy `Provider.GEMINI` path has no truncation detection
either, but it uses a different SDK and response type and cannot share this fix,
so I left it out of a regression fix. Happy to follow up on it separately if
that would be useful.

### Testing

`tests/test_genai_truncation.py` is keyless and deterministic, built from real
`google.genai` types behind `pytest.importorskip`, in the same style as the
neighbouring `tests/test_genai_reask.py`, so no mocks, per `AGENT.md`:

- `MAX_TOKENS` raises `IncompleteOutputException`, in `Mode.TOOLS` and `Mode.JSON`.
- `STOP`, `SAFETY` and an unset `finish_reason` still parse, so a blocked
  response stays distinguishable from a truncated one.
- An empty `candidates` list behaves exactly as before, with no `IndexError` and
  no false truncation report.

Revert the guard and keep the tests: the two `MAX_TOKENS` cases fail and the
other eight stay green.

Ran locally against `5ea35cdb`. The new file passes 10 of 10, the offline suite
is unchanged, and `ruff check` and `ruff format --check` are clean at the
`v0.9.9` pinned in `.pre-commit-config.yaml`. The added block has full statement
and branch coverage from these tests alone, so the `full-coverage` job's
zero missing statements gate stays green.

One note for reviewers: the `core-tests` job filters `-k 'not test_genai'`, so
this file is skipped there, as `tests/test_genai_reask.py` already is. It does
run in `full-coverage`, which applies no provider filter.

## Issue ticket number and link

None open. #2213, #2214 and #2232 all proposed this guard and are closed. The
specification is the documented behaviour in `docs/concepts/error_handling.md`
plus the v1.15.0 changelog entry quoted above.

No open PR touches this file. The recent genai work (#2539, #2546, #2582, #2591,
#2595, #2596) is all closed, and none of it touched `parse_response` or
`finish_reason`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation. (No doc change
      needed. This restores conformance with the behaviour that
      `docs/concepts/error_handling.md` already documents.)

---

Written with assistance from Claude Code. Every claim above
was verified against `5ea35cdb`, and the tests were run locally.