### PR TITLE
fix(retry): stop treating the per-request timeout as a total retry budget

### DIFF
--- a/instructor/v2/core/retry.py
+++ b/instructor/v2/core/retry.py
@@ -190,9 +190,6 @@ def retry_sync_v2(
     # Setup retrying
     if isinstance(max_retries, int):
         stop_condition = stop_after_attempt(max(max_retries, 0) + 1)
-        timeout = kwargs.get("timeout")
-        if isinstance(timeout, (int, float)):
-            stop_condition = stop_condition | stop_after_delay(timeout)
         max_retries_instance = Retrying(
             stop=stop_condition,
             retry=retry_if_exception_type(_RETRYABLE_PARSE_ERRORS),
@@ -486,9 +483,6 @@ async def retry_async_v2(
     # Setup retrying
     if isinstance(max_retries, int):
         stop_condition = stop_after_attempt(max(max_retries, 0) + 1)
-        timeout = kwargs.get("timeout")
-        if isinstance(timeout, (int, float)):
-            stop_condition = stop_condition | stop_after_delay(timeout)
         max_retries_instance = AsyncRetrying(
             stop=stop_condition,
             retry=retry_if_exception_type(_RETRYABLE_PARSE_ERRORS),


### PR DESCRIPTION
Related open reports from the same conflation: #1597, #1614, #1082

## Summary

`kwargs["timeout"]` is the **per-request HTTP timeout** under OpenAI SDK semantics, but the retry setup OR'd it into tenacity's stop condition as `stop_after_delay(timeout)` — turning it into a total budget for the whole retry loop. With `max_retries=3, timeout=5`, two failed-validation attempts of ~2.6s each exhausted the budget and attempts 3-4 never ran; for reasoning models with 30-60s requests and `timeout=30`, only 1-2 attempts ever executed.

The retry loop is now governed by `stop_after_attempt` alone. The per-request timeout still applies to each individual HTTP call — where it belongs.

## Repro

Executed the verbatim tenacity construction from `retry.py` with `max_retries=3, timeout=5` and attempts taking 2.6s: **bug — gave up after 2 of 4 allowed attempts**; control without the `timeout` kwarg — succeeded after 3. Same harness post-fix: all attempts run.

Both the sync (`Retrying`) and async (`AsyncRetrying`) paths patched.