### PR TITLE
refactor(bedrock): move SDK construction into provider module

### DIFF
--- a/instructor/v2/auto_client.py
+++ b/instructor/v2/auto_client.py
@@ -983,64 +983,9 @@ def _build_bedrock(
     kwargs: dict[str, Any],
     provider_info: dict[str, str],
 ) -> InstructorType:
+    """Compatibility entry point for the provider-owned Bedrock builder."""
     try:
-        import os
-        import boto3
-        from instructor.v2.providers.bedrock.client import from_bedrock
-
-        # Get AWS configuration from environment or kwargs
-        if "region" in kwargs:
-            region = kwargs.pop("region")
-        else:
-            logger.debug(
-                "AWS_DEFAULT_REGION is not set. Using default region us-east-1"
-            )
-            region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
-
-        # Extract AWS-specific parameters
-        # Dictionary to collect AWS credentials and session parameters for boto3 client
-        aws_kwargs = {}
-        for key in [
-            "aws_access_key_id",
-            "aws_secret_access_key",
-            "aws_session_token",
-        ]:
-            if key in kwargs:
-                aws_kwargs[key] = kwargs.pop(key)
-            elif key.upper() in os.environ:
-                logger.debug(f"Using {key.upper()} from environment variable")
-                aws_kwargs[key] = os.environ[key.upper()]
-
-        # Add region to client configuration
-        aws_kwargs["region_name"] = region
-
-        # Create bedrock-runtime client
-        client = boto3.client("bedrock-runtime", **aws_kwargs)
-
-        # Determine default mode based on model
-        if mode is None:
-            # Anthropic models (Claude) support tools, others use JSON
-            if model_name and (
-                "anthropic" in model_name.lower() or "claude" in model_name.lower()
-            ):
-                default_mode = Mode.TOOLS
-            else:
-                default_mode = Mode.MD_JSON
-        else:
-            default_mode = mode
-
-        result = from_bedrock(
-            client,
-            mode=default_mode,
-            async_client=async_client,
-            model=model_name,
-            **kwargs,
-        )
-        logger.info(
-            "Client initialized",
-            extra={**provider_info, "status": "success"},
-        )
-        return result
+        from instructor.v2.providers.bedrock.client import build_from_model
     except ImportError:
         from instructor.v2.core.errors import ConfigurationError
 
@@ -1048,15 +993,16 @@ def _build_bedrock(
             "The boto3 package is required to use the AWS Bedrock provider. "
             "Install it with `pip install boto3`."
         ) from None
