### PR TITLE
fix(cache): prevent mapping-key collisions and strengthen coverage contracts

### DIFF
--- a/instructor/cache/__init__.py
+++ b/instructor/cache/__init__.py
@@ -362,10 +362,18 @@ def make_request_cache_key(
 
     def encode(value: Any) -> Any:
         if isinstance(value, BaseModel):
-            return value.model_dump(mode="json")
+            return encode(value.model_dump(mode="json"))
         if isinstance(value, type) and issubclass(value, BaseModel):
-            return value.model_json_schema()
-        raise TypeError(f"Unsupported cache identity value: {type(value).__name__}")
+            return encode(value.model_json_schema())
+        if isinstance(value, dict):
+            # JSON coerces mapping keys to strings, aliasing distinct policies
+            # such as {1: "allowed"} and {"1": "allowed"} in validation context.
+            if any(not isinstance(key, str) for key in value):
+                raise TypeError("Cache identity mappings require string keys")
+            return {key: encode(item) for key, item in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [encode(item) for item in value]
+        return value
 
     try:
         payload = {
@@ -380,7 +388,7 @@ def make_request_cache_key(
             "context": context,
             "strict": strict,
         }
-        data = json.dumps(payload, sort_keys=True, default=encode, allow_nan=False)
+        data = json.dumps(encode(payload), sort_keys=True, allow_nan=False)
     except (TypeError, ValueError, AttributeError, RecursionError):
         return None
     return hashlib.sha256(data.encode()).hexdigest()

--- a/tests/v2/test_cache_identity_contracts.py
+++ b/tests/v2/test_cache_identity_contracts.py
@@ -1,0 +1,61 @@
+"""Cache identity must preserve typed mapping keys in validation context."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from instructor.cache import make_request_cache_key
+
+
+class Answer(BaseModel):
+    value: int
+
+
+def key(context: dict[str, Any]) -> str | None:
+    return make_request_cache_key(
+        request={"model": "local"},
+        args=(),
+        response_model=Answer,
+        provider="openai",
+        mode="json",
+        namespace="contract",
+        context=context,
+        strict=True,
+    )
+
+
+@pytest.mark.parametrize("mapping_key", [1, False, None, 1.5])
+def test_context_mapping_keys_do_not_alias_json_strings(mapping_key: Any) -> None:
+    typed = {"policy": {mapping_key: "allowed"}}
+    stringified = json.loads(json.dumps(typed))
+    typed_key = key(typed)
+    string_key = key(stringified)
+    assert string_key is not None
+    # JSON stringifies these keys; bypass caching rather than alias a policy.
+    assert typed_key is None
+
+
+def test_context_mapping_order_does_not_change_identity() -> None:
+    first = key({"policy": {"a": 1, "b": 2}})
+    assert first is not None
+    assert first == key({"policy": {"b": 2, "a": 1}})
+
+
+@pytest.mark.parametrize("container", [list, tuple])
+def test_context_mapping_keys_inside_sequences_bypass_cache(container: Any) -> None:
+    assert key({"policy": container([{1: "allowed"}])}) is None
+
+
+@pytest.mark.parametrize("value", [object(), float("nan"), float("inf")])
+def test_unsupported_context_keeps_bypassing_cache(value: Any) -> None:
+    assert key({"policy": value}) is None
+
+
+def test_cyclic_context_bypasses_cache() -> None:
+    context: dict[str, Any] = {}
+    context["self"] = context
+    assert key(context) is None

--- a/tests/v2/test_iterable_streaming.py
+++ b/tests/v2/test_iterable_streaming.py
@@ -123,3 +123,27 @@ def test_iterable_pep604_union_reports_unmatched_payload_as_value_error() -> Non
 
     with pytest.raises(ValueError, match="Failed to extract task type"):
         iterable_model.extract_cls_task_type('{"unrelated": true}')
+
+
+@pytest.mark.asyncio
+async def test_streaming_is_independent_of_chunk_boundaries() -> None:
+    """Exercise every split, including escapes, strings and object delimiters."""
+    import json
+
+    expected = [
+        User(name="Alice", bio='braces } {, brackets ][, quote " and slash \\'),
+        User(name="Bob", bio="雪"),
+    ]
+    payload = json.dumps({"tasks": [user.model_dump() for user in expected]})
+    model = cast(Any, IterableModel(User))
+    partitions = [[payload[:i], payload[i:]] for i in range(len(payload) + 1)]
+    partitions.append(list(payload))
+    for chunks in partitions:
+        assert list(model.tasks_from_chunks(chunks)) == expected, chunks
+
+        async def source(parts=chunks):
+            for chunk in parts:
+                yield chunk
+
+        actual = [item async for item in model.tasks_from_chunks_async(source())]
+        assert actual == expected, chunks

--- a/tests/v2/test_merge_boundary_contracts.py
+++ b/tests/v2/test_merge_boundary_contracts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import errno
 import socket
 from typing import Any
 
@@ -52,20 +53,25 @@ def test_json_depth_limit_rejects_parseable_nested_containers() -> None:
         extract_json_from_codeblock(nested)
 
 
-def test_public_connection_closes_socket_when_source_bind_fails() -> None:
-    # A numeric IPv4 destination with an IPv6 source fails before any connect.
-    connection = _PublicHTTPConnection(
-        "8.8.8.8",
-        port=443,
-        timeout=0.01,
-        source_address=("::1", 0),
-        socket_options=[],
-    )
-    with pytest.raises(NewConnectionError, match="Unable to connect") as caught:
-        connection._new_conn()
-    assert isinstance(caught.value.__cause__, OSError)
-    assert isinstance(caught.value.__cause__.__cause__, socket.gaierror)
-    assert connection.sock is None
+def test_public_connection_reports_source_bind_failure() -> None:
+    # Occupy the source port so binding fails locally on every platform.
+    # An IPv6 source on an IPv4 socket can instead reach connect() on macOS.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as occupied:
+        occupied.bind(("127.0.0.1", 0))
+        connection = _PublicHTTPConnection(
+            "8.8.8.8",
+            port=443,
+            timeout=0.01,
+            source_address=occupied.getsockname(),
+            socket_options=[],
+        )
+        with pytest.raises(NewConnectionError, match="Unable to connect") as caught:
+            connection._new_conn()
+        assert isinstance(caught.value.__cause__, OSError)
+        source_error = caught.value.__cause__.__cause__
+        assert isinstance(source_error, OSError)
+        assert source_error.errno == errno.EADDRINUSE
+        assert connection.sock is None
 
 
 def test_anthropic_uppercase_url_downloads_pdf_through_public_transport() -> None:

--- a/tests/v2/test_security_regressions.py
+++ b/tests/v2/test_security_regressions.py
@@ -437,3 +437,42 @@ def test_generic_named_alias_markers_rejected():
     outer = create_model("GenericAliasedOuter", answer=(GenericAlias[int], ...))
     with pytest.raises(ValueError, match="async validators are not supported"):
         prepare_response_model(outer)
+
+
+@pytest.mark.parametrize("async_client", [False, True])
+@pytest.mark.asyncio
+async def test_cache_does_not_reuse_response_for_stringified_context_keys(
+    local_provider, async_client
+):
+    url, calls = local_provider
+    client = instructor.from_provider(
+        "openai/local",
+        base_url=url,
+        api_key="local",
+        mode=instructor.Mode.JSON,
+        async_client=async_client,
+    )
+    cache = AutoCache()
+
+    async def ask(policy):
+        response = client.create(
+            response_model=Answer,
+            cache=cache,
+            context={"policy": policy},
+            messages=[{"role": "user", "content": "answer"}],
+        )
+        return await response if async_client else response
+
+    try:
+        assert (await ask({1: "allowed"})).value == 1
+        assert (await ask({"1": "allowed"})).value == 1
+        assert len(calls) == 2
+        assert (await ask({"1": "allowed"})).value == 1
+        assert len(calls) == 2
+        assert "context" not in calls[-1]
+        assert "cache" not in calls[-1]
+    finally:
+        if async_client:
+            await client.client.close()
+        else:
+            client.client.close()


### PR DESCRIPTION
Cache identities can collide even with zero uncovered statements: `{1: "allowed"}` and `{"1": "allowed"}` in validation context previously hashed identically. Both sync and async clients consequently reused a response instead of making the second request. The active request-key helper now bypasses caching for non-string mapping keys, including nested mappings in sequences. Ordinary JSON request identities remain unchanged. No new mocks, coverage exclusions, threshold changes, or runtime refactoring outside this helper.

Added 14 tests: 11 cache identity cases, two real-SDK/local-HTTP client cases, and a streaming test that checks every two-chunk split plus single-character chunks against exact expected models for both sync and async parsers. Also replaced a platform-dependent socket test with an occupied local source port and an explicit `EADDRINUSE` assertion. Its old IPv6 setup reached connection establishment on macOS instead of the intended bind failure.

## Before/after evidence

Fetched `origin/main` at `f539bf2bf43ef4d1cb4e2a405751d6a8815ce05f` (1.17.0). Before the fix, four typed-key collision cases and both real-client cases failed. Older type-collision tests cover `make_cache_key`, while the patched clients use `make_request_cache_key`.

Python 3.11.11, locked all-extras dependencies, macOS, full CI test selection with provider credentials removed and dotenv disabled:

| Check | Baseline | Final |
| --- | --- | --- |
| Passed | 3,149 | 3,164 |
| Failed | 1 (platform-dependent socket test) | 0 |
| Skipped | 199 | 199 |
| Missing statements | 0 / 9,529 | 0 / 9,535 |
| Covered branches | 3,396 / 3,402 | 3,404 / 3,408 |
| Statement + branch coverage | 99.9535998763% | 99.9690952638% |

The final run deselected 849 tests under the existing `not llm` / `not docs` selection. Baseline omitted the newly added tests. Both cache-wrapper bypass branches are now covered. The existing `--fail-under=99` and zero-missing-statements checks pass.

Executed validation:

- Full suite: `coverage run --branch -m pytest tests/ --asyncio-mode=auto --strict-config --strict-markers -m 'not llm' -k 'not docs' -rs` — 3,164 passed, 199 skipped; 92 warnings.
- `ruff check instructor examples tests` and `ruff format --check instructor examples tests` — pass.
- `ty check --error-on-warning instructor/` and tests with `ty-tests.toml` — pass.
- Same source/tests type checks targeting Python 3.9 and 3.14 on all platforms — pass.
- `tests/typing/check_installed_package.sh` — pass; builds and checks an installed wheel in a temporary environment.
- Commit hooks and `git diff --check` — pass.

## Coverage audit and remaining risks

- `.coveragerc` omits CLI source. Coverage reports 1,093 excluded source lines, largely overloads, ellipsis bodies and `TYPE_CHECKING`; the optional diskcache import helper also has an explicit runtime exclusion. These settings were not changed.
- The full “offline” job's marker selection is not a strict network boundary. For example, `tests/llm/test_anthropic/test_reasoning.py` has no `llm` marker; provider conftests skip it only when credentials are absent. An initial inherited-credential run was interrupted and is not counted as successful validation. Final evidence explicitly removes provider credentials and disables dotenv. Some existing non-LLM tests still fetch public resources.
- Live provider jobs can report success after missing-secret skips, and several convert pytest exit code 5 (no tests collected) to success. This PR does not establish live-provider compatibility. Follow-up should make credential/collection coverage visible independently from green job status.
- Retry tests include detailed attempt/error/hook assertions, but some replace registry/parser/usage functions; their execution coverage cannot establish all SDK contracts. The mutation workflow is manual and limited to async retry, with survivor/timeout budgets. Mutation testing and the complete Python runtime matrix were not executed here.
- Four uncovered branches remain: empty Anthropic batch system content, a legacy distillation overload arc, the remote connection's nonnumeric timeout path, and the optional-model helper's one-non-None union path. No exclusions were added to hide them.
- Unsupported mapping keys now cause a provider call instead of a cache hit. Validation context reaches validators unchanged. This is a narrow collision fix, not a proof that every arbitrary Python context object has a lossless cache identity.
- Existing issue [#2603](https://github.com/567-labs/instructor/issues/2603) tracks response-model class/validator allocation. It appeared in the verified open-cache issue search but is separate from this fix; no issue is closed by this PR.

Draft for review. No merge or release requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request cache key semantics for non-string mapping keys in context (now bypass cache instead of colliding); behavior is safer but may increase provider calls for those cases.
> 
> **Overview**
> Fixes incorrect **cache hits** when validation `context` used dict keys that JSON would stringify (e.g. `{1: "allowed"}` vs `{"1": "allowed"}`), which could reuse a response across different policies.
> 
> **`make_request_cache_key`** now recursively normalizes the identity payload before hashing: nested models, dicts, and sequences are walked explicitly, dicts must use **string keys** (otherwise key generation returns `None` and caching is skipped), and hashing uses `json.dumps(encode(payload), …)` instead of a `default=` hook that did not preserve key types.
> 
> Adds contract tests for identity edge cases (typed keys, ordering, cycles, unsupported values), a **sync/async** local-client test proving two policy shapes always produce two provider calls, an iterable streaming test over **every chunk split**, and replaces a flaky socket bind test with a deterministic **`EADDRINUSE`** setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c01a39515e2b23339b0bba4aff71a8278987a52f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->