### PR TITLE
docs: fix the citation.md dead anchor and two ensembling-doc typos

### DIFF
--- a/docs/concepts/citation.md
+++ b/docs/concepts/citation.md
@@ -185,6 +185,6 @@ Use CitationMixin when:
 ## See Also
 
 - [Validation](./validation.md) - Learn about validation in Instructor
-- [Context-Based Validation](./validation.md#context-based-validation) - Using context for validation
+- [Semantic Validation](./validation.md#semantic-validation) - Using context for validation
 - [Citation Examples](../examples/exact_citations.md) - More citation examples
 - [RAG Patterns](../blog/posts/rag-and-beyond.md) - Building RAG systems with Instructor

--- a/docs/prompting/ensembling/max_mutual_information.md
+++ b/docs/prompting/ensembling/max_mutual_information.md
@@ -8,7 +8,7 @@ Max Mutual Information Method is a method of prompting that aims to find the bes
 
 ### Entropy
 
-When a language model recieves a prompt as input, it outputs a series of token probabilities sequentially until it reaches the `<EOS>` token. In the paper, they take the final probability distribution as $P(Y|X)$ where $Y$ is the final prediction of the model and $X$ the prompt.
+When a language model receives a prompt as input, it outputs a series of token probabilities sequentially until it reaches the `<EOS>` token. In the paper, they take the final probability distribution as $P(Y|X)$ where $Y$ is the final prediction of the model and $X$ the prompt.
 
 When we have a probability distribution, we can calculate a probability known as entropy. The lower this value is, the better. This is because a lower entropy value means that the model is more confident in its prediction.
 

--- a/docs/prompting/ensembling/more.md
+++ b/docs/prompting/ensembling/more.md
@@ -6,7 +6,7 @@ Language Models struggle to generalize across question types that require distin
 
 In the original paper, they utilise four different experts
 
-1. Factual Expert : This is a model that is augmented by a RAG prompting pipeline. WHen it recieves a query, it retrieves the top 10 most relevant passages from Wikipedia and appends them to the prompt right before the question.
+1. Factual Expert : This is a model that is augmented by a RAG prompting pipeline. When it recieves a query, it retrieves the top 10 most relevant passages from Wikipedia and appends them to the prompt right before the question.
 
 2. Multihop Expert : This is an expert that has manually written rationales after each demo to elicit multi-step reasoning processes for the questions
 


### PR DESCRIPTION
- `docs/concepts/citation.md`: linked `validation.md#context-based-validation` — no such heading in validation.md; the matching section is `## Semantic Validation`, so the link now points there
- `docs/prompting/ensembling/max_mutual_information.md": "recieves" → "receives"
- `docs/prompting/ensembling/more.md`: "WHen" → "When"

Docs-only.