### PR TITLE
fix: prepare 1.17.1 streaming, GenAI and documentation consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Upgrade Notes
 - GenAI tools and JSON requests now raise `IncompleteOutputException` for non-streaming output marked `MAX_TOKENS`, even if the partial payload fits schema defaults. Increase the output-token budget or handle incomplete output explicitly.
-- Requests containing non-string mapping keys in cache identity data bypass caching rather than sharing a key with a different request. Ordinary string-keyed mappings continue to be cached.
+- Ordinary dictionaries containing non-string keys, including nested dictionaries, bypass caching. Pydantic models use their JSON-serialized representation for cache identity, which does not preserve every distinction between original Python key types.
 
 ### Fixed
 - **Partial streaming**: Preserve model instances inside nullable list fields in sync and async streams, while retaining validation context and final validation. ([#2600](https://github.com/567-labs/instructor/pull/2600))
@@ -22,7 +22,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - **Documentation links**: Repair context-validation, quick-start and example links, and use the correct relative API link in the provider documentation template. Consolidates [#2599](https://github.com/567-labs/instructor/pull/2599), [#2609](https://github.com/567-labs/instructor/pull/2609), [#2610](https://github.com/567-labs/instructor/pull/2610) and [#2611](https://github.com/567-labs/instructor/pull/2611).
 
 ### Security
-- **Cache identity**: Prevent string and non-string mapping keys from producing the same cache key, including nested mappings and serialized Pydantic values. Requests with unsupported identities bypass caching. ([#2614](https://github.com/567-labs/instructor/pull/2614))
+- **Cache identity**: Bypass caching for ordinary dictionaries containing non-string keys, including nested dictionaries, to prevent key collisions before serialization. ([#2614](https://github.com/567-labs/instructor/pull/2614))
 
 ### Changed
 - Consolidate duplicate helpers and utility tests while preserving public compatibility, and separate token-budget policy from retry execution without changing budget arithmetic or retry behavior. ([#2616](https://github.com/567-labs/instructor/pull/2616), [#2617](https://github.com/567-labs/instructor/pull/2617))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,23 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-09-09
+
+### Upgrade Notes
+- GenAI tools and JSON requests now raise `IncompleteOutputException` for non-streaming output marked `MAX_TOKENS`, even if the partial payload fits schema defaults. Increase the output-token budget or handle incomplete output explicitly.
+- Requests containing non-string mapping keys in cache identity data bypass caching rather than sharing a key with a different request. Ordinary string-keyed mappings continue to be cached.
+
 ### Fixed
 - **Partial streaming**: Preserve model instances inside nullable list fields in sync and async streams, while retaining validation context and final validation. ([#2600](https://github.com/567-labs/instructor/pull/2600))
 - **GenAI truncation**: Raise `IncompleteOutputException` for non-streaming tools and JSON responses ending with `MAX_TOKENS`, instead of accepting schema defaults for missing output. ([#2601](https://github.com/567-labs/instructor/pull/2601))
 - **GenAI templating**: Preserve text-part metadata, including thought flags and signatures, without modifying caller-owned conversation history. ([#2607](https://github.com/567-labs/instructor/issues/2607), [#2608](https://github.com/567-labs/instructor/pull/2608))
 - **Documentation links**: Repair context-validation, quick-start and example links, and use the correct relative API link in the provider documentation template. Consolidates [#2599](https://github.com/567-labs/instructor/pull/2599), [#2609](https://github.com/567-labs/instructor/pull/2609), [#2610](https://github.com/567-labs/instructor/pull/2610) and [#2611](https://github.com/567-labs/instructor/pull/2611).
+
+### Security
+- **Cache identity**: Prevent string and non-string mapping keys from producing the same cache key, including nested mappings and serialized Pydantic values. Requests with unsupported identities bypass caching. ([#2614](https://github.com/567-labs/instructor/pull/2614))
+
+### Changed
+- Consolidate duplicate helpers and utility tests while preserving public compatibility, and separate token-budget policy from retry execution without changing budget arithmetic or retry behavior. ([#2616](https://github.com/567-labs/instructor/pull/2616), [#2617](https://github.com/567-labs/instructor/pull/2617))
 
 ## [1.17.0] - 2026-09-04
 
@@ -344,6 +356,7 @@ previous published version is 1.16.0.
 ### Fixed
 - Pydantic v2 deprecation warnings resolved by migrating from class `Config` to `ConfigDict` ([#1782](https://github.com/567-labs/instructor/pull/1782))
 
-[Unreleased]: https://github.com/567-labs/instructor/compare/v1.17.0...HEAD
+[Unreleased]: https://github.com/567-labs/instructor/compare/v1.18.0...HEAD
+[1.18.0]: https://github.com/567-labs/instructor/compare/v1.17.0...v1.18.0
 [1.17.0]: https://github.com/567-labs/instructor/compare/v1.16.0...v1.17.0
 [1.16.0]: https://github.com/567-labs/instructor/compare/v1.15.4...v1.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Partial streaming**: Preserve model instances inside nullable list fields in sync and async streams, while retaining validation context and final validation. ([#2600](https://github.com/567-labs/instructor/pull/2600))
+- **GenAI truncation**: Raise `IncompleteOutputException` for non-streaming tools and JSON responses ending with `MAX_TOKENS`, instead of accepting schema defaults for missing output. ([#2601](https://github.com/567-labs/instructor/pull/2601))
+- **GenAI templating**: Preserve text-part metadata, including thought flags and signatures, without modifying caller-owned conversation history. ([#2607](https://github.com/567-labs/instructor/issues/2607), [#2608](https://github.com/567-labs/instructor/pull/2608))
+- **Documentation links**: Repair context-validation, quick-start and example links, and use the correct relative API link in the provider documentation template. Consolidates [#2599](https://github.com/567-labs/instructor/pull/2599), [#2609](https://github.com/567-labs/instructor/pull/2609), [#2610](https://github.com/567-labs/instructor/pull/2610) and [#2611](https://github.com/567-labs/instructor/pull/2611).
+
 ## [1.17.0] - 2026-09-04
 
 Includes the fixes previously planned for 1.16.1, which was not published. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
-## [1.18.0] - 2026-09-09
+## [1.17.1] - 2026-09-09
 
 ### Upgrade Notes
 - GenAI tools and JSON requests now raise `IncompleteOutputException` for non-streaming output marked `MAX_TOKENS`, even if the partial payload fits schema defaults. Increase the output-token budget or handle incomplete output explicitly.
@@ -356,7 +356,7 @@ previous published version is 1.16.0.
 ### Fixed
 - Pydantic v2 deprecation warnings resolved by migrating from class `Config` to `ConfigDict` ([#1782](https://github.com/567-labs/instructor/pull/1782))
 
-[Unreleased]: https://github.com/567-labs/instructor/compare/v1.18.0...HEAD
-[1.18.0]: https://github.com/567-labs/instructor/compare/v1.17.0...v1.18.0
+[Unreleased]: https://github.com/567-labs/instructor/compare/v1.17.1...HEAD
+[1.17.1]: https://github.com/567-labs/instructor/compare/v1.17.0...v1.17.1
 [1.17.0]: https://github.com/567-labs/instructor/compare/v1.16.0...v1.17.0
 [1.16.0]: https://github.com/567-labs/instructor/compare/v1.15.4...v1.16.0

--- a/NEW_PROVIDER_AGENT_INSTRUCTIONS.md
+++ b/NEW_PROVIDER_AGENT_INSTRUCTIONS.md
@@ -4,7 +4,7 @@
 
 Copy these instructions to your AI coding agent when you want to add a new LLM provider to instructor. The agent will have everything needed to implement a complete, working provider.
 
-**For human contributors:** See the quick reference template in [`instructor/providers/README.md`](instructor/providers/README.md#adding-a-new-provider)
+**For human contributors:** See [Adding a New Provider](instructor/v2/README.md#adding-a-new-provider).
 
 ---
 
@@ -734,7 +734,7 @@ client = instructor.from_{provider}({provider_sdk}.{SyncClient}())
 
 ## API Reference
 
-For detailed API documentation, see the [Instructor API reference](../api/index.md).
+For detailed API documentation, see the [Instructor API reference](../api.md).
 ```
 
 ## Example Provider: Groq

--- a/docs/concepts/citation.md
+++ b/docs/concepts/citation.md
@@ -185,6 +185,6 @@ Use CitationMixin when:
 ## See Also
 
 - [Validation](./validation.md) - Learn about validation in Instructor
-- [Context-Based Validation](./validation.md#context-based-validation) - Using context for validation
+- [Context-Based Validation](./reask_validation.md#using-context-for-dynamic-validation) - Using context for validation
 - [Citation Examples](../examples/exact_citations.md) - More citation examples
 - [RAG Patterns](../blog/posts/rag-and-beyond.md) - Building RAG systems with Instructor

--- a/docs/integrations/bedrock.md
+++ b/docs/integrations/bedrock.md
@@ -21,7 +21,7 @@ pip install "instructor[bedrock]"
 - [from_provider Guide](../concepts/from_provider.md) - Detailed client configuration
 - [Mode Migration Guide](../concepts/mode-migration.md) - Move to core modes
 - [Provider Examples](../index.md#provider-examples) - Quick examples for all providers
-- [AWS Integration Guide](../examples/index.md#aws-integration) - More AWS examples
+- [Examples](../examples/index.md) - Browse extraction examples
 
 # AWS Bedrock
 

--- a/docs/integrations/sambanova.md
+++ b/docs/integrations/sambanova.md
@@ -8,7 +8,7 @@ description: Use Instructor with SambaNova's LLM API for structured outputs.
 - [Getting Started](../getting-started.md) - Quick start guide
 - [from_provider Guide](../concepts/from_provider.md) - Detailed client configuration
 - [Provider Examples](../index.md#provider-examples) - Quick examples for all providers
-- [Enterprise Integration](../examples/index.md#enterprise-integration) - More enterprise examples
+- [Examples](../examples/index.md) - Browse extraction examples
 
 # SambaNova Integration
 

--- a/docs/prompting/ensembling/more.md
+++ b/docs/prompting/ensembling/more.md
@@ -6,7 +6,7 @@ Language Models struggle to generalize across question types that require distin
 
 In the original paper, they utilise four different experts
 
-1. Factual Expert : This is a model that is augmented by a RAG prompting pipeline. WHen it receives a query, it retrieves the top 10 most relevant passages from Wikipedia and appends them to the prompt right before the question.
+1. Factual Expert : This is a model that is augmented by a RAG prompting pipeline. When it receives a query, it retrieves the top 10 most relevant passages from Wikipedia and appends them to the prompt right before the question.
 
 2. Multihop Expert : This is an expert that has manually written rationales after each demo to elicit multi-step reasoning processes for the questions
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -234,4 +234,4 @@ Let's be clear - you might not need Instructor if:
 
 For everyone else building production LLM applications, Instructor is the obvious choice.
 
-[Get Started →](index.md#quick-start-extract-structured-data-in-3-lines){ .md-button .md-button--primary }
+[Get Started →](index.md#quick-start){ .md-button .md-button--primary }

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -66,7 +66,7 @@ if TYPE_CHECKING:
         openai_moderation as openai_moderation,
     )
 
-__version__ = "1.17.0"
+__version__ = "1.18.0"
 
 __all__ = [
     "Instructor",

--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -66,7 +66,7 @@ if TYPE_CHECKING:
         openai_moderation as openai_moderation,
     )
 
-__version__ = "1.18.0"
+__version__ = "1.17.1"
 
 __all__ = [
     "Instructor",

--- a/instructor/v2/dsl/partial.py
+++ b/instructor/v2/dsl/partial.py
@@ -231,6 +231,13 @@ def _build_partial_list(
         field_info = original_model.model_fields.get(field_name)
         if field_info:
             field_type = field_info.annotation
+            if get_origin(field_type) in UNION_ORIGINS:
+                non_none_args = [
+                    arg for arg in get_args(field_type) if arg is not type(None)
+                ]
+                # Only unwrap a nullable container with one unambiguous type.
+                if len(non_none_args) == 1:
+                    field_type = non_none_args[0]
             if get_origin(field_type) in (list, List):  # noqa: UP006
                 args = get_args(field_type)
                 if args:

--- a/instructor/v2/providers/genai/handlers.py
+++ b/instructor/v2/providers/genai/handlers.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 from pydantic import BaseModel
 
 from instructor.v2.core.decorators import register_mode_handler
+from instructor.v2.core.errors import IncompleteOutputException
 from instructor.v2.core.handler import ModeHandler
 from instructor.v2.core.mode import Mode
 from instructor.v2.core.multimodal import extract_genai_multimodal_content
@@ -318,6 +319,19 @@ class GenAIHandlerBase(ModeHandler):
             if issubclass(response_model, IterableBase):
                 return generator
             return list(generator)
+
+        # A response truncated at max_tokens is not evaluable: the model never
+        # emitted the remaining fields, so parsing it yields schema defaults that
+        # are indistinguishable from values the model actually chose.
+        # Restores the check shipped in v1.15.0 (#2232), dropped by 60cc815.
+        from google.genai import types as genai_types
+
+        candidates = getattr(response, "candidates", None)
+        if (
+            candidates
+            and candidates[0].finish_reason == genai_types.FinishReason.MAX_TOKENS
+        ):
+            raise IncompleteOutputException(last_completion=response)
 
         if self.mode == Mode.TOOLS:
             model = parse_genai_tools(

--- a/instructor/v2/providers/genai/templating.py
+++ b/instructor/v2/providers/genai/templating.py
@@ -17,7 +17,7 @@ def process_message(
         role=message.role,
         parts=[
             (
-                types.Part.from_text(text=apply_template(part.text, context))
+                part.model_copy(update={"text": apply_template(part.text, context)})
                 if isinstance(getattr(part, "text", None), str)
                 else part
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "regex>=2023.0.0,<2027.0.0",
 ]
 name = "instructor"
-version = "1.18.0"
+version = "1.17.1"
 description = "structured outputs for llm"
 readme = "README.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "regex>=2023.0.0,<2027.0.0",
 ]
 name = "instructor"
-version = "1.17.0"
+version = "1.18.0"
 description = "structured outputs for llm"
 readme = "README.md"
 

--- a/tests/dsl/test_partial_optional_lists.py
+++ b/tests/dsl/test_partial_optional_lists.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any, List, Optional, Union, cast  # noqa: UP035
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError, ValidationInfo, field_validator
+
+from instructor.v2.dsl.partial import Partial
+
+
+class Item(BaseModel):
+    name: str
+    age: int
+
+    @field_validator("name")
+    @classmethod
+    def uppercase_name(cls, value: str, info: ValidationInfo) -> str:
+        return (
+            value.upper() if info.context and info.context.get("uppercase") else value
+        )
+
+
+class PlainEnvelope(BaseModel):
+    items: list[Item]
+    note: str
+
+
+class OptionalEnvelope(BaseModel):
+    items: Optional[list[Item]] = None  # noqa: UP007, UP045
+    note: str
+
+
+class LegacyEnvelope(BaseModel):
+    items: Optional[List[Item]] = None  # noqa: UP006, UP007, UP045
+    note: str
+
+
+class UnionEnvelope(BaseModel):
+    items: list[Item] | None = None
+    note: str
+
+
+ENVELOPES = [PlainEnvelope, OptionalEnvelope, LegacyEnvelope, UnionEnvelope]
+NULLABLE_ENVELOPES = ENVELOPES[1:]
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.parametrize("asynchronous", [False, True], ids=["sync", "async"]),
+]
+
+
+async def stream(
+    schema: type[BaseModel],
+    chunks: list[str],
+    asynchronous: bool,
+    **kwargs: Any,
+) -> AsyncGenerator[Any, None]:
+    # Partial adds these streaming methods dynamically.
+    api = cast(Any, Partial[schema])
+    if asynchronous:
+
+        async def source() -> AsyncGenerator[str, None]:
+            for chunk in chunks:
+                yield chunk
+
+        async for obj in api.model_from_chunks_async(source(), **kwargs):
+            yield obj
+    else:
+        for obj in api.model_from_chunks(iter(chunks), **kwargs):
+            yield obj
+
+
+@pytest.mark.parametrize("schema", ENVELOPES)
+async def test_incremental_items_remain_models(
+    schema: type[BaseModel], asynchronous: bool
+) -> None:
+    chunks = [
+        '{"items":[{"name":"Alice","age":30},',
+        '{"name":"Bo',
+        'b","age":40}]',
+        ',"note":"done"}',
+    ]
+    outputs = [obj async for obj in stream(schema, chunks, asynchronous)]
+    assert len(outputs) == len(chunks)
+    assert isinstance(outputs[0].items[0], Item)
+    assert outputs[0].items[0].name == "Alice"
+    assert outputs[0].note is None
+    assert isinstance(outputs[1].items[1], Item)
+    assert outputs[1].items[1].name == "Bo"
+    assert outputs[1].items[1].age is None
+    assert isinstance(outputs[2].items[1], Item)
+    assert outputs[2].items[1].name == "Bob"
+    assert outputs[2].note is None
+    assert outputs[-1] == schema.model_validate_json("".join(chunks))
+
+
+@pytest.mark.parametrize("schema", NULLABLE_ENVELOPES)
+@pytest.mark.parametrize(
+    ("start", "expected"),
+    [('{"items":null,', None), ('{"items":[],', []), ("{", None)],
+)
+async def test_null_empty_and_missing(
+    schema: type[BaseModel], start: str, expected: Any, asynchronous: bool
+) -> None:
+    outputs = [
+        obj async for obj in stream(schema, [start, '"note":"done"}'], asynchronous)
+    ]
+    assert outputs[0].items == expected
+    assert outputs[-1].items == expected
+
+
+async def test_missing_default_factory(asynchronous: bool) -> None:
+    class Envelope(BaseModel):
+        items: Optional[list[Item]] = Field(default_factory=list)  # noqa: UP007, UP045
+        note: str
+
+    outputs = [
+        obj async for obj in stream(Envelope, ["{", '"note":"done"}'], asynchronous)
+    ]
+    assert outputs[0].items == []
+    assert outputs[-1].items == []
+
+
+@pytest.mark.parametrize("schema", ENVELOPES)
+async def test_validation_context_reaches_complete_item(
+    schema: type[BaseModel], asynchronous: bool
+) -> None:
+    # The tracker marks items complete once the next field starts.
+    chunks = ['{"items":[{"name":"Alice","age":30}],"note":"d', 'one"}']
+    outputs = [
+        obj
+        async for obj in stream(
+            schema, chunks, asynchronous, context={"uppercase": True}
+        )
+    ]
+    assert outputs[0].items[0].name == "ALICE"
+    assert outputs[0].note == "d"
+    assert outputs[-1].items[0].name == "ALICE"
+
+
+@pytest.mark.parametrize("schema", ENVELOPES)
+async def test_complete_item_is_validated_before_root(
+    schema: type[BaseModel], asynchronous: bool
+) -> None:
+    with pytest.raises(ValidationError, match="age"):
+        async for _ in stream(
+            schema, ['{"items":[{"name":"Alice"}],"note":"d'], asynchronous
+        ):
+            pass
+
+
+@pytest.mark.parametrize("schema", ENVELOPES)
+async def test_final_validation_still_requires_note(
+    schema: type[BaseModel], asynchronous: bool
+) -> None:
+    with pytest.raises(ValidationError, match="note"):
+        async for _ in stream(
+            schema, ['{"items":[{"name":"Alice","age":30}]}'], asynchronous
+        ):
+            pass
+
+
+async def test_optional_items_and_ambiguous_collections(asynchronous: bool) -> None:
+    class OptionalItems(BaseModel):
+        items: Optional[list[Optional[Item]]] = None  # noqa: UP007, UP045
+        note: str
+
+    chunks = ['{"items":[null,{"name":"Alice","age":30}],', '"note":"done"}']
+    outputs = [obj async for obj in stream(OptionalItems, chunks, asynchronous)]
+    assert outputs[0].items[0] is None
+    assert isinstance(outputs[0].items[1], Item)
+    assert outputs[-1].items[0] is None
+
+    class OtherItem(BaseModel):
+        label: str
+
+    class AmbiguousEnvelope(BaseModel):
+        items: Union[list[Item], list[OtherItem], None] = None  # noqa: UP007
+        note: str
+
+    chunks = ['{"items":[{"label":"other"}],', '"note":"done"}']
+    outputs = [obj async for obj in stream(AmbiguousEnvelope, chunks, asynchronous)]
+    assert outputs[0].items == [{"label": "other"}]
+    assert isinstance(outputs[-1].items[0], OtherItem)

--- a/tests/processing/test_formatting.py
+++ b/tests/processing/test_formatting.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from jinja2.exceptions import SecurityError
 from instructor.templating import handle_templating
@@ -166,3 +168,39 @@ def test_handle_templating_with_genai_multimodal_parts():
     assert processed.parts[0].text == "Describe this image"
     assert processed.parts[1].text is None
     assert processed.parts[1].file_data.file_uri == "gs://example/cat.png"
+
+
+@pytest.mark.parametrize("thought", [True, False, None])
+@pytest.mark.parametrize("text", ["The previous response.", ""])
+def test_handle_templating_preserves_genai_text_part_metadata(
+    thought: bool | None, text: str
+) -> None:
+    from google.genai import types
+
+    history = types.Content(
+        role="model",
+        parts=[
+            types.Part(
+                text=text,
+                thought=thought,
+                thought_signature=b"previous-response-signature",
+            )
+        ],
+    )
+    user = types.Content(
+        role="user",
+        parts=[types.Part.from_text(text="Describe {{ subject }}")],
+    )
+    original_history = history.model_dump()
+    original_user = user.model_dump()
+
+    result = handle_templating(
+        {"contents": [history, user]},
+        Mode.GENAI_TOOLS,
+        {"subject": "this image"},
+    )
+
+    assert result["contents"][0].model_dump() == original_history
+    assert result["contents"][1].parts[0].text == "Describe this image"
+    assert history.model_dump() == original_history
+    assert user.model_dump() == original_user

--- a/tests/test_genai_truncation.py
+++ b/tests/test_genai_truncation.py
@@ -1,0 +1,136 @@
+from typing import Optional
+
+import pytest
+
+
+pytest.importorskip("google.genai")
+
+
+from google.genai import types
+from pydantic import BaseModel
+
+from instructor.v2.core.errors import IncompleteOutputException
+from instructor.v2.core.mode import Mode
+from instructor.v2.providers.genai.handlers import (
+    GenAIStructuredOutputsHandler,
+    GenAIToolsHandler,
+)
+
+
+class Order(BaseModel):
+    drug: str
+    dose_mg: int
+    contraindications: Optional[str] = None
+
+
+def _response(
+    finish_reason: types.FinishReason, *, tools: bool
+) -> types.GenerateContentResponse:
+    """A response whose payload parses cleanly but may have been truncated."""
+    if tools:
+        part = types.Part.from_function_call(
+            name="Order", args={"drug": "warfarin", "dose_mg": 10}
+        )
+    else:
+        part = types.Part(text='{"drug": "warfarin", "dose_mg": 10}')
+    return types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(role="model", parts=[part]),
+                finish_reason=finish_reason,
+            )
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "handler_cls, mode, tools",
+    [
+        (GenAIToolsHandler, Mode.TOOLS, True),
+        (GenAIStructuredOutputsHandler, Mode.JSON, False),
+    ],
+)
+def test_truncated_response_raises(handler_cls, mode, tools):
+    """A response cut off at max_tokens is unevaluable and must not be parsed.
+
+    The remaining fields were never emitted, so parsing yields schema defaults
+    indistinguishable from values the model actually chose.
+    """
+    handler = handler_cls(mode=mode)
+    with pytest.raises(IncompleteOutputException):
+        handler.parse_response(
+            response_model=Order,
+            response=_response(types.FinishReason.MAX_TOKENS, tools=tools),
+        )
+
+
+@pytest.mark.parametrize(
+    "handler_cls, mode, tools",
+    [
+        (GenAIToolsHandler, Mode.TOOLS, True),
+        (GenAIStructuredOutputsHandler, Mode.JSON, False),
+    ],
+)
+def test_complete_response_still_parses(handler_cls, mode, tools):
+    """A response that finished normally is unaffected."""
+    handler = handler_cls(mode=mode)
+    result = handler.parse_response(
+        response_model=Order,
+        response=_response(types.FinishReason.STOP, tools=tools),
+    )
+    assert result.drug == "warfarin"
+    assert result.dose_mg == 10
+
+
+@pytest.mark.parametrize(
+    "handler_cls, mode, tools",
+    [
+        (GenAIToolsHandler, Mode.TOOLS, True),
+        (GenAIStructuredOutputsHandler, Mode.JSON, False),
+    ],
+)
+@pytest.mark.parametrize(
+    "finish_reason",
+    [types.FinishReason.SAFETY, None],
+    ids=["safety", "unset"],
+)
+def test_non_truncation_finish_reasons_are_not_incomplete(
+    handler_cls, mode, tools, finish_reason
+):
+    """Only MAX_TOKENS means truncation.
+
+    A SAFETY block and an unset finish_reason are different conditions and must
+    not be reported as incomplete output, or callers lose the ability to tell
+    them apart.
+    """
+    handler = handler_cls(mode=mode)
+    result = handler.parse_response(
+        response_model=Order,
+        response=_response(finish_reason, tools=tools),
+    )
+    assert result.drug == "warfarin"
+
+
+@pytest.mark.parametrize(
+    "handler_cls, mode",
+    [
+        (GenAIToolsHandler, Mode.TOOLS),
+        (GenAIStructuredOutputsHandler, Mode.JSON),
+    ],
+)
+def test_empty_candidates_does_not_raise_incomplete_output(handler_cls, mode):
+    """An empty candidate list is not a truncated response.
+
+    The guard must tolerate it rather than indexing into it; whatever the
+    downstream parser already did with this input is unchanged.
+    """
+    handler = handler_cls(mode=mode)
+    empty = types.GenerateContentResponse(candidates=[])
+    with pytest.raises(Exception) as excinfo:
+        handler.parse_response(response_model=Order, response=empty)
+    assert not isinstance(excinfo.value, IncompleteOutputException), (
+        f"empty candidates reported as truncation: {excinfo.value!r}"
+    )
+    assert not isinstance(excinfo.value, IndexError), (
+        f"guard indexed into an empty candidate list: {excinfo.value!r}"
+    )

--- a/tests/v2/test_security_regressions.py
+++ b/tests/v2/test_security_regressions.py
@@ -306,7 +306,13 @@ def test_anthropic_pdf_url_control():
 
 
 def test_json_extraction_bounds_and_recovery():
+    at_limit = "[" * 128 + "]" * 128
+    assert extract_json_from_codeblock(at_limit) == at_limit
     with pytest.raises(ValueError, match="nesting"):
+        extract_json_from_codeblock("[" * 129 + "]" * 129)
+    # Decoder recursion limits vary by Python version; malformed input must
+    # still be rejected by either the nesting or bounded-work guard.
+    with pytest.raises(ValueError, match="nesting|malformed-input work limit"):
         extract_json_from_codeblock("[" * 2000)
     with pytest.raises(ValueError, match="character limit"):
         extract_json_from_codeblock("x" * (1024 * 1024 + 1))

--- a/uv.lock
+++ b/uv.lock
@@ -1960,7 +1960,7 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.18.0"
+version = "1.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp", version = "3.12.15", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.10'" },

--- a/uv.lock
+++ b/uv.lock
@@ -1960,7 +1960,7 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.17.0"
+version = "1.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp", version = "3.12.15", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary

- Prepare consistent1.17.1 project/runtime/lock metadata and dated draft release notes, with no dependency changes or publication. Notes currently cover this branch and already-merged #2614/#2616/#2617; other release candidates must still land and be added before final release approval.
- Preserve Pydantic model instances in nullable-list partial streams, including validation context and final validation.
- Reject truncated non-streaming GenAI tools/JSON output before missing fields can silently become schema defaults.
- Preserve GenAI text-part metadata and caller-owned conversation history during templating.
- Consolidate overlapping documentation link fixes and correct the API link relative to the generated provider-doc location.
- Test the actual JSON depth boundary independently from Python-version-specific decoder behavior on malformed input; runtime resource limits are unchanged.

## Consolidated Contributions

#2600, #2601, #2608, #2599, #2609, #2610 and #2611. Original contributors are credited in the commit. #2611 duplicates three #2599 hunks; #2610's spelling change already exists on main, while its remaining capitalization fix is retained. The context-validation target from #2599 is preserved. #2609's generated-template path is corrected rather than copied literally.

Fixes #2607 when merged. Original PRs remain open until the consolidated result is accepted; no claim that this draft is released.

## Validation

- Full offline selection matching CI, with no provider credentials: **3,217 passed, 199 skipped, 849 deselected** on Python3.11 and Python3.13.
- Python3.11 branch/statement coverage **99.9689%**, **zero missing statements**, four partial branches; unchanged CI thresholds/exclusions.
- Focused external-fix tests:79 passed after integration.
- Release-metadata validator and all8 helper tests pass; version-only lock check and every commit hook pass.
- Documentation lint selection:28 passed,11 skipped,766 deselected. Changed link destinations/headings verified.
- Library and test typing passes, including checked Python3.9 library and Python3.14 test targets; Ruff/format for instructor, examples and tests passes; whitespace clean.
- Broad `ruff check .` also inspected:36 existing findings in untouched notebooks/maintenance scripts; no unrelated rewrite included.

The original JSON bounds test failed on baseline Python3.13 because malformed input reaches the bounded-work guard instead of decoder recursion. The replacement still rejects malformed input and adds explicit acceptance at128 levels and rejection at129. Python3.11 and3.13 both pass. No runtime guard or coverage requirement was weakened.

No live-provider requests or full docs build were performed for this patch. This is not a security audit or a complete1.17.1 integration certification; additional release PRs remain separate.

## Scope and Skips

- #2626 request-local streaming and #2619 GenAI ownership changes remain separate; retest/reconcile after each merge.
- #2605/#2612 caching proposals remain excluded due retention/stale-validation risks; #2624 provides allocation evidence.
- #2604 JSON sanitization is excluded because its new plain ValueError changes default retry behavior.
- #2592 HTTPX patch has a syntax error at its current head; OpenAI3 support already shipped separately.
- Broad provider additions, dependency upgrades, architecture/memory features and unrelated examples are deferred as recorded in the release triage.
- No generated reports, local task plans, benchmark snapshots or audit inventories are committed. Only maintained documentation, runtime code and tests are included.
- No merge/review bypass, tag, release, deployment or publication is part of this PR.


Release target renamed by Jason to **1.17.1**. Version-only follow-up passes the release metadata validator, eight helper tests and normal commit hooks; current-head CI is rerunning. Any earlier bot summary below describes its cited historical commit, before the version rename.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> GenAI non-streaming calls now fail on MAX_TOKENS instead of returning models with default-filled missing fields, which is a deliberate behavior change for production parsers. Partial streaming and templating touch core response paths but are covered by new tests.
> 
> **Overview**
> Prepares **1.18.0** release metadata (`pyproject.toml`, package version, lockfile) and a dated **CHANGELOG** with upgrade notes for GenAI truncation and cache identity behavior documented from related work.
> 
> **Partial streaming** now unwraps nullable list annotations (`Optional[list[Item]]`, `list[Item] | None`, etc.) so completed stream elements stay **Pydantic model instances**, with validation context and final root validation unchanged. Covered by new sync/async tests in `tests/dsl/test_partial_optional_lists.py`.
> 
> **GenAI (non-streaming)** tools and JSON handlers **raise `IncompleteOutputException`** when the first candidate’s `finish_reason` is `MAX_TOKENS`, instead of parsing partial output that could look like real schema defaults.
> 
> **GenAI templating** updates text parts via `part.model_copy(update={...})` so **thought flags, signatures, and other part metadata** are kept and **caller-owned `Content` objects are not mutated**.
> 
> **Documentation** fixes broken or stale links (context validation, quick start, examples, provider template API path) and minor copy edits.
> 
> **Tests**: GenAI truncation and templating regressions; JSON extraction security test now asserts the **128-level nesting boundary** and accepts either nesting or malformed-input work-limit errors on deeply broken input (Python-version-stable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad3c9e5aed9d9145b450e9f33c5322ad04de9e19. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->