### PR TITLE
fix(simple_type): use types.UnionType instead of hasattr(__or__) to detect pipe unions

### DIFF
--- a/instructor/v2/dsl/simple_type.py
+++ b/instructor/v2/dsl/simple_type.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from inspect import isclass
+import types
 import typing
 from pydantic import BaseModel, create_model
 from enum import Enum
@@ -43,8 +44,6 @@ def validateIsSubClass(response_model: type):
         return issubclass(typing.get_args(response_model)[0], BaseModel)
     try:
         # Add a guard here to prevent issues with GenericAlias
-        import types
-
         if isinstance(response_model, types.GenericAlias):
             return False
     except Exception:
@@ -100,8 +99,9 @@ def is_simple_type(
                 except TypeError:
                     pass
 
-                # Check for Python 3.10+ pipe syntax
-                if hasattr(inner_arg, "__or__"):
+                # Check for Python 3.10+ pipe syntax (str | int creates types.UnionType;
+                # plain classes also have __or__ since Python 3.10, so check the type)
+                if hasattr(types, "UnionType") and isinstance(inner_arg, types.UnionType):
                     return True
 
                 # For simple list with basic types, also return True
@@ -127,8 +127,9 @@ def is_simple_type(
             ):
                 return True
 
-            # Check for Python 3.10+ pipe syntax
-            if hasattr(inner_arg, "__or__"):
+            # Check for Python 3.10+ pipe syntax (str | int creates types.UnionType;
+            # plain classes also have __or__ since Python 3.10, so check the type)
+            if hasattr(types, "UnionType") and isinstance(inner_arg, types.UnionType):
                 return True
 
             # For simple list with basic types, also return True


### PR DESCRIPTION
## Summary

`is_simple_type` incorrectly returns `True` for `list[MyClass]` (any custom non-Pydantic class) on Python 3.10+, crashing with `PydanticSchemaGenerationError`.

### Root cause

PEP 604 (Python 3.10) added `__or__` directly to the `type` builtin so that `str | int` works. This means **every class** now has `__or__`:

```python
class MyClass: pass
hasattr(MyClass, '__or__')  # True on Python 3.10+!
```

`is_simple_type` used `hasattr(inner_arg, '__or__')` as the check for "this is a `|`-style union type". That check now matches all classes, so `list[MyClass]` falls through the `issubclass(inner_arg, BaseModel)` guard and returns `True`, triggering `ModelAdapter.__class_getitem__` on a non-BaseModel class.

### Fix

The `|` operator on types produces an actual `types.UnionType` instance (not just any object with `__or__`). The correct check is:

```python
if hasattr(types, "UnionType") and isinstance(inner_arg, types.UnionType):
    return True
```

- `str | int` → `isinstance(..., types.UnionType)` → `True` ✅
- `MyClass` → `isinstance(..., types.UnionType)` → `False` ✅  
- Python < 3.10 → `hasattr(types, "UnionType")` → `False` (safe fallback) ✅

Both occurrences of the `hasattr(__or__)` guard are fixed (one for `list` origin, one for `Iterable`/`Partial` origin). The top-level `import types` is hoisted from the local import inside `validateIsSubClass`.

### Reproducer (from #2613)

```python
from instructor.v2.dsl.simple_type import is_simple_type

class MyClass:
    pass

# Before this PR: True (wrong) → PydanticSchemaGenerationError
# After this PR:  False (correct)
print(is_simple_type(list[MyClass]))

# Still True after fix:
print(is_simple_type(list[str | int]))  # True ✅
print(is_simple_type(list[str]))        # True ✅
```

Fixes #2613.