### PR TITLE
fix(genai): append model attempt then user validation error on structured output reask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **GenAI structured output retry**: Append the model's previous attempt followed by a user turn containing the validation error instead of ending the reask request with a model turn, avoiding Gemini 400 `INVALID_ARGUMENT` errors and caller `contents` list mutation.
+
 ## [1.17.1] - 2026-09-09
 
 ### Upgrade Notes

--- a/instructor/v2/providers/genai/handlers.py
+++ b/instructor/v2/providers/genai/handlers.py
@@ -94,19 +94,46 @@ def reask_genai_structured_outputs(
     from google.genai import types
 
     kwargs = kwargs.copy()
-    genai_response = (
-        response.text
-        if response and hasattr(response, "text")
-        else "You must generate a response to the user's request that is consistent with the response model"
+    existing_contents = kwargs.get("contents")
+    if isinstance(existing_contents, list):
+        kwargs["contents"] = existing_contents.copy()
+    elif existing_contents is None:
+        kwargs["contents"] = []
+    else:
+        kwargs["contents"] = list(existing_contents)
+
+    model_content = None
+    candidates = getattr(response, "candidates", None) if response is not None else None
+    if isinstance(candidates, list):
+        for candidate in candidates:
+            content = getattr(candidate, "content", None)
+            if content is not None:
+                model_content = content
+                break
+
+    if model_content is not None:
+        kwargs["contents"].append(model_content)
+    else:
+        genai_response = (
+            response.text
+            if response and hasattr(response, "text") and response.text
+            else "You must generate a response to the user's request that is consistent with the response model"
+        )
+        kwargs["contents"].append(
+            types.ModelContent(
+                parts=[types.Part.from_text(text=genai_response)],
+            )
+        )
+
+    error_msg = (
+        f"Validation Error found:\n{exception}\n"
+        "Recall the function correctly, fix the errors"
     )
     kwargs["contents"].append(
-        types.ModelContent(
-            parts=[
-                types.Part.from_text(
-                    text=f"Validation Error found:\n{exception}\nRecall the function correctly, fix the errors in the following attempt:\n{genai_response}"
-                ),
-            ]
-        ),
+        types.Content(
+            role="user",
+            parts=[types.Part.from_text(text=error_msg)],
+        )
     )
     return kwargs
 

--- a/tests/v2/test_genai_handlers_deterministic.py
+++ b/tests/v2/test_genai_handlers_deterministic.py
@@ -68,18 +68,28 @@ def test_reask_genai_tools_with_function_call_appends_user_response(
     assert "Validation Error found" in function_response["response"]["error"]
 
 
-def test_reask_genai_structured_outputs_appends_model_content(
+def test_reask_genai_structured_outputs_appends_model_then_user_turn(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install_fake_genai_types(monkeypatch)
-    kwargs = {"contents": []}
+    original_contents = []
+    kwargs = {"contents": original_contents}
     response = SimpleNamespace(text='{"bad": true}')
 
     result = reask_genai_structured_outputs(kwargs, response, ValueError("bad json"))
 
-    assert isinstance(result["contents"][-1], FakeModelContent)
+    # Original contents must not be mutated
+    assert len(original_contents) == 0
+
+    # Model content from previous attempt must be appended
+    assert isinstance(result["contents"][-2], FakeModelContent)
+    assert result["contents"][-2].role == "model"
+    assert '{"bad": true}' in result["contents"][-2].parts[0].text
+
+    # Final turn must be a user turn carrying the validation error to avoid Gemini 400 error
+    assert result["contents"][-1].role == "user"
+    assert "Validation Error found" in result["contents"][-1].parts[0].text
     assert "bad json" in result["contents"][-1].parts[0].text
-    assert '{"bad": true}' in result["contents"][-1].parts[0].text
 
 
 def test_tools_handler_prepare_request_without_response_model(


### PR DESCRIPTION
Fixes #2631

## Problem
In `reask_genai_structured_outputs`, when validation fails for Gemini structured outputs (`Mode.GENAI_STRUCTURED_OUTPUTS`), the reask logic appends the validation error as a `types.ModelContent`. As a result, the rebuilt request ends with a model turn, causing Gemini API to reject the request with HTTP 400: `Requests ending with a model turn are not supported.` In addition, shallow copying `kwargs` allowed `kwargs["contents"]\ run` to mutate the caller's original list.

## Root Cause
`reask_genai_structured_outputs` only appended a single `ModelContent` part containing both the error and the prior response text, omitting the necessary user turn required by the Gemini conversation turn contract.

## Fix
1. Safely copy `kwargs["contents"]\ to avoid in-place mutation of caller-provided content lists.
2. Extract the model's previous attempt from `response.candidates` or `response.text` and append it as model content.
3. Append the validation error message as a trailing `types.Content(role="user", ...)` so the request correctly terminates on a user turn.
4. Update `CHANGELOG.md` under `[Unreleased]`.

## Testing
Updated `tests/v2/test_genai_handlers_deterministic.py` to assert that the caller's original contents list is not mutated, the model's prior output is preserved in the preceding turn, and the final turn is a user turn carrying the validation error message.