### PR TITLE
fix(packaging): verify installed distributions and declare CLI dependency

### DIFF
--- a/.github/workflows/package-compatibility.yml
+++ b/.github/workflows/package-compatibility.yml
@@ -1,0 +1,44 @@
+name: Package compatibility
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  installed-package:
+    name: Wheel / Python ${{ matrix.python }} / ${{ matrix.sdk }} / ${{ matrix.extras || 'core' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python: "3.9"
+            sdk: minimum
+          - python: "3.9"
+            sdk: latest
+          - python: "3.11"
+            sdk: latest
+          - python: "3.14"
+            sdk: latest
+          - python: "3.11"
+            sdk: latest
+            extras: google-genai
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python }}
+      - name: Build sdist and exercise installed wheel without checkout imports
+        env:
+          PACKAGE_PYTHON: ${{ matrix.python }}
+          PACKAGE_SDK: ${{ matrix.sdk }}
+          PACKAGE_EXTRAS: ${{ matrix.extras }}
+        run: tests/packaging/check_package.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
-- **CLI installation**: Declare the CLI’s `tqdm` dependency directly to fix the missing-dependency crash in OpenAI 3 installations, which no longer supply it transitively. The CLI still requires an API key even for `--help`.
+- **CLI installation**: Declare the CLI’s `tqdm` dependency directly to fix the missing-dependency crash in OpenAI 3 installations, which no longer supply it transitively. Defer file and job client construction so top-level and subcommand help work without provider credentials.
 
 ## [1.17.0] - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **CLI installation**: Declare the CLI’s `tqdm` dependency directly so `instructor --help` works in clean OpenAI 3 installations, which no longer supply it transitively.
+
 ## [1.17.0] - 2026-09-04
 
 Includes the fixes previously planned for 1.16.1, which was not published. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
-- **CLI installation**: Declare the CLI’s `tqdm` dependency directly so `instructor --help` works in clean OpenAI 3 installations, which no longer supply it transitively.
+- **CLI installation**: Declare the CLI’s `tqdm` dependency directly to fix the missing-dependency crash in OpenAI 3 installations, which no longer supply it transitively. The CLI still requires an API key even for `--help`.
 
 ## [1.17.0] - 2026-09-04
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -377,10 +377,9 @@ Run `PACKAGE_PYTHON=3.11 tests/packaging/check_package.sh` with uv installed.
 This builds an sdist, builds its wheel, and installs the wheel in a temporary
 environment outside the checkout. It checks dependency consistency, the typing
 marker, public imports and selected legacy aliases, model/schema helpers, real
-OpenAI sync/async client construction without requests, and `instructor --help`
-with a dummy API key. This is a constrained CLI smoke: credential-free `--help`
-still fails because CLI modules construct clients at import time, a separate
-unresolved defect.
+OpenAI sync/async client construction without requests, and CLI help with provider
+credentials removed. File and job clients are constructed only when an operation
+needs them.
 Temporary environments are removed on exit; resolved versions appear in the log.
 
 The package compatibility workflow has five bounded combinations:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -377,7 +377,8 @@ Run `PACKAGE_PYTHON=3.11 tests/packaging/check_package.sh` with uv installed.
 This builds an sdist, builds its wheel, and installs the wheel in a temporary
 environment outside the checkout. It checks dependency consistency, the typing
 marker, public imports and selected legacy aliases, model/schema helpers, real
