### PR TITLE
fix(hooks): preserve dispatch when callbacks change handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Hooks**: Preserve callback order when handlers register or unregister handlers during an emission; registration changes take effect on the next emission.
+
 ## [1.17.1] - 2026-09-09
 
 ### Upgrade Notes

--- a/instructor/v2/core/hooks.py
+++ b/instructor/v2/core/hooks.py
@@ -151,12 +151,14 @@ class Hooks:
         """
         Generic method to emit events for any hook type.
 
+        Handler additions and removals take effect on the next emission.
+
         Args:
             hook_name: The hook to emit
             *args: Positional arguments to pass to handlers
             **kwargs: Keyword arguments to pass to handlers
         """
-        for handler in self._handlers[hook_name]:
+        for handler in self._handlers[hook_name].copy():
             try:
                 if kwargs:
                     try:

--- a/tests/coverage/test_core_hooks_registry_coverage.py
+++ b/tests/coverage/test_core_hooks_registry_coverage.py
@@ -86,6 +86,46 @@ def test_hooks_reject_invalid_name_and_remove_or_clear_registered_handlers() -> 
         hooks.get_hook_name(cast(Any, "completion:missing"))
 
 
+def test_hooks_self_removal_does_not_skip_the_next_handler() -> None:
+    hooks = Hooks()
+    seen: list[str] = []
+
+    def once(response: str) -> None:
+        seen.append(f"once:{response}")
+        hooks.off("completion:response", once)
+
+    def always(response: str) -> None:
+        seen.append(f"always:{response}")
+
+    hooks.on("completion:response", once)
+    hooks.on("completion:response", always)
+
+    hooks.emit_completion_response("first")
+    hooks.emit_completion_response("second")
+
+    assert seen == ["once:first", "always:first", "always:second"]
+
+
+def test_hooks_new_handlers_start_with_the_next_emission() -> None:
+    hooks = Hooks()
+    seen: list[str] = []
+
+    def register(response: str) -> None:
+        seen.append(f"register:{response}")
+        if response == "first":
+            hooks.on("completion:response", added)
+
+    def added(response: str) -> None:
+        seen.append(f"added:{response}")
+
+    hooks.on("completion:response", register)
+
+    hooks.emit_completion_response("first")
+    hooks.emit_completion_response("second")
+
+    assert seen == ["register:first", "register:second", "added:second"]
+
+
 def test_hooks_emit_retry_events_with_metadata_and_remove_the_final_handler() -> None:
     hooks = Hooks()
     error = ValueError("invalid response")


### PR DESCRIPTION
## Describe your changes

When a one-shot hook callback unregisters itself during an emission, iterating the live handler list skips the next callback. Registering a callback during an emission also runs that new callback immediately.

Iterate over a copy of the handler list so the callbacks present at the start run in order, and registration changes apply to the next emission. Add two regression tests with real callbacks, document the behavior in `emit`, and update the changelog.

## Issue ticket number and link

Found while inspecting the hook registry; no existing issue or overlapping PR found.

## Validation

- Before the fix: both new regression tests failed.
- `python -m pytest tests/coverage/test_core_hooks_registry_coverage.py -q`: 15 passed.
- Focused Ruff lint, formatting, and type checks passed.
- Full-repository lint/format checks report existing findings in unrelated files; the full type check also requires optional provider SDKs absent from the local environment. No provider API requests were made.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.
