### PR TITLE
fix(genai): end structured-output reasks with a user turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **GenAI structured-output retries**: Preserve the failed model response and append validation feedback as a user turn without modifying the caller's conversation history. ([#2631](https://github.com/567-labs/instructor/issues/2631))
+
 ## [1.17.1] - 2026-09-09
 
 ### Upgrade Notes

--- a/instructor/v2/providers/genai/handlers.py
+++ b/instructor/v2/providers/genai/handlers.py
@@ -96,7 +96,7 @@ def reask_genai_structured_outputs(
     kwargs = kwargs.copy()
     kwargs["contents"] = list(kwargs.get("contents") or [])
     candidates = getattr(response, "candidates", None)
-    if candidates and candidates[0].content is not None:
+    if candidates and candidates[0].content is not None and candidates[0].content.parts:
         kwargs["contents"].append(candidates[0].content)
     kwargs["contents"].append(
         types.Content(

--- a/instructor/v2/providers/genai/handlers.py
+++ b/instructor/v2/providers/genai/handlers.py
@@ -94,18 +94,19 @@ def reask_genai_structured_outputs(
     from google.genai import types
 
     kwargs = kwargs.copy()
-    genai_response = (
-        response.text
-        if response and hasattr(response, "text")
-        else "You must generate a response to the user's request that is consistent with the response model"
-    )
+    kwargs["contents"] = list(kwargs.get("contents") or [])
+    candidates = getattr(response, "candidates", None)
+    if candidates and candidates[0].content is not None:
+        kwargs["contents"].append(candidates[0].content)
     kwargs["contents"].append(
-        types.ModelContent(
+        types.Content(
+            role="user",
             parts=[
                 types.Part.from_text(
-                    text=f"Validation Error found:\n{exception}\nRecall the function correctly, fix the errors in the following attempt:\n{genai_response}"
+                    text=f"Validation Error found:\n{exception}\n"
+                    "Generate a response that fixes these errors and matches the response model."
                 ),
-            ]
+            ],
         ),
     )
     return kwargs

--- a/tests/v2/test_genai_handlers_deterministic.py
+++ b/tests/v2/test_genai_handlers_deterministic.py
@@ -16,11 +16,6 @@ from instructor.v2.providers.genai.handlers import (
 from tests.v2._fake_genai import FakeContent, FakePart, install_fake_genai
 
 
-class FakeModelContent(FakeContent):
-    def __init__(self, parts: list[FakePart], role: str = "model") -> None:
-        super().__init__(role=role, parts=parts)
-
-
 class FakeGenerateContentConfig:
     def __init__(self, **kwargs: Any) -> None:
         self.kwargs = kwargs
@@ -30,7 +25,6 @@ def _install_fake_genai_types(monkeypatch: pytest.MonkeyPatch) -> None:
     install_fake_genai(
         monkeypatch,
         extra_types={
-            "ModelContent": FakeModelContent,
             "GenerateContentConfig": FakeGenerateContentConfig,
         },
     )
@@ -68,18 +62,51 @@ def test_reask_genai_tools_with_function_call_appends_user_response(
     assert "Validation Error found" in function_response["response"]["error"]
 
 
-def test_reask_genai_structured_outputs_appends_model_content(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("response_kind", ["content", "none", "empty", "no_content"])
+def test_reask_genai_structured_outputs_appends_user_error(
+    response_kind: str,
 ) -> None:
-    _install_fake_genai_types(monkeypatch)
-    kwargs = {"contents": []}
-    response = SimpleNamespace(text='{"bad": true}')
+    types = pytest.importorskip("google.genai.types")
+    original_content = types.UserContent(parts=[types.Part.from_text(text="hello")])
+    kwargs = {"contents": [original_content]}
+    model_content = types.ModelContent(
+        parts=[types.Part(text='{"bad": true}', thought_signature=b"signature")]
+    )
+    response = {
+        "content": types.GenerateContentResponse(
+            candidates=[types.Candidate(content=model_content)]
+        ),
+        "none": None,
+        "empty": types.GenerateContentResponse(candidates=[]),
+        "no_content": types.GenerateContentResponse(candidates=[types.Candidate()]),
+    }[response_kind]
 
     result = reask_genai_structured_outputs(kwargs, response, ValueError("bad json"))
 
-    assert isinstance(result["contents"][-1], FakeModelContent)
+    assert result["contents"][-1].role == "user"
     assert "bad json" in result["contents"][-1].parts[0].text
-    assert '{"bad": true}' in result["contents"][-1].parts[0].text
+    assert result is not kwargs
+    assert kwargs["contents"] == [original_content]
+    assert result["contents"] is not kwargs["contents"]
+    assert result["contents"][0] is original_content
+    if response_kind == "content":
+        assert [content.role for content in result["contents"]] == [
+            "user",
+            "model",
+            "user",
+        ]
+        assert result["contents"][-2] is model_content
+        assert result["contents"][-2].parts[0].thought_signature == b"signature"
+    else:
+        assert len(result["contents"]) == 2
+
+    retried = GenAIStructuredOutputsHandler(mode=Mode.JSON).handle_reask(
+        result, response, ValueError("still invalid")
+    )
+    assert retried["contents"] is not result["contents"]
+    assert retried["contents"][-1].role == "user"
+    assert "bad json" in result["contents"][-1].parts[0].text
+    assert "still invalid" in retried["contents"][-1].parts[0].text
 
 
 def test_tools_handler_prepare_request_without_response_model(

--- a/tests/v2/test_genai_handlers_deterministic.py
+++ b/tests/v2/test_genai_handlers_deterministic.py
@@ -62,7 +62,10 @@ def test_reask_genai_tools_with_function_call_appends_user_response(
     assert "Validation Error found" in function_response["response"]["error"]
 
 
-@pytest.mark.parametrize("response_kind", ["content", "none", "empty", "no_content"])
+@pytest.mark.parametrize(
+    "response_kind",
+    ["content", "none", "empty", "no_content", "no_parts", "empty_parts"],
+)
 def test_reask_genai_structured_outputs_appends_user_error(
     response_kind: str,
 ) -> None:
@@ -79,6 +82,12 @@ def test_reask_genai_structured_outputs_appends_user_error(
         "none": None,
         "empty": types.GenerateContentResponse(candidates=[]),
         "no_content": types.GenerateContentResponse(candidates=[types.Candidate()]),
+        "no_parts": types.GenerateContentResponse(
+            candidates=[types.Candidate(content=types.Content(role="model"))]
+        ),
+        "empty_parts": types.GenerateContentResponse(
+            candidates=[types.Candidate(content=types.Content(role="model", parts=[]))]
+        ),
     }[response_kind]
 
     result = reask_genai_structured_outputs(kwargs, response, ValueError("bad json"))


### PR DESCRIPTION
## Describe your changes

After a Gemini structured-output validation failure, the reask ended with a model turn containing the correction, which Gemini rejects. Preserve the failed model content and append the validation feedback as a user turn. Copy the contents list so retries do not mutate the caller's history.

- Keep the original model parts, including thought signatures.
- Replace the test that expected the incorrect model turn with a real SDK regression covering content, absent responses, empty candidates, and repeated retries.
- Add a changelog entry.

## Issue ticket number and link

Fixes #2631. The earlier closed #2539 addressed list ownership only; this also corrects the structured-output conversation roles.

## Testing

- Regression before the fix: 4 failed on the incorrect `model` role.
- Related GenAI and retry tests: 83 passed with the locked dependencies.
- GenAI tests with `google-genai==2.20.0`: 39 passed.
- Repository Ruff scope, formatting, changed-file pre-commit, and source/test ty checks passed, including the Python 3.9 and 3.14 platform checks.
- No live Gemini requests or full repository test suite run. The broader `ruff check .` reports 36 existing issues in unchanged notebooks/scripts; the CI scope `instructor examples tests` passes.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.

AI assistance: OpenAI Codex implemented and tested this change; a separate agent reviewed the diff read-only with no blocking findings. Human self-review is not claimed. Documentation is the changelog entry for this bug fix.
