### PR TITLE
docs: fix three dead example/API anchors

### DIFF
--- a/docs/integrations/bedrock.md
+++ b/docs/integrations/bedrock.md
@@ -21,7 +21,7 @@ pip install "instructor[bedrock]"
 - [from_provider Guide](../concepts/from_provider.md) - Detailed client configuration
 - [Mode Migration Guide](../concepts/mode-migration.md) - Move to core modes
 - [Provider Examples](../index.md#provider-examples) - Quick examples for all providers
-- [AWS Integration Guide](../examples/index.md#aws-integration) - More AWS examples
+- [AWS Integration Guide](../examples/index.md) - More AWS examples
 
 # AWS Bedrock
 

--- a/docs/integrations/sambanova.md
+++ b/docs/integrations/sambanova.md
@@ -8,7 +8,7 @@ description: Use Instructor with SambaNova's LLM API for structured outputs.
 - [Getting Started](../getting-started.md) - Quick start guide
 - [from_provider Guide](../concepts/from_provider.md) - Detailed client configuration
 - [Provider Examples](../index.md#provider-examples) - Quick examples for all providers
-- [Enterprise Integration](../examples/index.md#enterprise-integration) - More enterprise examples
+- [Enterprise Integration](../examples/index.md) - More enterprise examples
 
 # SambaNova Integration
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -234,4 +234,4 @@ Let's be clear - you might not need Instructor if:
 
 For everyone else building production LLM applications, Instructor is the obvious choice.
 
-[Get Started →](index.md#quick-start-extract-structured-data-in-3-lines){ .md-button .md-button--primary }
+[Get Started →](index.md#quick-start){ .md-button .md-button--primary }


### PR DESCRIPTION
- `docs/why.md`: the "Get Started" button anchored `index.md#quick-start-extract-structured-data-in-3-lines` — index.md's real heading is `## Quick Start`; repointed
- `docs/integrations/bedrock.md` + `docs/integrations/sambanova.md`: linked `examples/index.md#aws-integration` / `#enterprise-integration` — neither anchor exists in examples/index.md; fragments dropped (pages verified to exist)

Docs-only.