-OpenAI sync/async client construction without requests, and `instructor --help`.
+OpenAI sync/async client construction without requests, and `instructor --help`
+with a dummy API key (the CLI currently constructs a client even for help).
 Temporary environments are removed on exit; resolved versions appear in the log.
 
 The package compatibility workflow has five bounded combinations:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -371,6 +371,57 @@ uv run coverage report
 - Releases are tagged with version numbers
 - We follow [Semantic Versioning](https://semver.org/)
 
+### Installed-package compatibility
+
+Run `PACKAGE_PYTHON=3.11 tests/packaging/check_package.sh` with uv installed.
+This builds an sdist, builds its wheel, and installs the wheel in a temporary
+environment outside the checkout. It checks dependency consistency, the typing
+marker, public imports and selected legacy aliases, model/schema helpers, real
+OpenAI sync/async client construction without requests, and `instructor --help`.
+Temporary environments are removed on exit; resolved versions appear in the log.
+
+The package compatibility workflow has five bounded combinations:
+
+| Python | SDK selection | Extras |
+| --- | --- | --- |
+| 3.9 | OpenAI 2.0.0 and Pydantic 2.8.0 (declared floors) | None |
+| 3.9 | Latest compatible | None |
+| 3.11 | Latest compatible | None |
+| 3.14 | Latest compatible | None |
+| 3.11 | Latest compatible | google-genai |
+
+Use `PACKAGE_SDK=minimum` for the floor check, or `PACKAGE_EXTRAS=google-genai`
+for the optional import check. Latest means a fresh resolution within the package
+requirements and the selected Python version, not the lockfile or necessarily the
+newest upstream release. The minimum row pins only OpenAI and Pydantic; their
+transitive dependencies, including the matching pydantic-core, resolve normally.
+Pydantic 2.8 predates Python 3.14, so these are deliberately not a Cartesian matrix.
+
+This is packaging evidence, not provider behavioral certification. Other optional
+extras and their minimum SDK versions, intermediate Python versions, Windows and
+Linux/macOS differences are not exhaustively covered here. CI runs on Linux;
+local runs describe their own platform. No provider requests are made. The existing
+all-extras and provider tests supply separate evidence; declared support is unchanged.
+
+### GitHub release and PyPI publication are separate
+
+`scheduled-release.yml` prepares artifacts and only creates a GitHub release when
+explicitly dispatched with `publish=true`. It uses `github.token`.
+[GitHub documents that events created with GITHUB_TOKEN do not start another
+workflow](https://docs.github.com/en/actions/concepts/security/github_token), except
+for explicitly listed event types. A `release: published` event is not an exception.
+Consequently, that release creation does **not** trigger `python-publish.yml`, which
+currently listens only for published releases. A successful GitHub release job is
+not evidence of a PyPI upload; inspect both workflow runs and registry state.
+
+Until the handoff is changed and reviewed, do not rely on the scheduled-release
+publish switch to publish to PyPI. Any approved manual release process must account
+for how the release event is authenticated and preserve the tested attached
+artifacts. Do not create test tags/releases, re-publish an existing release, add a
+personal token, or broaden workflow permissions merely to exercise this path.
+A future explicit dispatch or reusable-workflow handoff needs its own review of
+approval, artifact identity, and duplicate-publication behavior.
+
 ## Using Cursor for PR Creation
 
 Cursor (https://cursor.sh) is a code editor powered by AI that can help you create PRs efficiently. We encourage using Cursor for Instructor development:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -378,7 +378,9 @@ This builds an sdist, builds its wheel, and installs the wheel in a temporary
 environment outside the checkout. It checks dependency consistency, the typing
 marker, public imports and selected legacy aliases, model/schema helpers, real
 OpenAI sync/async client construction without requests, and `instructor --help`
-with a dummy API key (the CLI currently constructs a client even for help).
+with a dummy API key. This is a constrained CLI smoke: credential-free `--help`
+still fails because CLI modules construct clients at import time, a separate
+unresolved defect.
 Temporary environments are removed on exit; resolved versions appear in the log.
 
 The package compatibility workflow has five bounded combinations:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -406,22 +406,18 @@ all-extras and provider tests supply separate evidence; declared support is unch
 
 ### GitHub release and PyPI publication are separate
 
-`scheduled-release.yml` prepares artifacts and only creates a GitHub release when
-explicitly dispatched with `publish=true`. It uses `github.token`.
-[GitHub documents that events created with GITHUB_TOKEN do not start another
-workflow](https://docs.github.com/en/actions/concepts/security/github_token), except
-for explicitly listed event types. A `release: published` event is not an exception.
-Consequently, that release creation does **not** trigger `python-publish.yml`, which
-currently listens only for published releases. A successful GitHub release job is
-not evidence of a PyPI upload; inspect both workflow runs and registry state.
+`scheduled-release.yml` creates a GitHub release only when explicitly dispatched
+with `publish=true`, using `github.token`. [GitHub suppresses downstream workflow
+runs for release events created with that token](https://docs.github.com/en/actions/concepts/security/github_token).
+Therefore it does **not** trigger `python-publish.yml`, which listens only for
+`release: published`. A successful GitHub release job is not evidence of a PyPI
+upload; check both workflow runs and registry state.
 
-Until the handoff is changed and reviewed, do not rely on the scheduled-release
-publish switch to publish to PyPI. Any approved manual release process must account
-for how the release event is authenticated and preserve the tested attached
-artifacts. Do not create test tags/releases, re-publish an existing release, add a
-personal token, or broaden workflow permissions merely to exercise this path.
-A future explicit dispatch or reusable-workflow handoff needs its own review of
-approval, artifact identity, and duplicate-publication behavior.
+The handoff needs a separately reviewed change that preserves publication approval,
+tested artifact identity, and duplicate-publication protection. Do not create test
+tags/releases or broaden permissions to exercise it. Until then, an approved manual
+release process must explicitly account for event authentication and the tested
+attached artifacts.
 
 ## Using Cursor for PR Creation
 

--- a/instructor/cli/files.py
+++ b/instructor/cli/files.py
@@ -2,7 +2,7 @@
 
 import time
 from datetime import datetime
-from typing import Literal, cast
+from typing import Literal, Optional, cast
 
 import openai
 import typer
@@ -10,9 +10,16 @@ from openai import OpenAI
 from rich.console import Console
 from rich.table import Table
 
-client = OpenAI()
+client: Optional[OpenAI] = None
 app = typer.Typer()
 console = Console()
+
+
+def _get_client() -> OpenAI:
+    global client
+    if client is None:
+        client = OpenAI()
+    return client
 
 
 # Sample response data
@@ -39,13 +46,13 @@ def generate_file_table(files: list[openai.types.FileObject]) -> Table:
 
 
 def get_files() -> list[openai.types.FileObject]:
-    files = client.files.list()
+    files = _get_client().files.list()
     files = files.data
     return sorted(files, key=lambda x: x.created_at, reverse=True)
 
 
 def get_file_status(file_id: str) -> str:
-    response = client.files.retrieve(file_id)
+    response = _get_client().files.retrieve(file_id)
     return response.status
 
 
@@ -60,7 +67,7 @@ def upload(
     # Literals aren't supported by Typer yet.
     file_purpose = cast(Literal["fine-tune", "assistants"], purpose)
     with open(filepath, "rb") as file:
-        response = client.files.create(file=file, purpose=file_purpose)
+        response = _get_client().files.create(file=file, purpose=file_purpose)
     file_id = response.id
     with console.status(f"Monitoring upload: {file_id}...") as status:
         status.spinner_style = "dots"
@@ -80,7 +87,7 @@ def download(
     output: str = typer.Argument(help="Output path for the downloaded file"),
 ) -> None:
     with console.status(f"[bold green]Downloading file {file_id}...", spinner="dots"):
-        content = client.files.download(file_id)
+        content = _get_client().files.download(file_id)
         with open(output, "wb") as file:
             file.write(content)
         console.log(f"[bold green]File {file_id} downloaded successfully!")
@@ -92,7 +99,7 @@ def download(
 def delete(file_id: str = typer.Argument(help="ID of the file to delete")) -> None:
     with console.status(f"[bold red]Deleting file {file_id}...", spinner="dots"):
         try:
-            client.files.delete(file_id)
+            _get_client().files.delete(file_id)
             console.log(f"[bold red]File {file_id} deleted successfully!")
         except Exception as e:
             console.log(f"[bold red]Error deleting file {file_id}: {e}")

--- a/instructor/cli/files.py
+++ b/instructor/cli/files.py
@@ -97,9 +97,10 @@ def download(
     help="Delete a file from OpenAI's servers",
 )
 def delete(file_id: str = typer.Argument(help="ID of the file to delete")) -> None:
+    active_client = _get_client()
     with console.status(f"[bold red]Deleting file {file_id}...", spinner="dots"):
         try:
-            _get_client().files.delete(file_id)
+            active_client.files.delete(file_id)
             console.log(f"[bold red]File {file_id} deleted successfully!")
         except Exception as e:
             console.log(f"[bold red]Error deleting file {file_id}: {e}")

--- a/instructor/cli/jobs.py
+++ b/instructor/cli/jobs.py
@@ -10,9 +10,16 @@ from rich.console import Console
 from datetime import datetime
 from openai.types.fine_tuning import FineTuningJob
 
-client = OpenAI()
+client: Optional[OpenAI] = None
 app = typer.Typer()
 console = Console()
+
+
+def _get_client() -> OpenAI:
+    global client
+    if client is None:
+        client = OpenAI()
+    return client
 
 
 class FuneTuningParams(TypedDict, total=False):
@@ -72,11 +79,11 @@ def status_color(status: str) -> str:
 
 
 def get_jobs(limit: int = 5) -> list[FineTuningJob]:
-    return client.fine_tuning.jobs.list(limit=limit).data
+    return _get_client().fine_tuning.jobs.list(limit=limit).data
 
 
 def get_file_status(file_id: str) -> str:
-    response = client.files.retrieve(file_id)
+    response = _get_client().files.retrieve(file_id)
     return response.status
 
 
@@ -130,7 +137,7 @@ def create_from_id(
     with console.status(
         f"[bold green]Creating fine-tuning job from ID {id}...", spinner="dots"
     ):
-        job = client.fine_tuning.jobs.create(
+        job = _get_client().fine_tuning.jobs.create(
             training_file=id,
             model=model,
             hyperparameters=hyperparameters_dict,
@@ -172,14 +179,16 @@ def create_from_file(
         hyperparameters_dict["learning_rate_multiplier"] = learning_rate_multiplier
 
     with open(file, "rb") as file_buffer:
-        response = client.files.create(file=file_buffer, purpose="fine-tune")
+        response = _get_client().files.create(file=file_buffer, purpose="fine-tune")
 
     file_id = response.id
 
     validation_file_id = None
     if validation_file:
         with open(validation_file, "rb") as val_file:
-            val_response = client.files.create(file=val_file, purpose="fine-tune")
+            val_response = _get_client().files.create(
+                file=val_file, purpose="fine-tune"
+            )
         validation_file_id = val_response.id
 
     with console.status(f"Monitoring upload: {file_id} before finetuning...") as status:
@@ -210,7 +219,7 @@ def create_from_file(
     if model_suffix:
         additional_params["suffix"] = model_suffix
 
-    job = client.fine_tuning.jobs.create(
+    job = _get_client().fine_tuning.jobs.create(
         training_file=file_id,
         model=model,
         **additional_params,
@@ -234,7 +243,7 @@ def cancel(
 ) -> None:
     with console.status(f"[bold red]Cancelling job {id}...", spinner="dots"):
         try:
-            client.fine_tuning.jobs.cancel(id)
+            _get_client().fine_tuning.jobs.cancel(id)
             console.log(f"[bold red]Job {id} cancelled successfully!")
         except Exception as e:
             console.log(f"[bold red]Error cancelling job {id}: {e}")

--- a/instructor/cli/jobs.py
+++ b/instructor/cli/jobs.py
@@ -241,9 +241,10 @@ def create_from_file(
 def cancel(
     id: str = typer.Argument(help="ID of the fine-tuning job to cancel"),
 ) -> None:
+    active_client = _get_client()
     with console.status(f"[bold red]Cancelling job {id}...", spinner="dots"):
         try:
-            _get_client().fine_tuning.jobs.cancel(id)
+            active_client.fine_tuning.jobs.cancel(id)
             console.log(f"[bold red]Job {id} cancelled successfully!")
         except Exception as e:
             console.log(f"[bold red]Error cancelling job {id}: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "aiohttp<3.14.0,>=3.9.1 ; python_version < '3.10'",
     "aiohttp<4.0.0,>=3.14.3 ; python_version >= '3.10'",
     "tenacity<10.0.0,>=8.2.3",
+    "tqdm>=4.27.0,<5.0.0",
     "pydantic-core<3.0.0,>=2.18.0",
     "jiter>=0.6.1,<0.15",
     "jinja2<4.0.0,>=3.1.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,7 +93,9 @@ sniffio==1.3.1
 tenacity==9.1.4
     # via instructor (pyproject.toml)
 tqdm==4.70.0
-    # via openai
+    # via
+    #   instructor (pyproject.toml)
+    #   openai
 typer==0.27.1
     # via instructor (pyproject.toml)
 typing-extensions==4.16.0

--- a/tests/cli/test_files.py
+++ b/tests/cli/test_files.py
@@ -1,13 +1,9 @@
 """Tests for instructor.cli.files."""
 
 from openai.types import FileObject
-import pytest
 
 
-def test_generate_file_table_uses_attribute_access(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key-for-cli-import")
+def test_generate_file_table_uses_attribute_access() -> None:
     from instructor.cli.files import generate_file_table
 
     file = FileObject(

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -1,0 +1,61 @@
+"""CLI help must be available before provider credentials are configured."""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [[], ["files"], ["jobs"], ["files", "upload"], ["jobs", "create-from-file"]],
+)
+def test_help_without_credentials(arguments: list[str]) -> None:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("OPENAI_", "ANTHROPIC_", "AZURE_OPENAI_"))
+    }
+    result = subprocess.run(
+        [sys.executable, "-m", "instructor.cli.cli", *arguments, "--help"],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Usage:" in result.stdout
+
+
+@pytest.mark.parametrize("module_name", ["files", "jobs"])
+def test_client_creation_is_lazy_and_preserves_injection(
+    module_name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import openai
+    from instructor.cli import files, jobs
+
+    module = files if module_name == "files" else jobs
+    original = module.client
+    for key in os.environ:
+        if key.startswith("OPENAI_"):
+            monkeypatch.delenv(key)
+    module.client = None
+    try:
+        operation = files.get_files if module_name == "files" else jobs.get_jobs
+        with pytest.raises(openai.OpenAIError):
+            operation()
+        assert module.client is None
+
+        monkeypatch.setenv("OPENAI_API_KEY", "cli-contract")
+        created = module._get_client()
+        try:
+            assert isinstance(created, openai.OpenAI)
+            assert module._get_client() is created
+            with openai.OpenAI(api_key="injected-cli-contract") as injected:
+                module.client = injected
+                assert module._get_client() is injected
+        finally:
+            created.close()
+    finally:
+        module.client = original

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -7,23 +7,27 @@ import sys
 import pytest
 
 
-@pytest.mark.parametrize(
-    "arguments",
-    [[], ["files"], ["jobs"], ["files", "upload"], ["jobs", "create-from-file"]],
-)
-def test_help_without_credentials(arguments: list[str]) -> None:
+def run_without_credentials(arguments: list[str]) -> subprocess.CompletedProcess[str]:
     environment = {
         key: value
         for key, value in os.environ.items()
         if not key.startswith(("OPENAI_", "ANTHROPIC_", "AZURE_OPENAI_"))
     }
-    result = subprocess.run(
-        [sys.executable, "-m", "instructor.cli.cli", *arguments, "--help"],
+    return subprocess.run(
+        [sys.executable, "-m", "instructor.cli.cli", *arguments],
         env=environment,
         capture_output=True,
         text=True,
         timeout=20,
     )
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [[], ["files"], ["jobs"], ["files", "upload"], ["jobs", "create-from-file"]],
+)
+def test_help_without_credentials(arguments: list[str]) -> None:
+    result = run_without_credentials([*arguments, "--help"])
     assert result.returncode == 0, result.stderr
     assert "Usage:" in result.stdout
 
@@ -59,3 +63,12 @@ def test_client_creation_is_lazy_and_preserves_injection(
             created.close()
     finally:
         module.client = original
+
+
+@pytest.mark.parametrize(
+    "arguments", [["files", "delete", "file-test"], ["jobs", "cancel", "job-test"]]
+)
+def test_mutating_commands_fail_without_credentials(arguments: list[str]) -> None:
+    result = run_without_credentials(arguments)
+    assert result.returncode != 0, result.stdout
+    assert "OpenAIError" in result.stderr

--- a/tests/packaging/check_package.sh
+++ b/tests/packaging/check_package.sh
@@ -23,6 +23,12 @@ cp "$repo_root/tests/packaging/contract.py" "$tmp_dir/contract.py"
 cd "$tmp_dir"
 unset PYTHONPATH
 "$tmp_dir/.venv/bin/python" -I contract.py
-# CLI modules construct a client at import time, even for help.
-# Use an explicit dummy key so neither user credentials nor CI secrets are needed.
-OPENAI_API_KEY=package-contract "$tmp_dir/.venv/bin/instructor" --help >/dev/null
+# Help must not need credentials or contact a provider.
+unset OPENAI_API_KEY OPENAI_ADMIN_KEY OPENAI_ORG_ID OPENAI_PROJECT_ID
+for command in "" files jobs; do
+    if [ -n "$command" ]; then
+        "$tmp_dir/.venv/bin/instructor" "$command" --help >/dev/null
+    else
+        "$tmp_dir/.venv/bin/instructor" --help >/dev/null
+    fi
+done

--- a/tests/packaging/check_package.sh
+++ b/tests/packaging/check_package.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# The default build creates an sdist, then builds the wheel from that sdist.
+uv build --default-index https://pypi.org/simple --out-dir "$tmp_dir/dist" "$repo_root"
+wheels=("$tmp_dir"/dist/*.whl)
+uv venv --python "${PACKAGE_PYTHON:-3.11}" "$tmp_dir/.venv"
+constraints=()
+if [ "${PACKAGE_SDK:-latest}" = minimum ]; then
+    # Pin the declared SDK/model floors, allowing their transitive dependencies
+    # (notably pydantic-core) to resolve to compatible versions.
+    constraints=("openai==2.0.0" "pydantic==2.8.0")
+fi
+uv pip install --default-index https://pypi.org/simple \
+    --python "$tmp_dir/.venv/bin/python" \
+    "${wheels[0]}${PACKAGE_EXTRAS:+[$PACKAGE_EXTRAS]}" "${constraints[@]}"
+uv pip check --python "$tmp_dir/.venv/bin/python"
+cp "$repo_root/tests/packaging/contract.py" "$tmp_dir/contract.py"
+cd "$tmp_dir"
+unset PYTHONPATH
+"$tmp_dir/.venv/bin/python" -I contract.py
+"$tmp_dir/.venv/bin/instructor" --help >/dev/null

--- a/tests/packaging/check_package.sh
+++ b/tests/packaging/check_package.sh
@@ -23,4 +23,6 @@ cp "$repo_root/tests/packaging/contract.py" "$tmp_dir/contract.py"
 cd "$tmp_dir"
 unset PYTHONPATH
 "$tmp_dir/.venv/bin/python" -I contract.py
-"$tmp_dir/.venv/bin/instructor" --help >/dev/null
+# CLI modules construct a client at import time, even for help.
+# Use an explicit dummy key so neither user credentials nor CI secrets are needed.
+OPENAI_API_KEY=package-contract "$tmp_dir/.venv/bin/instructor" --help >/dev/null

--- a/tests/packaging/contract.py
+++ b/tests/packaging/contract.py
@@ -1,0 +1,66 @@
+"""Offline installed-wheel contracts; run outside the repository checkout."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import importlib.metadata
+import os
+from pathlib import Path
+import sys
+
+import instructor
+import openai
+from pydantic import BaseModel
+
+
+def main() -> None:
+    package = Path(instructor.__file__).resolve().parent
+    assert package.is_relative_to(Path(sys.prefix).resolve()), package
+    assert (package / "py.typed").is_file()
+    assert instructor.__version__ == importlib.metadata.version("instructor")
+
+    # Resolve the public core exports in an environment without dev/provider extras.
+    for name in instructor.__all__:
+        getattr(instructor, name)
+    for module, name in (
+        ("instructor.core.client", "Instructor"),
+        ("instructor.core.client", "AsyncInstructor"),
+        ("instructor.function_calls", "OpenAISchema"),
+        ("instructor.function_calls", "openai_schema"),
+        ("instructor.dsl.partial", "Partial"),
+    ):
+        assert getattr(importlib.import_module(module), name) is getattr(
+            instructor, name
+        )
+
+    class Result(BaseModel):
+        value: int
+
+    schema = instructor.generate_openai_schema(Result)
+    assert schema["parameters"]["required"] == ["value"]
+    assert instructor.response_schema(Result).model_validate({"value": 7}).value == 7
+
+    # Real SDK construction only: no network requests and no real credentials.
+    with openai.OpenAI(api_key="package-contract") as client:
+        assert isinstance(instructor.from_openai(client), instructor.Instructor)
+
+    async def check_async() -> None:
+        async with openai.AsyncOpenAI(api_key="package-contract") as client:
+            assert isinstance(
+                instructor.from_openai(client), instructor.AsyncInstructor
+            )
+
+    asyncio.run(check_async())
+    if os.environ.get("PACKAGE_EXTRAS") == "google-genai":
+        assert callable(instructor.from_genai)
+    else:
+        assert "from_genai" not in instructor.__all__
+        assert "from_anthropic" not in instructor.__all__
+    for name in ("instructor", "openai", "pydantic", "pydantic-core"):
+        print(f"{name}=={importlib.metadata.version(name)}")
+    print(f"Installed-wheel contracts passed on Python {sys.version.split()[0]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/typing/check_installed_package.sh
+++ b/tests/typing/check_installed_package.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
 tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
 
 uv build --default-index https://pypi.org/simple --wheel \
     --out-dir "$tmp_dir/dist" "$repo_root"
@@ -14,11 +15,12 @@ uv pip install --default-index https://pypi.org/simple \
     --python "$tmp_dir/.venv/bin/python" \
     "${wheels[0]}" "ty==0.0.44" typing_extensions
 
-VIRTUAL_ENV="$tmp_dir/.venv" "$tmp_dir/.venv/bin/python" -c \
+cd "$tmp_dir"
+unset PYTHONPATH
+VIRTUAL_ENV="$tmp_dir/.venv" "$tmp_dir/.venv/bin/python" -I -c \
     'from importlib.util import find_spec; from pathlib import Path; spec = find_spec("instructor"); assert spec is not None and spec.submodule_search_locations is not None; assert (Path(next(iter(spec.submodule_search_locations))) / "py.typed").is_file()'
 
 cp "$repo_root/tests/typing/test_installed_package.py" "$tmp_dir/test_installed_package.py"
 
-cd "$tmp_dir"
 VIRTUAL_ENV="$tmp_dir/.venv" "$tmp_dir/.venv/bin/ty" check \
     --error-on-warning test_installed_package.py

--- a/uv.lock
+++ b/uv.lock
@@ -1979,6 +1979,7 @@ dependencies = [
     { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.10'" },
     { name = "rich" },
     { name = "tenacity" },
+    { name = "tqdm" },
     { name = "typer" },
     { name = "urllib3", version = "2.7.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.10'" },
 ]
@@ -2154,6 +2155,7 @@ requires-dist = [
     { name = "sqlmodel", marker = "extra == 'sqlmodel'", specifier = ">=0.0.22,<1.0.0" },
     { name = "tabulate", marker = "extra == 'test-docs'", specifier = ">=0.9.0,<1.0.0" },
     { name = "tenacity", specifier = ">=8.2.3,<10.0.0" },
+    { name = "tqdm", specifier = ">=4.27.0,<5.0.0" },
     { name = "trafilatura", marker = "extra == 'trafilatura'", specifier = ">=1.12.2,<3.0.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.44" },
     { name = "typer", specifier = ">=0.9.0,<1.0.0" },


### PR DESCRIPTION
## Problem and change

Clean OpenAI 3 installations could not start the CLI: Instructor imports `tqdm` without declaring it, and files/jobs created OpenAI clients at import time, preventing even `--help` without credentials.

- Declare the existing CLI dependency directly. All locked package versions are retained; the requirements export changes dependency annotations only.
- Defer files/jobs client creation until an operation needs it. Each module retains its injectable `client` and a small cached getter; real SDK creation failures propagate from operations, and existing command request/exception handling remains in place. No generic client framework.
- Add a five-row read-only package workflow: build sdist → wheel, install outside the checkout, verify dependency consistency, `py.typed`, version metadata, public exports, selected aliases, schema helpers, real sync/async client construction, and top-level/files/jobs help with OpenAI credentials removed.
- Move the existing installed-wheel typing-marker assertion outside the checkout and run isolated Python. Previously it could inspect the checkout's marker instead of the wheel. Temporary environments are cleaned up on exit.

## Before/after evidence

Base: `6969bb6849c49bf742fcdbfec7e969cfd5046274`.

The clean OpenAI 3 package reproduced `ModuleNotFoundError: No module named 'tqdm'`; OpenAI 2 masked it through its transitive dependency. Separately, all five credential-free subprocess help cases failed before the lazy-client correction and passed after: root, files, jobs, files upload, and jobs create-from-file.

Focused CLI checks also exercise real SDK lazy creation, reuse, injected-client identity, and missing-credential operation errors without making provider requests. No new mocks.

All five final package combinations, including credential-free root/files/jobs help, passed locally on macOS:

| Python | OpenAI | Pydantic | pydantic-core | Extras |
| --- | --- | --- | --- | --- |
| 3.9.6 | 2.0.0 | 2.8.0 | 2.20.0 | none |
| 3.9.6 | 2.48.0 | 2.13.5 | 2.46.5 | none |
| 3.11.11 | 3.3.0 | 2.13.5 | 2.46.5 | none |
| 3.14.5 | 3.3.0 | 2.13.5 | 2.46.5 | none |
| 3.11.11 | 3.3.0 | 2.13.5 | 2.46.5 | google-genai |

Reproduce: `PACKAGE_PYTHON=3.9 PACKAGE_SDK=minimum tests/packaging/check_package.sh`; select another Python and omit SDK selection for latest compatible. Set `PACKAGE_EXTRAS=google-genai` for the optional row.

Validation:
- CLI tests plus release-preparation tests: 18 passed on `d5e73dc1588003011a641956e5afbcc30aa08fd6`.
- Existing installed-wheel public typing contract: passed on the final CLI-fix head; production and focused-test ty checks pass.
- Ruff lint/format, ShellCheck, workflow YAML parsing, `git diff --check`: passed.
- Lock validation, frozen all-extras installation and commit hooks passed without bypasses.
- GitHub evidence at `a1a49ddae5ac9ea55fcf96c7f53d7362b48ecec1` (before the exit-status correction): package matrix: all five rows passed ([run](https://github.com/567-labs/instructor/actions/runs/34308484737)); Ruff and ty passed. Full Test workflow finished: Core Tests, Full Coverage, and offline coverage on Python 3.9–3.13 passed. The Other provider job failed only in the live documented Google model check (`google/gemini-3.8-flash`) with `[Errno 104] Connection reset by peer`; that step reports 4 passed, 9 credentials-missing skips, 1 failed. Downstream provider/auto-client jobs were consequently skipped. [Run](https://github.com/567-labs/instructor/actions/runs/34308484842). No paid retry or test weakening was performed.

## Release boundary and scope

CONTRIBUTING documents the existing event trap: a release created with `github.token` does not trigger the separate `release: published` PyPI workflow. [Official GitHub documentation](https://docs.github.com/en/actions/concepts/security/github_token). No publishing triggers, credentials, permissions or pinned Actions change; no test tags, releases or uploads were created.

Merged fresh main (`d99b6a36c6d7193e505818aa17375f65ed2c9e71`, #2628) without rewriting branch history. The release target is now 1.17.1, and this PR’s CLI fix note is under that existing section with its verified upgrade notes unchanged. Release validation remains enabled; the prior 1.17.0 tag mismatch is historical evidence, not a claimed current failure.

Reviewed #2553/#2583 and coordinated with provider CI ownership. `test.yml`, provider behavior and token accounting are untouched.

## Simplification and limits

One parameterized smoke entrypoint serves five explicit rows and a shared Python contract. The typing entrypoint remains separate to avoid adding ty to core-only runtime environments. The CLI getters preserve independent module injection without a generic abstraction. No test row or isolation assertion was removed during simplification.

Latest means fresh compatible resolution; future upstream changes can fail the jobs. The floor row pins only OpenAI/Pydantic, not all transitive dependencies; old Pydantic is not combined with Python 3.14. Other optional SDK floors, every intermediate Python version and Windows remain untested by this matrix. macOS system Python 3.9 emits an existing urllib3/LibreSSL warning. These are offline installation and CLI contracts, not live-provider certification or a security audit. The release-event handoff still needs a separately reviewed publishing change.



### Client initialization exit status

`files delete` and `jobs cancel` now resolve the lazy client before their existing request-error handlers. Missing credentials therefore propagate as an SDK initialization error and a nonzero process exit; existing API-request error handling stays intact. Two credential-free subprocess regressions reproduced exit 0 before the correction and pass after. The help and command tests share one subprocess setup helper. Production/test types, lint, formatting, all 18 focused tests and commit hooks pass. Normal CI runs on the new commit; no standalone paid retry was requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging, CI, and CLI startup behavior changes with targeted tests; core library request paths are unchanged aside from deferred client construction in two CLI modules.
> 
> **Overview**
> Fixes **clean installs** where the CLI could crash on missing `tqdm` (notably with OpenAI 3, which no longer pulls it in transitively) by declaring `tqdm` in core dependencies, and makes **`files` / `jobs` help usable without API keys** by lazily creating the OpenAI client only when a command actually runs.
> 
> Adds **installed-package CI**: build sdist → wheel, install outside the repo, run `uv pip check`, an offline import/schema/client contract, and credential-free `instructor` help across Python 3.9–3.14 (minimum OpenAI/Pydantic floors plus latest resolution, including optional `google-genai`). Tightens the existing installed-wheel typing check to run isolated from the checkout. **CONTRIBUTING** documents the matrix and clarifies that GitHub releases created with `github.token` do not auto-trigger PyPI publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5e73dc1588003011a641956e5afbcc30aa08fd6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


Merged-head validation at `6543e662bfcfdfd8e0365a37a8272da16a7b3fb1`: 18 focused CLI/release tests passed with credential-shaped environment variables removed and repository dotenv loading disabled (`--noconftest`, `PYTHON_DOTENV_DISABLED=1`). Production/focused-test types, lint, formatting and normal merge hooks passed. New-head GitHub CI is queued/in progress; no standalone provider rerun was requested.
