### PR TITLE
fix(genai): preserve text part metadata during templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **GenAI templating**: Preserve text-part metadata, including thought flags and thought signatures, when rendering context variables in conversation history.
+
 ### Security
 - Route Anthropic PDF downloads through the bounded public-network fetcher and pin each media connection to a validated IP before sending HTTP.
 - Key cached responses by the complete prepared request, provider, validation context and strictness. Clients have isolated cache namespaces by default; `cache_namespace` explicitly enables sharing and must identify the endpoint and tenant. Revalidate cache hits with the current context and strictness.

--- a/instructor/v2/providers/genai/templating.py
+++ b/instructor/v2/providers/genai/templating.py
@@ -17,7 +17,7 @@ def process_message(
         role=message.role,
         parts=[
             (
-                types.Part.from_text(text=apply_template(part.text, context))
+                part.model_copy(update={"text": apply_template(part.text, context)})
                 if isinstance(getattr(part, "text", None), str)
                 else part
             )

--- a/tests/processing/test_formatting.py
+++ b/tests/processing/test_formatting.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from jinja2.exceptions import SecurityError
 from instructor.templating import handle_templating
@@ -166,3 +168,39 @@ def test_handle_templating_with_genai_multimodal_parts():
     assert processed.parts[0].text == "Describe this image"
     assert processed.parts[1].text is None
     assert processed.parts[1].file_data.file_uri == "gs://example/cat.png"
+
+
+@pytest.mark.parametrize("thought", [True, False, None])
+@pytest.mark.parametrize("text", ["The previous response.", ""])
+def test_handle_templating_preserves_genai_text_part_metadata(
+    thought: bool | None, text: str
+) -> None:
+    from google.genai import types
+
+    history = types.Content(
+        role="model",
+        parts=[
+            types.Part(
+                text=text,
+                thought=thought,
+                thought_signature=b"previous-response-signature",
+            )
+        ],
+    )
+    user = types.Content(
+        role="user",
+        parts=[types.Part.from_text(text="Describe {{ subject }}")],
+    )
+    original_history = history.model_dump()
+    original_user = user.model_dump()
+
+    result = handle_templating(
+        {"contents": [history, user]},
+        Mode.GENAI_TOOLS,
+        {"subject": "this image"},
+    )
+
+    assert result["contents"][0].model_dump() == original_history
+    assert result["contents"][1].parts[0].text == "Describe this image"
+    assert history.model_dump() == original_history
+    assert user.model_dump() == original_user


### PR DESCRIPTION
## Describe your changes

When a nonempty templating context is supplied, GenAI text parts are rebuilt from text alone. This silently removes `thought` and `thought_signature` from prior model messages, even when that history contains no template expressions.

Copy each text part with only its rendered text updated. Other part fields survive, non-text parts retain their existing behavior, and caller-owned content remains unchanged.

- Add six regression cases covering `thought=True/False/None` with normal and empty text, user-template rendering, and input immutability.
- Document the fix in `CHANGELOG.md`.

Validation with the locked dependencies (Python 3.12.14, google-genai 1.31.0):

- All six new cases fail on current main and pass with this patch.
- Processing and related GenAI suites: **235 passed, 1 skipped** (`--asyncio-mode=auto`).
- Repository `instructor/examples/tests` Ruff lint and formatting pass; changed-module `ty check --error-on-warning` and `git diff --check` pass.
- Full-project type checking has baseline failures reproduced on unchanged main: missing optional SDK imports and an unrelated assignment in `remote.py`. This patch adds no type diagnostic.

This contribution was investigated, implemented, tested, and independently reviewed with OpenAI Codex. The regression uses real SDK objects and a synthetic signature without API requests; no live Gemini inference result is claimed.

## Issue ticket number and link

Fixes #2607

## Checklist before requesting a review

- [x] Code and tests reviewed, including a separate Codex agent review.
- [x] Regression tests fail before the fix and pass afterward.
- [x] User-visible behavior documented in the changelog.
