### PR TITLE
feat(providers): add Hubris provider

### DIFF
--- a/docs/concepts/from_provider.md
+++ b/docs/concepts/from_provider.md
@@ -75,6 +75,7 @@ user = client.create(
 - DeepSeek: `"deepseek/deepseek-chat"`
 - xAI: `"xai/grok-beta"`
 - OpenRouter: `"openrouter/meta-llama/llama-3.1-70b"`
+- Hubris: `"hubris/anthropic/claude-sonnet-5"`
 - Ollama: `"ollama/llama3.2"` (local models)
 - LiteLLM: `"litellm/gpt-4o"` (meta-provider)
 

--- a/docs/integrations/hubris.md
+++ b/docs/integrations/hubris.md
@@ -1,0 +1,220 @@
+---
+title: "Structured outputs with Hubris, a complete guide with instructor"
+description: "Learn how to use Instructor with Hubris, an OpenAI-compatible gateway that serves Anthropic, OpenAI, Google, DeepSeek, Moonshot and xAI models behind one API key."
+---
+
+# Structured outputs with Hubris, a complete guide with instructor
+
+[Hubris](https://hubris.pw) is an OpenAI-compatible gateway that serves models from Anthropic, OpenAI, Google, DeepSeek, Moonshot, xAI, Z.ai and Qwen behind a single API key. It is aimed at users in Russia, where several of those vendors are not directly reachable, and bills in Russian roubles.
+
+Because the wire format is plain OpenAI, Instructor works through the OpenAI client with nothing extra to install.
+
+## Quick Start
+
+Create an API key at [hubris.pw/keys](https://hubris.pw/keys) and export it:
+
+```bash
+export HUBRIS_API_KEY=sk-gw-...
+```
+
+Model IDs take the form `vendor/model` and are resolved exactly, with no aliasing, so pass the full ID. The catalogue is public — you can browse it without a key at [api.hubris.pw/v1/models](https://api.hubris.pw/v1/models).
+
+## Simple User Example (Sync)
+
+```python
+import instructor
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+client = instructor.from_provider("hubris/openai/gpt-5.6-luna")
+
+resp = client.create(
+    messages=[
+        {
+            "role": "user",
+            "content": "Ivan is 28 years old",
+        },
+    ],
+    response_model=User,
+)
+
+print(resp)
+#> User(name='Ivan', age=28)
+```
+
+The provider prefix is split on the first slash only, so `hubris/openai/gpt-5.6-luna` selects the Hubris provider and the `openai/gpt-5.6-luna` model.
+
+## Simple User Example (Async)
+
+```python
+import asyncio
+import instructor
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+client = instructor.from_provider(
+    "hubris/anthropic/claude-sonnet-5",
+    async_client=True,
+)
+
+
+async def extract_user():
+    return await client.create(
+        messages=[
+            {
+                "role": "user",
+                "content": "Ivan is 28 years old",
+            },
+        ],
+        response_model=User,
+    )
+
+
+print(asyncio.run(extract_user()))
+#> User(name='Ivan', age=28)
+```
+
+## Bring your own client
+
+If you would rather construct the OpenAI client yourself:
+
+```python
+from openai import OpenAI
+import instructor
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+client = instructor.from_hubris(
+    OpenAI(
+        api_key="sk-gw-...",
+        base_url="https://api.hubris.pw/v1",
+    ),
+    model="google/gemini-3.7-flash",
+)
+
+print(
+    client.create(
+        messages=[{"role": "user", "content": "Ivan is 28 years old"}],
+        response_model=User,
+    )
+)
+#> User(name='Ivan', age=28)
+```
+
+## Nested Example
+
+```python
+import instructor
+from pydantic import BaseModel
+
+
+class Address(BaseModel):
+    street: str
+    city: str
+    country: str
+
+
+class User(BaseModel):
+    name: str
+    age: int
+    addresses: list[Address]
+
+
+client = instructor.from_provider("hubris/openai/gpt-5.6-luna")
+
+user = client.create(
+    messages=[
+        {
+            "role": "user",
+            "content": """
+            Extract: Jason is 25 years old.
+            He lives at 123 Main St, New York, USA
+            and has a summer house at 456 Beach Rd, Miami, USA
+        """,
+        },
+    ],
+    response_model=User,
+)
+
+print(user)
+#> User(
+#>     name='Jason',
+#>     age=25,
+#>     addresses=[
+#>         Address(street='123 Main St', city='New York', country='USA'),
+#>         Address(street='456 Beach Rd', city='Miami', country='USA'),
+#>     ],
+#> )
+```
+
+## Streaming Support
+
+Partial and iterable streaming both work over the standard OpenAI streaming format:
+
+```python
+import instructor
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+client = instructor.from_provider("hubris/openai/gpt-5.6-luna")
+
+for partial in client.create_partial(
+    messages=[{"role": "user", "content": "Ivan is 28 years old"}],
+    response_model=User,
+):
+    print(partial)
+#> User(name=None, age=None)
+#> User(name='Ivan', age=None)
+#> User(name='Ivan', age=28)
+```
+
+## Supported Modes
+
+| Mode | Supported | Notes |
+|------|-----------|-------|
+| `Mode.TOOLS` | ✅ | Default. Standard OpenAI tool calling. |
+| `Mode.JSON_SCHEMA` | ✅ | `response_format` with a JSON schema. |
+| `Mode.MD_JSON` | ✅ | Prompt-based JSON, works on every model. |
+| `Mode.PARALLEL_TOOLS` | ✅ | Several tool calls in one response. |
+| `Mode.RESPONSES_TOOLS` | ❌ | Not wired up for this provider. |
+
+Not every model in the catalogue supports every mode. Each entry in [`GET /v1/models`](https://api.hubris.pw/v1/models) carries a `supported_parameters` list — look for `tools` and `structured_outputs` before choosing a mode.
+
+## Choosing a model
+
+| Model | Good for |
+|-------|----------|
+| `google/gemini-3.7-flash` | cheap, fast extraction at volume |
+| `openai/gpt-5.6-luna` | general-purpose structured output |
+| `anthropic/claude-sonnet-5` | long documents, images, harder schemas |
+| `deepseek/deepseek-v4-pro` | inexpensive reasoning and code |
+
+## Related Resources
+
+- [Hubris documentation](https://hubris.pw/docs)
+- [Model catalogue](https://hubris.pw/models)
+- [Instructor's core concepts](../concepts/index.md)
+
+## Updates and Compatibility
+
+Instructor reaches Hubris through the OpenAI client, so it inherits OpenAI SDK compatibility. New models appear in the catalogue without an Instructor release.

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
         from_openai as from_openai,
         from_together as from_together,
     )
+    from .v2.providers.hubris.client import from_hubris as from_hubris
     from .v2.providers.openrouter.client import from_openrouter as from_openrouter
     from .v2.providers.perplexity.client import from_perplexity as from_perplexity
     from .v2.providers.vertexai.client import from_vertexai as from_vertexai
@@ -77,6 +78,7 @@ __all__ = [
     "from_together",
     "from_databricks",
     "from_deepseek",
+    "from_hubris",
     "from_openrouter",
     "from_litellm",
     "from_vertexai",
@@ -116,6 +118,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
     "from_together": (".v2.providers.openai.client", "from_together"),
     "from_databricks": (".v2.providers.openai.client", "from_databricks"),
     "from_deepseek": (".v2.providers.openai.client", "from_deepseek"),
+    "from_hubris": (".v2.providers.hubris.client", "from_hubris"),
     "from_openrouter": (".v2.providers.openrouter.client", "from_openrouter"),
     "from_litellm": (".v2.providers.litellm.client", "from_litellm"),
     "Mode": (".mode", "Mode"),

--- a/instructor/v2/auto_client.py
+++ b/instructor/v2/auto_client.py
@@ -1486,6 +1486,69 @@ def _build_xai(
         raise
 
 
+def _build_hubris(
+    *,
+    provider: str,
+    model_name: str,
+    async_client: bool,
+    mode: Mode | None,
+    api_key: str | None,
+    kwargs: dict[str, Any],
+    provider_info: dict[str, str],
+) -> InstructorType:
+    try:
+        import openai
+        from instructor.v2.providers.hubris.client import from_hubris
+        import os
+
+        # Get API key from kwargs or environment
+        api_key = api_key or os.environ.get("HUBRIS_API_KEY")
+
+        if not api_key:
+            from instructor.v2.core.errors import ConfigurationError
+
+            raise ConfigurationError(
+                "HUBRIS_API_KEY is not set. "
+                "Set it with `export HUBRIS_API_KEY=<your-api-key>` or pass it as kwarg api_key=<your-api-key>"
+            )
+
+        # Hubris uses an OpenAI-compatible API
+        base_url = kwargs.pop("base_url", "https://api.hubris.pw/v1")
+
+        client = (
+            openai.AsyncOpenAI(api_key=api_key, base_url=base_url)
+            if async_client
+            else openai.OpenAI(api_key=api_key, base_url=base_url)
+        )
+
+        result = from_hubris(
+            client,
+            model=model_name,
+            mode=mode if mode else Mode.TOOLS,
+            **kwargs,
+        )
+        logger.info(
+            "Client initialized",
+            extra={**provider_info, "status": "success"},
+        )
+        return result
+    except ImportError:
+        from instructor.v2.core.errors import ConfigurationError
+
+        raise ConfigurationError(
+            "The openai package is required to use the Hubris provider. "
+            "Install it with `pip install openai`."
+        ) from None
+    except Exception as e:
+        logger.error(
+            "Error initializing %s client: %s",
+            provider,
+            e,
+            extra={**provider_info, "status": "error"},
+        )
+        raise
+
+
 def _build_openrouter(
     *,
     provider: str,
@@ -1618,5 +1681,6 @@ _PROVIDER_BUILDERS: dict[str, ProviderBuilder] = {
     "deepseek": _build_deepseek,
     "xai": _build_xai,
     "openrouter": _build_openrouter,
+    "hubris": _build_hubris,
     "litellm": _build_litellm,
 }

--- a/instructor/v2/core/provider_specs.py
+++ b/instructor/v2/core/provider_specs.py
@@ -166,6 +166,26 @@ PROVIDER_SPECS: Mapping[Provider, ProviderSpec] = MappingProxyType(
             client_module="instructor.v2.providers.openrouter.client",
             sdk_module="openai",
         ),
+        Provider.HUBRIS: _spec(
+            Provider.HUBRIS,
+            aliases=("hubris",),
+            handler_module="instructor.v2.providers.hubris.handlers",
+            supported_modes=(
+                Mode.TOOLS,
+                Mode.JSON_SCHEMA,
+                Mode.MD_JSON,
+                Mode.PARALLEL_TOOLS,
+            ),
+            unsupported_modes=(Mode.RESPONSES_TOOLS,),
+            legacy_modes={
+                Mode.FUNCTIONS: Mode.TOOLS,
+                Mode.TOOLS_STRICT: Mode.TOOLS,
+                Mode.JSON_O1: Mode.JSON_SCHEMA,
+            },
+            from_function="from_hubris",
+            client_module="instructor.v2.providers.hubris.client",
+            sdk_module="openai",
+        ),
         Provider.ANTHROPIC: _spec(
             Provider.ANTHROPIC,
             aliases=("anthropic",),

--- a/instructor/v2/core/providers.py
+++ b/instructor/v2/core/providers.py
@@ -36,6 +36,7 @@ class Provider(Enum):
     BEDROCK = "bedrock"
     PERPLEXITY = "perplexity"
     OPENROUTER = "openrouter"
+    HUBRIS = "hubris"
 
 
 def provider_from_mode(mode: Mode, default: Provider = Provider.OPENAI) -> Provider:
@@ -117,6 +118,7 @@ def get_provider(base_url: str) -> Provider:
         ("localhost:11434", Provider.OLLAMA),
         ("litellm", Provider.LITELLM),
         ("openrouter", Provider.OPENROUTER),
+        ("hubris", Provider.HUBRIS),
         ("x.ai", Provider.XAI),
         ("xai", Provider.XAI),
     )

--- a/instructor/v2/providers/hubris/__init__.py
+++ b/instructor/v2/providers/hubris/__init__.py
@@ -1,0 +1,5 @@
+"""Hubris v2 provider handlers and client."""
+
+from .client import from_hubris
+
+__all__ = ["from_hubris"]

--- a/instructor/v2/providers/hubris/client.py
+++ b/instructor/v2/providers/hubris/client.py
@@ -1,0 +1,51 @@
+"""v2 Hubris client factory."""
+
+from __future__ import annotations
+
+from typing import Any, overload
+
+import openai
+
+from instructor.v2.core.client import AsyncInstructor, Instructor
+from instructor.v2.core.mode import Mode
+from instructor.v2.core.providers import Provider
+from instructor.v2.providers.openai.client import _from_openai_compat
+
+# Ensure Hubris handlers are registered.
+from instructor.v2.providers.hubris import handlers  # noqa: F401
+
+
+@overload
+def from_hubris(
+    client: openai.OpenAI,
+    mode: Mode = Mode.TOOLS,
+    model: str | None = None,
+    **kwargs: Any,
+) -> Instructor: ...
+
+
+@overload
+def from_hubris(
+    client: openai.AsyncOpenAI,
+    mode: Mode = Mode.TOOLS,
+    model: str | None = None,
+    **kwargs: Any,
+) -> AsyncInstructor: ...
+
+
+def from_hubris(
+    client: openai.OpenAI | openai.AsyncOpenAI,
+    mode: Mode = Mode.TOOLS,
+    model: str | None = None,
+    **kwargs: Any,
+) -> Instructor | AsyncInstructor:
+    return _from_openai_compat(
+        client=client,
+        provider=Provider.HUBRIS,
+        mode=mode,
+        model=model,
+        **kwargs,
+    )
+
+
+__all__ = ["from_hubris"]

--- a/instructor/v2/providers/hubris/handlers.py
+++ b/instructor/v2/providers/hubris/handlers.py
@@ -1,0 +1,13 @@
+"""Hubris v2 mode handlers.
+
+Hubris speaks the OpenAI wire format without provider-specific quirks, so it is
+listed in the OpenAI-compatible provider groups and reuses those handlers for
+TOOLS, JSON_SCHEMA, MD_JSON and PARALLEL_TOOLS. Importing the module here is
+what performs that registration.
+"""
+
+from __future__ import annotations
+
+from instructor.v2.providers.openai import handlers as _openai_handlers  # noqa: F401
+
+__all__: list[str] = []

--- a/instructor/v2/providers/openai/handlers.py
+++ b/instructor/v2/providers/openai/handlers.py
@@ -55,6 +55,7 @@ logger = logging.getLogger("instructor")
 
 OPENAI_COMPAT_PROVIDERS = [
     Provider.OPENAI,
+    Provider.HUBRIS,
     Provider.ANYSCALE,
     Provider.TOGETHER,
     Provider.DATABRICKS,
@@ -67,6 +68,7 @@ OPENAI_COMPAT_PROVIDERS = [
 
 OPENAI_PARALLEL_TOOL_PROVIDERS = [
     Provider.OPENAI,
+    Provider.HUBRIS,
     Provider.ANYSCALE,
     Provider.TOGETHER,
     Provider.DATABRICKS,
@@ -77,6 +79,7 @@ OPENAI_PARALLEL_TOOL_PROVIDERS = [
 
 OPENAI_JSON_SCHEMA_PROVIDERS = [
     Provider.OPENAI,
+    Provider.HUBRIS,
     Provider.ANYSCALE,
     Provider.TOGETHER,
     Provider.DATABRICKS,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -194,6 +194,7 @@ nav:
     - Perplexity: 'integrations/perplexity.md'
     - Writer: 'integrations/writer.md'
     - OpenRouter: 'integrations/openrouter.md'
+    - Hubris: 'integrations/hubris.md'
     - SambaNova: 'integrations/sambanova.md'
     - TrueFoundry: 'integrations/truefoundry.md'
   - Cookbook:

--- a/tests/v2/test_client_unified.py
+++ b/tests/v2/test_client_unified.py
@@ -29,6 +29,7 @@ _HANDLER_MODULE_PATHS: dict[Provider, Path] = {
     Provider.COHERE: _PROJECT_ROOT / "instructor/v2/providers/cohere/handlers.py",
     Provider.OPENROUTER: _PROJECT_ROOT
     / "instructor/v2/providers/openrouter/handlers.py",
+    Provider.HUBRIS: _PROJECT_ROOT / "instructor/v2/providers/hubris/handlers.py",
     Provider.PERPLEXITY: _PROJECT_ROOT
     / "instructor/v2/providers/perplexity/handlers.py",
     Provider.XAI: _PROJECT_ROOT / "instructor/v2/providers/xai/handlers.py",


### PR DESCRIPTION
Adds **Hubris** ([hubris.pw](https://hubris.pw)) as a provider. Hubris is an OpenAI-compatible gateway that serves models from Anthropic, OpenAI, Google, DeepSeek, Moonshot, xAI, Z.ai and Qwen behind a single API key. It is aimed at users in Russia, where several of those vendors are not directly reachable, and bills in Russian roubles.

```python
import instructor
from pydantic import BaseModel

class User(BaseModel):
    name: str
    age: int

client = instructor.from_provider("hubris/openai/gpt-5.6-luna")
client.create(messages=[{"role": "user", "content": "Ivan is 28 years old"}], response_model=User)
#> User(name='Ivan', age=28)
```

### What's here

Hubris speaks plain OpenAI with no provider-specific quirks, so rather than write a handler I added it to the three existing groups in `providers/openai/handlers.py` — `OPENAI_COMPAT_PROVIDERS`, `OPENAI_PARALLEL_TOOL_PROVIDERS` and `OPENAI_JSON_SCHEMA_PROVIDERS`. Its own `handlers.py` exists only to trigger that registration, mirroring how `openrouter` does it minus the structured-output override, which Hubris does not need.

The rest is the usual chain: `Provider.HUBRIS` and its base-URL prefix in `core/providers.py`, a `_spec` entry in `core/provider_specs.py`, the v2 client factory, `_build_hubris` in `auto_client.py` reading `HUBRIS_API_KEY`, the `from_hubris` public export, `docs/integrations/hubris.md`, and its `mkdocs.yml` nav entry.

Model IDs carry a vendor prefix of their own, and `from_provider` splits on the first slash only, so `hubris/openai/gpt-5.6-luna` resolves to the Hubris provider and the `openai/gpt-5.6-luna` model — same shape as `openrouter/...`.

### Verification

Everything below was run against the live API rather than mocks, with a throwaway key that has since been revoked:

| Path | Result |
|------|--------|
| `from_provider("hubris/openai/gpt-5.6-luna")`, default `Mode.TOOLS` | `User(name='Ivan', age=28)` |
| same with `mode=Mode.JSON_SCHEMA` | `User(name='Anna', age=31)` |
| `from_provider("hubris/anthropic/claude-sonnet-5")` | `User(name='Pyotr', age=44)` |
| `async_client=True` | `User(name='Olga', age=35)` |
| `create_partial(...)` | 11 partial frames, final `User(name='Ivan', age=28)` |
| `from_hubris(OpenAI(...), model="google/gemini-3.7-flash")` | `User(name='Sergey', age=19)` |

The four modes claimed in the spec were also checked at the wire level before being declared: tool calling returns a proper `tool_calls` entry, `parallel_tool_calls` returns two calls in one response, and `response_format` with a JSON schema returns `{"name":"Anna","age":31}`. `RESPONSES_TOOLS` is listed as unsupported — I have not wired that path.

Test suite:

```
pytest tests/v2 tests/typing -q
1818 passed, 188 skipped, 6 failed
```

The six failures are in `test_bedrock_handlers`, `test_messages_not_mutated[mistral]`, `test_security_regressions` and `test_vertexai_runtime`. I confirmed they are pre-existing by stashing this branch and re-running them on a clean tree — same six, and none mention Hubris; they look like missing optional SDKs in my environment.

One test needed a line: `tests/v2/test_client_unified.py` keeps a `_HANDLER_MODULE_PATHS` map that must name every provider's handler module, so `test_handlers_importable[hubris]` failed until Hubris was added there.

`ruff check` and `ruff format --check` are clean on every file touched.
