### PR TITLE
refactor(v2): separate token-budget policy from retry execution

### DIFF
--- a/instructor/v2/core/budget.py
+++ b/instructor/v2/core/budget.py
@@ -1,0 +1,76 @@
+"""Token-budget policy for the v2 runtime."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from instructor.v2.core.errors import (
+    FailedAttempt,
+    TokenBudgetError,
+    TokenBudgetExceeded,
+    TokenUsageUnavailableError,
+)
+from instructor.v2.core.messages import extract_messages
+from instructor.v2.core.usage import _usage_snapshot, _usage_total_tokens
+
+
+def _validate_token_budget(
+    token_budget: int | None,
+    *,
+    response_model: object,
+    kwargs: dict[str, Any],
+) -> None:
+    if token_budget is None:
+        return
+    if isinstance(token_budget, bool) or not isinstance(token_budget, int):
+        raise TypeError("token_budget must be a positive integer or None")
+    if token_budget <= 0:
+        raise ValueError("token_budget must be greater than zero")
+    if response_model is None:
+        raise ValueError("token_budget requires a structured response_model")
+    if kwargs.get("stream"):
+        raise ValueError("token_budget is not supported for streaming responses")
+
+
+def _budget_error(
+    *,
+    token_budget: int | None,
+    usage_available: bool,
+    total_usage: Any,
+    attempt_number: int,
+    response: Any,
+    kwargs: dict[str, Any],
+    failed_attempts: list[FailedAttempt],
+) -> TokenBudgetError | None:
+    if token_budget is None:
+        return None
+
+    error_kwargs = {
+        "budget": token_budget,
+        "last_completion": response,
+        "messages": extract_messages(kwargs),
+        "n_attempts": attempt_number,
+        "total_usage": _usage_snapshot(total_usage),
+        "create_kwargs": kwargs,
+        "failed_attempts": failed_attempts,
+    }
+    if not usage_available:
+        return TokenUsageUnavailableError(
+            "Token budget cannot be enforced because the provider response did "
+            "not include compatible usage metadata",
+            **error_kwargs,
+        )
+
+    used_tokens = _usage_total_tokens(total_usage)
+    if used_tokens is None:
+        return TokenUsageUnavailableError(
+            "Token budget cannot be enforced because total token usage is unavailable",
+            **error_kwargs,
+        )
+    if used_tokens >= token_budget:
+        return TokenBudgetExceeded(
+            f"Token budget exhausted after {used_tokens} tokens across "
+            f"{attempt_number} attempts (budget: {token_budget})",
+            **error_kwargs,
+        )
+    return None

--- a/instructor/v2/core/patch.py
+++ b/instructor/v2/core/patch.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast, overload
 
 from pydantic import BaseModel
 
+from instructor.v2.core.budget import _validate_token_budget
 from instructor.v2.core.mode import Mode
 from instructor.v2.core.providers import Provider
 from instructor.v2.core.hooks import Hooks
@@ -25,11 +26,7 @@ from instructor.v2.core.exceptions import RegistryValidationMixin
 from instructor.v2.core.registry import mode_registry
 from instructor.v2.core.messages import isolate_retry_kwargs
 from instructor.v2.core.response_model import prepare_response_model
-from instructor.v2.core.retry import (
-    _validate_token_budget,
-    retry_async_v2,
-    retry_sync_v2,
-)
+from instructor.v2.core.retry import retry_async_v2, retry_sync_v2
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable

--- a/instructor/v2/core/retry.py
+++ b/instructor/v2/core/retry.py
@@ -6,10 +6,8 @@ instead of v1's process_response.
 
 from __future__ import annotations
 
-import copy
 import json
 import logging
-from numbers import Real
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from pydantic import BaseModel, ValidationError
@@ -23,6 +21,10 @@ from tenacity import (
 
 from instructor.v2.core.mode import Mode
 from instructor.v2.core.providers import Provider
+from instructor.v2.core.budget import (
+    _budget_error as _budget_error,
+    _validate_token_budget as _validate_token_budget,
+)
 from instructor.v2.core.errors import (
     AsyncValidationError,
     FailedAttempt,
@@ -30,14 +32,17 @@ from instructor.v2.core.errors import (
     InstructorRetryException,
     ResponseParsingError,
     TokenBudgetError,
-    TokenBudgetExceeded,
-    TokenUsageUnavailableError,
 )
 from instructor.v2.dsl.iterable import IterableBase
 from instructor.v2.dsl.response_list import ListResponse
 from instructor.v2.dsl.simple_type import AdapterBase
 from instructor.v2.core.messages import extract_messages
-from instructor.v2.core.usage import has_compatible_usage, update_total_usage
+from instructor.v2.core.usage import (
+    _usage_snapshot as _usage_snapshot,
+    _usage_total_tokens as _usage_total_tokens,
+    has_compatible_usage,
+    update_total_usage,
+)
 from instructor.v2.core.exceptions import RegistryValidationMixin
 from instructor.v2.core.registry import mode_registry
 
@@ -74,50 +79,6 @@ def _attempt_metadata(
     }
 
 
-def _usage_snapshot(total_usage: Any) -> Any:
-    if isinstance(total_usage, BaseModel):
-        return total_usage.model_copy(deep=True)
-    return copy.deepcopy(total_usage)
-
-
-def _usage_total_tokens(total_usage: Any) -> int | None:
-    direct_total = getattr(total_usage, "total_tokens", None)
-    if isinstance(direct_total, Real) and not isinstance(direct_total, bool):
-        return int(direct_total)
-
-    token_fields = (
-        "input_tokens",
-        "output_tokens",
-        "cache_creation_input_tokens",
-        "cache_read_input_tokens",
-    )
-    values = [getattr(total_usage, field, None) for field in token_fields]
-    numeric_values = [
-        int(value)
-        for value in values
-        if isinstance(value, Real) and not isinstance(value, bool)
-    ]
-    return sum(numeric_values) if numeric_values else None
-
-
-def _validate_token_budget(
-    token_budget: int | None,
-    *,
-    response_model: object,
-    kwargs: dict[str, Any],
-) -> None:
-    if token_budget is None:
-        return
-    if isinstance(token_budget, bool) or not isinstance(token_budget, int):
-        raise TypeError("token_budget must be a positive integer or None")
-    if token_budget <= 0:
-        raise ValueError("token_budget must be greater than zero")
-    if response_model is None:
-        raise ValueError("token_budget requires a structured response_model")
-    if kwargs.get("stream"):
-        raise ValueError("token_budget is not supported for streaming responses")
-
-
 def _finalize_parsed_response(
     parsed: Any,
     response: Any,
@@ -143,50 +104,6 @@ def _finalize_parsed_response(
         if usage is not None:
             parsed._total_usage = usage  # type: ignore[attr-defined]
     return parsed
-
-
-def _budget_error(
-    *,
-    token_budget: int | None,
-    usage_available: bool,
-    total_usage: Any,
-    attempt_number: int,
-    response: Any,
-    kwargs: dict[str, Any],
-    failed_attempts: list[FailedAttempt],
-) -> TokenBudgetError | None:
-    if token_budget is None:
-        return None
-
-    error_kwargs = {
-        "budget": token_budget,
-        "last_completion": response,
-        "messages": extract_messages(kwargs),
-        "n_attempts": attempt_number,
-        "total_usage": _usage_snapshot(total_usage),
-        "create_kwargs": kwargs,
-        "failed_attempts": failed_attempts,
-    }
-    if not usage_available:
-        return TokenUsageUnavailableError(
-            "Token budget cannot be enforced because the provider response did "
-            "not include compatible usage metadata",
-            **error_kwargs,
-        )
-
-    used_tokens = _usage_total_tokens(total_usage)
-    if used_tokens is None:
-        return TokenUsageUnavailableError(
-            "Token budget cannot be enforced because total token usage is unavailable",
-            **error_kwargs,
-        )
-    if used_tokens >= token_budget:
-        return TokenBudgetExceeded(
-            f"Token budget exhausted after {used_tokens} tokens across "
-            f"{attempt_number} attempts (budget: {token_budget})",
-            **error_kwargs,
-        )
-    return None
 
 
 def _initialize_usage(provider: Provider | Mode) -> Any:

--- a/instructor/v2/core/usage.py
+++ b/instructor/v2/core/usage.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 from numbers import Real
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from pydantic import BaseModel
 
@@ -14,6 +15,32 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("instructor")
 T_Response = TypeVar("T_Response")
+
+
+def _usage_snapshot(total_usage: Any) -> Any:
+    if isinstance(total_usage, BaseModel):
+        return total_usage.model_copy(deep=True)
+    return copy.deepcopy(total_usage)
+
+
+def _usage_total_tokens(total_usage: Any) -> int | None:
+    direct_total = getattr(total_usage, "total_tokens", None)
+    if isinstance(direct_total, Real) and not isinstance(direct_total, bool):
+        return int(direct_total)
+
+    token_fields = (
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+    )
+    values = [getattr(total_usage, field, None) for field in token_fields]
+    numeric_values = [
+        int(value)
+        for value in values
+        if isinstance(value, Real) and not isinstance(value, bool)
+    ]
+    return sum(numeric_values) if numeric_values else None
 
 
 def _field_names(model: BaseModel) -> set[str]:

--- a/tests/v2/test_retry_budget.py
+++ b/tests/v2/test_retry_budget.py
@@ -10,6 +10,10 @@ from openai.types import CompletionUsage
 from pydantic import BaseModel, ValidationError
 
 from instructor import Mode, Provider
+from instructor.v2.core.budget import (
+    _budget_error as budget_error,
+    _validate_token_budget as validate_token_budget,
+)
 from instructor.v2.core.client import (
     AsyncInstructor,
     AsyncResponse,
@@ -28,15 +32,27 @@ from instructor.v2.core.retry import (
     _finalize_parsed_response,
     _usage_snapshot,
     _usage_total_tokens,
+    _validate_token_budget,
     retry_async_v2,
     retry_sync_v2,
 )
-from instructor.v2.core.usage import has_compatible_usage
+from instructor.v2.core.usage import (
+    _usage_snapshot as usage_snapshot,
+    _usage_total_tokens as usage_total_tokens,
+    has_compatible_usage,
+)
 from instructor.v2.dsl.response_list import ListResponse
 
 
 class Answer(BaseModel):
     value: int
+
+
+def test_retry_helper_aliases_preserve_import_compatibility() -> None:
+    assert _budget_error is budget_error
+    assert _validate_token_budget is validate_token_budget
+    assert _usage_snapshot is usage_snapshot
+    assert _usage_total_tokens is usage_total_tokens
 
 
 def _validation_error() -> ValidationError:


### PR DESCRIPTION
## Summary

Implements recommendation 1 / Stage A from #2615:

- add `instructor/v2/core/budget.py` as the owner of token-budget preflight and exhaustion errors
- move usage snapshots and token-total arithmetic into `instructor/v2/core/usage.py`
- make `patch.py` use budget preflight directly and `retry.py` depend on budget + usage
- retain the four old `instructor.v2.core.retry` helper names as identical compatibility aliases
- add a contract for alias identity

This is a behavior-preserving extraction only. Retry loops, finalization, hooks, retry counts, Tenacity policy behavior, provider handling, streaming state, and unrelated coverage/deduplication work are unchanged.

## Post-PR simplification and provider-consistency review

Reviewed the complete five-file diff and all token-budget/usage call sites after opening the PR. No further code simplification is justified:

- budget validation and error construction have one owner in `core/budget.py`
- usage snapshots and token-total arithmetic have one owner in `core/usage.py`
- `retry.py` aliases are intentional compatibility exports and preserve exact object identity
- shared sync/async retry behavior remains covered by common contracts rather than provider copies
- provider-specific SDK/wire semantics remain in adapters: OpenAI Chat Completions and stable Anthropic Messages are the currently compatible aggregate shapes; native xAI retains its documented unsupported-budget path; other native/endpoint shapes are not coerced into OpenAI semantics

Coordinated with #2620: that PR retains its narrow Anthropic thinking-token semantic adapter and separates durable provider regression contracts from known-limit characterizations. It imports the moved helpers through the retry compatibility aliases, so no helpers or token arithmetic are duplicated here.

## Verification

- required budget/retry/usage suites plus shared handler/client contracts — **754 passed, 88 skipped**
- `uv run --frozen ruff check instructor tests` — passed
- `uv run --frozen ruff format --check instructor tests` — **423 files already formatted**
- focused `ty check` for changed runtime and requested test files — passed
- fresh-process imports and compatibility-alias identity checks — passed
- `tests/typing/check_installed_package.sh` — passed
- GitHub Actions Ruff, ty, and Test workflows — passed

A broader proxy-free `tests/v2` run produced **1,798 passed, 178 skipped, 6 failed**. Five failures require unavailable optional SDK/network facilities (`botocore`, `mistralai`, `google-genai`, and external DNS). The sixth JSON-extraction assertion fails identically on current `main`; it is unrelated to this diff. Full-package local `ty` likewise requires the repository's all-extras environment; focused changed-file typing, installed-wheel typing, and GitHub's full ty workflow are green.

Review baseline: `f539bf2bf43ef4d1cb4e2a405751d6a8815ce05f` / Instructor 1.17.0. Implementation base: `main` at `6969bb6849c49bf742fcdbfec7e969cfd5046274`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving module extraction with compatibility aliases; retry loops and budget enforcement logic are unchanged.
> 
> **Overview**
> **Refactors v2 token-budget and usage helpers** into dedicated modules without changing runtime behavior.
> 
> Token-budget preflight (`_validate_token_budget`) and exhaustion handling (`_budget_error`) now live in new `instructor/v2/core/budget.py`. Usage snapshot and total-token arithmetic (`_usage_snapshot`, `_usage_total_tokens`) move from `retry.py` into `usage.py`. `patch.py` imports budget validation directly; `retry.py` wires budget/usage and **re-exports the same four helper names** so existing `instructor.v2.core.retry` imports keep identical object identity. Tests add an explicit alias-identity contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1809b82649ebc18817f3234edf7187038ca73dbb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->