### PR TITLE
refactor(genai): own request configuration policy

### DIFF
--- a/instructor/utils/__init__.py
+++ b/instructor/utils/__init__.py
@@ -60,12 +60,16 @@ __all__ = [
 
 # Lazy imports for backward compatibility to avoid circular imports
 def __getattr__(name):
+    if name == "update_genai_kwargs":
+        from ..v2.providers.genai.request import update_genai_kwargs
+
+        return update_genai_kwargs
+
     # Gemini utils
     if name in [
         "transform_to_gemini_prompt",
         "verify_no_unions",
         "map_to_gemini_function_schema",
-        "update_genai_kwargs",
         "update_gemini_kwargs",
         "extract_genai_system_message",
         "convert_to_genai_messages",

--- a/instructor/v2/providers/gemini/utils.py
+++ b/instructor/v2/providers/gemini/utils.py
@@ -229,101 +229,12 @@ def map_to_genai_schema(obj: dict[str, Any]) -> genai_types.Schema:
 def update_genai_kwargs(
     kwargs: dict[str, Any], base_config: dict[str, Any]
 ) -> dict[str, Any]:
-    from google.genai.types import HarmBlockThreshold, HarmCategory
+    """Compatibility wrapper for the GenAI-owned request policy."""
+    from instructor.v2.providers.genai.request import (
+        update_genai_kwargs as update_genai_kwargs_impl,
+    )
 
-    new_kwargs = kwargs.copy()
-
-    OPENAI_TO_GEMINI_MAP = {
-        "max_tokens": "max_output_tokens",
-        "temperature": "temperature",
-        "n": "candidate_count",
-        "top_p": "top_p",
-        "stop": "stop_sequences",
-        "seed": "seed",
-        "presence_penalty": "presence_penalty",
-        "frequency_penalty": "frequency_penalty",
-    }
-
-    generation_config = new_kwargs.pop("generation_config", {})
-
-    for openai_key, gemini_key in OPENAI_TO_GEMINI_MAP.items():
-        if openai_key in generation_config:
-            val = generation_config.pop(openai_key)
-            if val is not None:
-                base_config[gemini_key] = val
-
-    safety_settings = new_kwargs.pop("safety_settings", {})
-    base_config["safety_settings"] = []
-
-    if isinstance(safety_settings, list):
-        base_config["safety_settings"] = safety_settings
-        safety_settings = None
-
-    excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
-    if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
-        excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
-
-    if safety_settings is not None:
-        text_categories = [
-            c
-            for c in HarmCategory
-            if c not in excluded_categories
-            and not c.name.startswith("HARM_CATEGORY_IMAGE_")
-        ]
-
-        for category in text_categories:
-            threshold = HarmBlockThreshold.OFF
-            if isinstance(safety_settings, dict):
-                if category in safety_settings:
-                    threshold = safety_settings[category]
-
-            base_config["safety_settings"].append(
-                {
-                    "category": category,
-                    "threshold": threshold,
-                }
-            )
-
-    user_config = new_kwargs.get("config")
-    user_thinking_config = None
-    if isinstance(user_config, dict):
-        user_thinking_config = user_config.get("thinking_config")
-    elif user_config is not None and hasattr(user_config, "thinking_config"):
-        user_thinking_config = user_config.thinking_config
-
-    thinking_config = new_kwargs.pop("thinking_config", None)
-    if thinking_config is None:
-        thinking_config = user_thinking_config
-
-    if thinking_config is not None:
-        base_config["thinking_config"] = thinking_config
-
-    if user_config is not None:
-        config_fields_to_merge = [
-            "automatic_function_calling",
-            "labels",
-            "cached_content",
-        ]
-        for field in config_fields_to_merge:
-            if isinstance(user_config, dict):
-                field_value = user_config.get(field)
-            elif hasattr(user_config, field):
-                field_value = getattr(user_config, field)
-            else:
-                field_value = None
-
-            if field_value is not None and field not in base_config:
-                base_config[field] = field_value
-
-    cached_content = new_kwargs.pop("cached_content", None)
-    if cached_content is not None and "cached_content" not in base_config:
-        base_config["cached_content"] = cached_content
-    if base_config.get("cached_content") is not None:
-        # Cached resources own these fields; sending them again is invalid.
-        for field in ("system_instruction", "tools", "tool_config"):
-            base_config.pop(field, None)
-
-    return base_config
+    return update_genai_kwargs_impl(kwargs, base_config)
 
 
 def update_gemini_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:

--- a/instructor/v2/providers/genai/handlers.py
+++ b/instructor/v2/providers/genai/handlers.py
@@ -17,6 +17,7 @@ from instructor.v2.dsl.parallel import ParallelBase
 from instructor.v2.dsl.partial import Partial, PartialBase
 from instructor.v2.dsl.simple_type import AdapterBase
 from instructor.v2.providers.gemini import utils as gemini_utils
+from instructor.v2.providers.genai.request import update_genai_kwargs
 
 
 def reask_genai_tools(
@@ -417,7 +418,7 @@ class GenAIToolsHandler(GenAIHandlerBase):
         }
         # Temporarily put generation_config back for update_genai_kwargs to process
         new_kwargs["generation_config"] = generation_config_dict
-        generation_config = gemini_utils.update_genai_kwargs(new_kwargs, base_config)
+        generation_config = update_genai_kwargs(new_kwargs, base_config)
         new_kwargs.pop("generation_config", None)  # Remove it after processing
         new_kwargs["config"] = types.GenerateContentConfig(**generation_config)
         new_kwargs = self._convert_messages_to_contents(new_kwargs, autodetect_images)
@@ -488,7 +489,7 @@ class GenAIStructuredOutputsHandler(GenAIHandlerBase):
         }
         # Temporarily put generation_config back for update_genai_kwargs to process
         new_kwargs["generation_config"] = generation_config_dict
-        generation_config = gemini_utils.update_genai_kwargs(new_kwargs, base_config)
+        generation_config = update_genai_kwargs(new_kwargs, base_config)
         new_kwargs.pop("generation_config", None)  # Remove it after processing
         new_kwargs["config"] = types.GenerateContentConfig(**generation_config)
         new_kwargs = self._convert_messages_to_contents(new_kwargs, autodetect_images)

--- a/instructor/v2/providers/genai/request.py
+++ b/instructor/v2/providers/genai/request.py
@@ -1,0 +1,106 @@
+"""Request configuration policy for the Google GenAI provider."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def update_genai_kwargs(
+    kwargs: dict[str, Any], base_config: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge GenAI request options into the provider configuration."""
+    from google.genai.types import HarmBlockThreshold, HarmCategory
+
+    new_kwargs = kwargs.copy()
+
+    OPENAI_TO_GEMINI_MAP = {
+        "max_tokens": "max_output_tokens",
+        "temperature": "temperature",
+        "n": "candidate_count",
+        "top_p": "top_p",
+        "stop": "stop_sequences",
+        "seed": "seed",
+        "presence_penalty": "presence_penalty",
+        "frequency_penalty": "frequency_penalty",
+    }
+
+    generation_config = new_kwargs.pop("generation_config", {})
+
+    for openai_key, gemini_key in OPENAI_TO_GEMINI_MAP.items():
+        if openai_key in generation_config:
+            val = generation_config.pop(openai_key)
+            if val is not None:
+                base_config[gemini_key] = val
+
+    safety_settings = new_kwargs.pop("safety_settings", {})
+    base_config["safety_settings"] = []
+
+    if isinstance(safety_settings, list):
+        base_config["safety_settings"] = safety_settings
+        safety_settings = None
+
+    excluded_categories = {HarmCategory.HARM_CATEGORY_UNSPECIFIED}
+    if hasattr(HarmCategory, "HARM_CATEGORY_JAILBREAK"):
+        excluded_categories.add(HarmCategory.HARM_CATEGORY_JAILBREAK)
+
+    if safety_settings is not None:
+        text_categories = [
+            c
+            for c in HarmCategory
+            if c not in excluded_categories
+            and not c.name.startswith("HARM_CATEGORY_IMAGE_")
+        ]
+
+        for category in text_categories:
+            threshold = HarmBlockThreshold.OFF
+            if isinstance(safety_settings, dict):
+                if category in safety_settings:
+                    threshold = safety_settings[category]
+
+            base_config["safety_settings"].append(
+                {
+                    "category": category,
+                    "threshold": threshold,
+                }
+            )
+
+    user_config = new_kwargs.get("config")
+    user_thinking_config = None
+    if isinstance(user_config, dict):
+        user_thinking_config = user_config.get("thinking_config")
+    elif user_config is not None and hasattr(user_config, "thinking_config"):
+        user_thinking_config = user_config.thinking_config
+
+    thinking_config = new_kwargs.pop("thinking_config", None)
+    if thinking_config is None:
+        thinking_config = user_thinking_config
+
+    if thinking_config is not None:
+        base_config["thinking_config"] = thinking_config
+
+    if user_config is not None:
+        config_fields_to_merge = [
+            "automatic_function_calling",
+            "labels",
+            "cached_content",
+        ]
+        for field in config_fields_to_merge:
+            if isinstance(user_config, dict):
+                field_value = user_config.get(field)
+            elif hasattr(user_config, field):
+                field_value = getattr(user_config, field)
+            else:
+                field_value = None
+
+            if field_value is not None and field not in base_config:
+                base_config[field] = field_value
+
+    cached_content = new_kwargs.pop("cached_content", None)
+    if cached_content is not None and "cached_content" not in base_config:
+        base_config["cached_content"] = cached_content
+    if base_config.get("cached_content") is not None:
+        # Cached resources own these fields; sending them again is invalid.
+        for field in ("system_instruction", "tools", "tool_config"):
+            base_config.pop(field, None)
+
+    return base_config

--- a/tests/v2/test_genai_request_imports.py
+++ b/tests/v2/test_genai_request_imports.py
@@ -1,0 +1,91 @@
+"""Import-boundary tests for GenAI request configuration ownership."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def _run_isolated(code: str) -> None:
+    subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        capture_output=True,
+        check=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_public_utility_resolves_to_genai_owner() -> None:
+    from instructor import utils
+    from instructor.v2.providers.genai.request import update_genai_kwargs
+
+    assert utils.update_genai_kwargs is update_genai_kwargs
+
+
+@pytest.mark.parametrize(
+    "first_provider, second_provider",
+    [
+        ("instructor.v2.providers.gemini", "instructor.v2.providers.genai"),
+        ("instructor.v2.providers.genai", "instructor.v2.providers.gemini"),
+    ],
+)
+def test_provider_import_orders_preserve_compatibility(
+    first_provider: str, second_provider: str
+) -> None:
+    _run_isolated(
+        f"""
+        import importlib
+
+        importlib.import_module({first_provider!r})
+        importlib.import_module({second_provider!r})
+
+        from instructor.providers.gemini.utils import update_genai_kwargs as legacy
+        from instructor.utils import update_genai_kwargs as public
+        from instructor.v2.providers.gemini.utils import update_genai_kwargs as legacy_v2
+        from instructor.v2.providers.genai.request import update_genai_kwargs as owned
+
+        assert legacy is legacy_v2
+        assert public is owned
+        """
+    )
+
+
+@pytest.mark.parametrize(
+    ("blocked_sdk", "provider_client"),
+    [
+        ("google.genai", "instructor.v2.providers.genai.client"),
+        ("google.generativeai", "instructor.v2.providers.gemini.client"),
+    ],
+    ids=["without-google-genai", "without-google-generativeai"],
+)
+def test_provider_imports_remain_lazy_without_each_optional_sdk(
+    blocked_sdk: str, provider_client: str
+) -> None:
+    _run_isolated(
+        f"""
+        import importlib
+        import importlib.util
+        import sys
+
+        blocked = {blocked_sdk!r}
+        real_find_spec = importlib.util.find_spec
+
+        def find_spec(name, *args, **kwargs):
+            return None if name == blocked else real_find_spec(name, *args, **kwargs)
+
+        importlib.util.find_spec = find_spec
+        sys.modules[blocked] = None
+
+        importlib.import_module({provider_client!r})
+        from instructor.providers.gemini.utils import update_genai_kwargs as legacy
+        from instructor.utils import update_genai_kwargs as public
+        from instructor.v2.providers.genai.request import update_genai_kwargs as owned
+
+        assert callable(legacy)
+        assert public is owned
+        """
+    )


### PR DESCRIPTION
## What

Move `update_genai_kwargs` from the legacy Gemini utility module into `instructor/v2/providers/genai/request.py`, and make the active GenAI handlers depend on that provider-owned request policy.

## Why

Implements recommendation 2 / Stage B from #2615 without changing the public v2 runtime or request behavior. GenAI SDK configuration should be owned by the GenAI provider, while the existing Gemini and `instructor.utils` imports remain compatible through lazy forwarding.

## Changes

- Move the existing implementation unchanged into `providers/genai/request.py`; its function-local Google SDK import remains lazy.
- Update the active TOOLS and JSON handlers to call the GenAI-owned function directly.
- Keep `instructor.v2.providers.gemini.utils.update_genai_kwargs`, `instructor.providers.gemini.utils`, and `instructor.utils.update_genai_kwargs` working through lazy compatibility paths.
- Cover Gemini→GenAI and GenAI→Gemini cold-import order.
- Cover `google.genai` and `google.generativeai` absence separately.
- Use the repository's small subprocess-test pattern; SDK absence is represented with `sys.modules` plus the same `find_spec` boundary used by the package, rather than a provider-specific meta-path loader.
- Exercise the public `instructor.utils` forwarding contract in-process so the full-coverage gate observes it.
- Leave shared schema/message conversion, provider-specific SDK/wire behavior, streaming state, and unrelated providers untouched.
- Preserve open #2608 and #2601 without absorbing their behavior changes.

The moved implementation's AST matches the `main` implementation exactly (excluding its new ownership docstring). This is behavior-preserving, so no changelog entry is needed under the repository rule for behavior changes.

## Testing

- Focused GenAI/Gemini behavior and compatibility selection — **108 passed**.
- Import boundary file — **5 passed**, including both import orders, both separately absent SDKs, and the public forwarding contract.
- `uv run ruff check instructor examples tests` — passed.
- `uv run ruff format --check instructor examples tests` — 551 files already formatted.
- `uv run ty check` with all extras installed — passed.
- Targeted branch coverage confirms the two statements previously missed in `instructor.utils.__getattr__` are now exercised.
- `git diff --check` — passed.

The exact full CI coverage command could not be reproduced cleanly in this workspace because its configured SOCKS proxy lacks `socksio`, causing 30 unrelated SDK-client construction tests to fail. GitHub's Python 3.11 Full Coverage job is the authoritative gate for the updated head. No live provider calls were made.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving relocation of existing request-merge logic; GenAI runtime paths change imports only, with compatibility shims and new import-boundary tests.
> 
> **Overview**
> **Moves GenAI request configuration into the GenAI provider** by relocating `update_genai_kwargs` from `instructor/v2/providers/gemini/utils.py` into new `instructor/v2/providers/genai/request.py`. The merge logic (generation params, safety settings, thinking/cached content) is unchanged; only ownership and call sites shift.
> 
> Active GenAI **TOOLS** and **JSON** handlers now import `update_genai_kwargs` from `genai.request` instead of `gemini_utils`. **Backward compatibility** is preserved: `gemini.utils.update_genai_kwargs` forwards to the GenAI module, and `instructor.utils.update_genai_kwargs` lazy-loads the GenAI-owned function directly (no longer via the Gemini utils bundle).
> 
> Adds **`tests/v2/test_genai_request_imports.py`** to lock import order (Gemini↔GenAI), optional SDK absence, and the public `instructor.utils` forwarding contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30278bac88a67ca1e28a3a61cc11dd0e28ba5a25. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->