-    except Exception as e:
-        logger.error(
-            "Error initializing %s client: %s",
-            provider,
-            e,
-            exc_info=True,
-            extra={**provider_info, "status": "error"},
-        )
-        raise
+
+    return build_from_model(
+        provider=provider,
+        model_name=model_name,
+        async_client=async_client,
+        mode=mode,
+        api_key=api_key,
+        kwargs=kwargs,
+        provider_info=provider_info,
+    )
 
 
 def _build_cerebras(

--- a/instructor/v2/auto_client.py
+++ b/instructor/v2/auto_client.py
@@ -984,22 +984,13 @@ def _build_bedrock(
     provider_info: dict[str, str],
 ) -> InstructorType:
     """Compatibility entry point for the provider-owned Bedrock builder."""
-    try:
-        from instructor.v2.providers.bedrock.client import build_from_model
-    except ImportError:
-        from instructor.v2.core.errors import ConfigurationError
+    from instructor.v2.providers.bedrock.client import _build_from_model
 
-        raise ConfigurationError(
-            "The boto3 package is required to use the AWS Bedrock provider. "
-            "Install it with `pip install boto3`."
-        ) from None
-
-    return build_from_model(
+    return _build_from_model(
         provider=provider,
         model_name=model_name,
         async_client=async_client,
         mode=mode,
-        api_key=api_key,
         kwargs=kwargs,
         provider_info=provider_info,
     )

--- a/instructor/v2/providers/bedrock/client.py
+++ b/instructor/v2/providers/bedrock/client.py
@@ -139,13 +139,12 @@ def from_bedrock(
     )
 
 
-def build_from_model(
+def _build_from_model(
     *,
     provider: str,
     model_name: str,
     async_client: bool,
     mode: Mode | None,
-    api_key: str | None,  # noqa: ARG001
     kwargs: dict[str, Any],
     provider_info: dict[str, str],
 ) -> Instructor | AsyncInstructor:
@@ -216,4 +215,4 @@ def build_from_model(
         raise
 
 
-__all__ = ["build_from_model", "from_bedrock"]
+__all__ = ["from_bedrock"]

--- a/instructor/v2/providers/bedrock/client.py
+++ b/instructor/v2/providers/bedrock/client.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 from instructor.v2.core.client import AsyncInstructor, Instructor
@@ -11,6 +13,8 @@ from instructor.v2.core.patch import patch_v2
 
 # Ensure handlers are registered (decorators auto-register on import)
 from instructor.v2.providers.bedrock import handlers  # noqa: F401
+
+logger = logging.getLogger("instructor.auto_client")
 
 if TYPE_CHECKING:
     from botocore.client import BaseClient
@@ -135,4 +139,81 @@ def from_bedrock(
     )
 
 
-__all__ = ["from_bedrock"]
+def build_from_model(
+    *,
+    provider: str,
+    model_name: str,
+    async_client: bool,
+    mode: Mode | None,
+    api_key: str | None,  # noqa: ARG001
+    kwargs: dict[str, Any],
+    provider_info: dict[str, str],
+) -> Instructor | AsyncInstructor:
+    """Construct and wrap a native Bedrock SDK client for ``from_provider``."""
+    try:
+        import boto3
+
+        if "region" in kwargs:
+            region = kwargs.pop("region")
+        else:
+            logger.debug(
+                "AWS_DEFAULT_REGION is not set. Using default region us-east-1"
+            )
+            region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+
+        aws_kwargs = {}
+        for key in [
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "aws_session_token",
+        ]:
+            if key in kwargs:
+                aws_kwargs[key] = kwargs.pop(key)
+            elif key.upper() in os.environ:
+                logger.debug(f"Using {key.upper()} from environment variable")
+                aws_kwargs[key] = os.environ[key.upper()]
+
+        aws_kwargs["region_name"] = region
+        client = boto3.client("bedrock-runtime", **aws_kwargs)
+
+        if mode is None:
+            if model_name and (
+                "anthropic" in model_name.lower() or "claude" in model_name.lower()
+            ):
+                default_mode = Mode.TOOLS
+            else:
+                default_mode = Mode.MD_JSON
+        else:
+            default_mode = mode
+
+        result = from_bedrock(
+            client,
+            mode=default_mode,
+            async_client=async_client,
+            model=model_name,
+            **kwargs,
+        )
+        logger.info(
+            "Client initialized",
+            extra={**provider_info, "status": "success"},
+        )
+        return result
+    except ImportError:
+        from instructor.v2.core.errors import ConfigurationError
+
+        raise ConfigurationError(
+            "The boto3 package is required to use the AWS Bedrock provider. "
+            "Install it with `pip install boto3`."
+        ) from None
+    except Exception as e:
+        logger.error(
+            "Error initializing %s client: %s",
+            provider,
+            e,
+            exc_info=True,
+            extra={**provider_info, "status": "error"},
+        )
+        raise
+
+
+__all__ = ["build_from_model", "from_bedrock"]

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -77,3 +77,10 @@ def test_v2_module_export_stays_lightweight():
         "instructor.v2.core.provider_specs",
         "instructor.v2.core.providers",
     ]
+
+
+def test_auto_client_keeps_bedrock_provider_lazy():
+    state = _cold_import_state("from instructor.v2 import auto_client")
+
+    assert "instructor.v2.auto_client" in state["modules"]
+    assert "instructor.v2.providers.bedrock.client" not in state["modules"]

--- a/tests/v2/test_auto_client_deterministic.py
+++ b/tests/v2/test_auto_client_deterministic.py
@@ -218,6 +218,43 @@ def test_build_bedrock_chooses_default_mode_from_model_name(
     assert calls[1]["mode"] == Mode.MD_JSON
 
 
+def test_build_bedrock_lazily_delegates_to_provider_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import instructor.v2.providers.bedrock.client as bedrock_client
+
+    captured: dict[str, Any] = {}
+
+    def fake_build_from_model(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "bedrock-client"
+
+    monkeypatch.setattr(bedrock_client, "build_from_model", fake_build_from_model)
+    provider_info = {"provider": "bedrock", "operation": "initialize"}
+    options = {"region": "us-west-2"}
+
+    result = auto_client._build_bedrock(
+        provider="bedrock",
+        model_name="amazon.titan-text",
+        async_client=True,
+        mode=Mode.MD_JSON,
+        api_key=None,
+        kwargs=options,
+        provider_info=provider_info,
+    )
+
+    assert result == "bedrock-client"
+    assert captured == {
+        "provider": "bedrock",
+        "model_name": "amazon.titan-text",
+        "async_client": True,
+        "mode": Mode.MD_JSON,
+        "api_key": None,
+        "kwargs": options,
+        "provider_info": provider_info,
+    }
+
+
 def test_build_ollama_uses_tool_mode_only_for_tool_capable_models(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/v2/test_auto_client_deterministic.py
+++ b/tests/v2/test_auto_client_deterministic.py
@@ -218,43 +218,6 @@ def test_build_bedrock_chooses_default_mode_from_model_name(
     assert calls[1]["mode"] == Mode.MD_JSON
 
 
-def test_build_bedrock_lazily_delegates_to_provider_owner(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    import instructor.v2.providers.bedrock.client as bedrock_client
-
-    captured: dict[str, Any] = {}
-
-    def fake_build_from_model(**kwargs: Any) -> str:
-        captured.update(kwargs)
-        return "bedrock-client"
-
-    monkeypatch.setattr(bedrock_client, "build_from_model", fake_build_from_model)
-    provider_info = {"provider": "bedrock", "operation": "initialize"}
-    options = {"region": "us-west-2"}
-
-    result = auto_client._build_bedrock(
-        provider="bedrock",
-        model_name="amazon.titan-text",
-        async_client=True,
-        mode=Mode.MD_JSON,
-        api_key=None,
-        kwargs=options,
-        provider_info=provider_info,
-    )
-
-    assert result == "bedrock-client"
-    assert captured == {
-        "provider": "bedrock",
-        "model_name": "amazon.titan-text",
-        "async_client": True,
-        "mode": Mode.MD_JSON,
-        "api_key": None,
-        "kwargs": options,
-        "provider_info": provider_info,
-    }
-
-
 def test_build_ollama_uses_tool_mode_only_for_tool_capable_models(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/v2/test_bedrock_client.py
+++ b/tests/v2/test_bedrock_client.py
@@ -7,14 +7,13 @@ import pytest
 from instructor import Mode
 
 
-def test_build_from_model_constructs_real_sdk_client_without_network(
+def test_from_provider_constructs_real_bedrock_sdk_client_without_network(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     pytest.importorskip("boto3")
     from botocore.client import BaseClient
 
-    from instructor import AsyncInstructor
-    from instructor.v2.providers.bedrock.client import build_from_model
+    from instructor import AsyncInstructor, from_provider
 
     monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "environment-access")
@@ -22,18 +21,12 @@ def test_build_from_model_constructs_real_sdk_client_without_network(
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-2")
     monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
 
-    wrapped = build_from_model(
-        provider="bedrock",
-        model_name="anthropic.claude-test",
+    wrapped = from_provider(
+        "bedrock/anthropic.claude-test",
         async_client=True,
-        mode=None,
-        api_key=None,
-        kwargs={
-            "region": "us-west-2",
-            "aws_access_key_id": "explicit-access",
-            "aws_secret_access_key": "explicit-secret",
-        },
-        provider_info={"provider": "bedrock", "operation": "initialize"},
+        region="us-west-2",
+        aws_access_key_id="explicit-access",
+        aws_secret_access_key="explicit-secret",
     )
 
     assert isinstance(wrapped, AsyncInstructor)

--- a/tests/v2/test_bedrock_client.py
+++ b/tests/v2/test_bedrock_client.py
@@ -7,6 +7,45 @@ import pytest
 from instructor import Mode
 
 
+def test_build_from_model_constructs_real_sdk_client_without_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("boto3")
+    from botocore.client import BaseClient
+
+    from instructor import AsyncInstructor
+    from instructor.v2.providers.bedrock.client import build_from_model
+
+    monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "environment-access")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "environment-secret")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-2")
+    monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
+
+    wrapped = build_from_model(
+        provider="bedrock",
+        model_name="anthropic.claude-test",
+        async_client=True,
+        mode=None,
+        api_key=None,
+        kwargs={
+            "region": "us-west-2",
+            "aws_access_key_id": "explicit-access",
+            "aws_secret_access_key": "explicit-secret",
+        },
+        provider_info={"provider": "bedrock", "operation": "initialize"},
+    )
+
+    assert isinstance(wrapped, AsyncInstructor)
+    assert isinstance(wrapped.client, BaseClient)
+    assert wrapped.client.meta.service_model.service_name == "bedrock-runtime"
+    assert wrapped.client.meta.region_name == "us-west-2"
+    assert wrapped.mode is Mode.TOOLS
+    credentials = wrapped.client._request_signer._credentials
+    assert credentials.access_key == "explicit-access"
+    assert credentials.secret_key == "explicit-secret"
+
+
 class TestBedrockClientWithSDK:
     """Tests for Bedrock client factory that require botocore."""
 


### PR DESCRIPTION
## Summary

- move Bedrock's existing boto3 construction, AWS credential/region precedence, and model-dependent mode selection into a private provider-owned `_build_from_model` helper
- keep `from_provider` responsible for parsing and selecting the existing router entry
- retain `auto_client._build_bedrock` and its compatibility signature as a thin lazy shim; its unused `api_key` does not leak into the provider API
- keep translated boto3 construction errors and initialization logging in the provider helper as their single owner
- preserve native boto3 client ownership, sync/async Instructor selection, aliases, modes, and remaining kwargs

This is the narrow Stage E implementation from #2615.

## Scope and architecture-stack overlap

#2355 (with dependent #2356 and #2357) and the related broad #2315 architecture branch move all providers to manifest-driven builder dispatch and introduce shared factory machinery. This PR does not copy that framework: it changes only Bedrock, adds no `ClientSpec`, provider-spec fields, method-path lookup, generic exception policy, or other-provider options.

Reconciliation remains small: that stack can retain the provider-owned Bedrock helper/body while later replacing the router shim/table entry with its broader dispatch. Bedrock-specific AWS and mode policy deliberately stays local rather than being imposed on OpenAI-compatible or other provider adapters.

## Simplification after review

Compared with the first head `a2924778`:

- removed the duplicated boto3 `ImportError` translation from the router
- made the provider builder private and removed it from `__all__`
- removed unused `api_key` from the provider helper while retaining the router compatibility signature
- deleted the fake delegation/kwargs plumbing test
- changed the real boto3 construction test to enter through public `from_provider`, covering routing plus SDK construction in one behavioral contract
- reduced the PR from five changed files and +177/-67 to four changed files and +129/-73

## Preserved contracts

- explicit AWS credentials override matching environment credentials
- `region` overrides `AWS_DEFAULT_REGION`, with `us-east-1` unchanged as fallback
- Anthropic/Claude model names default to `Mode.TOOLS`; other names default to `Mode.MD_JSON`
- explicit mode, model, async selection, remaining Instructor kwargs, logger name/metadata, and error precedence remain unchanged
- importing the central auto-client does not import the optional Bedrock provider/SDK
- provider-specific differences remain provider-owned; no OpenAI semantics are imposed on Bedrock or vice versa

## Validation

- `uv run --frozen --all-extras ruff format --check instructor tests`
- `uv run --frozen --all-extras ruff check instructor tests`
- `uv run --frozen --all-extras ty check`
- focused router/Bedrock/lazy/public-surface selection — **164 passed, 1 skipped**
- repository offline coverage suite — **772 passed**
- prior GitHub head `a2924778`: all Test jobs passed except Full Coverage (Python 3.11), which reported exactly three uncovered statements at the router's duplicated error translation (`auto_client.py:989-992`)
- updated-head GitHub CI: **Ruff, ty, and Test all passed**; Full Coverage (Python 3.11) passed with the unchanged zero-missing-statements gate

No coverage threshold or exclusion changed. A local full-suite replay could not complete five existing DNS-dependent remote-media tests in this network-restricted runtime; after clearing the injected SOCKS proxy it reached **3,143 passed, 199 skipped, 5 DNS failures**. The real boto3 construction contract uses explicit dummy credentials and makes no API request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with behavior preserved; risk is limited to Bedrock client initialization paths, now covered by lazy-import and `from_provider` construction tests.
> 
> **Overview**
> **Bedrock SDK setup** moves out of the central `auto_client` router into a private provider helper `_build_from_model` in `instructor/v2/providers/bedrock/client.py`. That helper still owns boto3 `bedrock-runtime` construction, AWS region/credential precedence, Claude vs non-Claude default `Mode`, `from_bedrock` wrapping, and init/error logging.
> 
> `auto_client._build_bedrock` becomes a **lazy compatibility shim** that only imports the provider module when Bedrock is selected, so importing `instructor.v2.auto_client` no longer pulls in optional Bedrock/boto3.
> 
> Tests add a **lazy-import guard** for Bedrock and an integration check that public `from_provider("bedrock/...")` builds a real local boto3 client (region, credentials, async wrapper, `Mode.TOOLS`) without network calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66b1567f5e992610de392bdfe76bdfe9457fa43a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->