### PR TITLE
fix(dsl): prevent false simple type match on custom classes (#2613)

### DIFF
--- a/instructor/v2/dsl/simple_type.py
+++ b/instructor/v2/dsl/simple_type.py
@@ -1,10 +1,31 @@
 from __future__ import annotations
 from inspect import isclass
+import sys
 import typing
 from pydantic import BaseModel, create_model
 from enum import Enum
 
 from instructor.v2.dsl.partial import Partial
+
+if sys.version_info >= (3, 10):
+    from types import UnionType
+
+    _UNION_ORIGINS: tuple[typing.Any, ...] = (typing.Union, UnionType)
+else:
+    _UNION_ORIGINS = (typing.Union,)
+
+
+def _is_union_type(tp: typing.Any, origin: typing.Any = None) -> bool:
+    if origin is None:
+        origin = typing.get_origin(tp)
+    if origin in _UNION_ORIGINS or str(origin) == "typing.Union":
+        return True
+    if str(type(tp)) == "<class 'typing._UnionGenericAlias'>":
+        return True
+    if sys.version_info >= (3, 10) and isinstance(tp, UnionType):
+        return True
+    return False
+
 
 T = typing.TypeVar("T")
 
@@ -85,12 +106,7 @@ def is_simple_type(
                 inner_origin = typing.get_origin(inner_arg)
 
                 # Explicit check for Union types - try different patterns across Python versions
-                if (
-                    inner_origin is typing.Union
-                    or inner_origin == typing.Union
-                    or str(inner_origin) == "typing.Union"
-                    or str(type(inner_arg)) == "<class 'typing._UnionGenericAlias'>"
-                ):
+                if _is_union_type(inner_arg, inner_origin):
                     return True
 
                 # Check if inner type is a BaseModel - if so, not a simple type
@@ -99,10 +115,6 @@ def is_simple_type(
                         return False
                 except TypeError:
                     pass
-
-                # Check for Python 3.10+ pipe syntax
-                if hasattr(inner_arg, "__or__"):
-                    return True
 
                 # For simple list with basic types, also return True
                 if inner_arg in {str, int, float, bool}:
@@ -119,16 +131,7 @@ def is_simple_type(
             inner_origin = typing.get_origin(inner_arg)
 
             # Explicit check for Union types - try different patterns across Python versions
-            if (
-                inner_origin is typing.Union
-                or inner_origin == typing.Union
-                or str(inner_origin) == "typing.Union"
-                or str(type(inner_arg)) == "<class 'typing._UnionGenericAlias'>"
-            ):
-                return True
-
-            # Check for Python 3.10+ pipe syntax
-            if hasattr(inner_arg, "__or__"):
+            if _is_union_type(inner_arg, inner_origin):
                 return True
 
             # For simple list with basic types, also return True
@@ -150,9 +153,12 @@ def is_simple_type(
     if origin in {
         typing.Annotated,
         typing.Literal,
-        typing.Union,
+        *_UNION_ORIGINS,
         list,  # origin of List[T] is list
     }:
+        return True
+
+    if sys.version_info >= (3, 10) and isinstance(response_model, UnionType):
         return True
 
     if isclass(response_model) and issubclass(response_model, Enum):

--- a/tests/coverage/test_dsl_small_coverage.py
+++ b/tests/coverage/test_dsl_small_coverage.py
@@ -198,7 +198,7 @@ def test_is_simple_type_covers_list_shapes_and_old_issubclass_behavior(
 ) -> None:
     assert is_simple_type(list[typing.Union[int, str]])
     assert not is_simple_type(list[User])
-    assert is_simple_type(list[object]) is hasattr(object, "__or__")
+    assert not is_simple_type(list[object])
     assert is_simple_type(typing.List)  # noqa: UP006
 
     monkeypatch.setattr(simple_type, "hasattr", lambda *_: False, raising=False)

--- a/tests/dsl/test_simple_types.py
+++ b/tests/dsl/test_simple_types.py
@@ -210,3 +210,24 @@ def test_list_of_model_three_way_union_generates_clean_name():
     prepared = prepare_response_model(list[A | B | C])
     assert prepared is not None
     assert prepared.__name__ == "IterableAOrBOrC"
+
+
+def test_custom_class_not_simple():
+    """Custom non-Pydantic classes must not be falsely identified as simple types (Issue #2613)."""
+
+    class MyCustomClass:
+        pass
+
+    assert not is_simple_type(MyCustomClass)
+    assert not is_simple_type(list[MyCustomClass])
+    assert not is_simple_type(Iterable[MyCustomClass])
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Union pipe syntax is only available in Python 3.10+",
+)
+def test_union_pipe_syntax_is_simple_type():
+    """Direct PEP 604 union types (e.g., int | str) must be identified as simple types."""
+    assert is_simple_type(int | str)
+


### PR DESCRIPTION
## Summary
Fixes #2613.

In Python 3.10+, `type.__or__` was added directly to Python's builtin `type` metaclass to support PEP 604 pipe unions (`A | B`). Because `is_simple_type` checked `if hasattr(inner_arg, "__or__"): return True`, all Python classes (including custom non-Pydantic classes and `object`) falsely returned `True` for `is_simple_type(list[CustomClass])`, causing `PydanticSchemaGenerationError` during model preparation. Furthermore, `is_simple_type(int | str)` returned `False` because `types.UnionType` wasn't checked as a direct union origin.

## Changes
- Replaced `hasattr(inner_arg, "__or__")` in `instructor/v2/dsl/simple_type.py` with `_is_union_type()` using `_UNION_ORIGINS` (`types.UnionType` on Python >= 3.10 and `typing.Union`).
- Added support for `UnionType` in direct `is_simple_type` checks so `is_simple_type(int | str)` returns `True` consistently with `typing.Union[int, str]`.
- Updated test coverage assertion in `tests/coverage/test_dsl_small_coverage.py`.
- Added unit tests in `tests/dsl/test_simple_types.py` covering custom non-Pydantic classes and direct `int | str` union types.

## Verification
- `pytest tests/dsl/test_simple_types.py tests/coverage/test_dsl_small_coverage.py` (38 passed)
- `pytest tests/dsl` (132 passed, 2 skipped)
