### PR TITLE
fix(genai): end structured-output reask on a user turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **GenAI structured-output retry**: End validation reasks on a user turn and copy caller-owned `contents`, matching tool-mode reasks, so Gemini no longer rejects the retry with `Requests ending with a model turn are not supported.` ([#2631](https://github.com/567-labs/instructor/issues/2631))
+
 ## [1.17.1] - 2026-09-09
 
 ### Upgrade Notes

--- a/instructor/v2/providers/genai/handlers.py
+++ b/instructor/v2/providers/genai/handlers.py
@@ -94,6 +94,14 @@ def reask_genai_structured_outputs(
     from google.genai import types
 
     kwargs = kwargs.copy()
+    existing_contents = kwargs.get("contents")
+    if isinstance(existing_contents, list):
+        kwargs["contents"] = existing_contents.copy()
+    elif existing_contents is None:
+        kwargs["contents"] = []
+    else:
+        kwargs["contents"] = list(existing_contents)
+
     genai_response = (
         response.text
         if response and hasattr(response, "text")
@@ -101,11 +109,20 @@ def reask_genai_structured_outputs(
     )
     kwargs["contents"].append(
         types.ModelContent(
+            parts=[types.Part.from_text(text=genai_response)],
+        ),
+    )
+    kwargs["contents"].append(
+        types.Content(
+            role="user",
             parts=[
                 types.Part.from_text(
-                    text=f"Validation Error found:\n{exception}\nRecall the function correctly, fix the errors in the following attempt:\n{genai_response}"
-                ),
-            ]
+                    text=(
+                        f"Validation Error found:\n{exception}\n"
+                        "Recall the function correctly, fix the errors"
+                    )
+                )
+            ],
         ),
     )
     return kwargs

--- a/tests/v2/test_genai_handlers_deterministic.py
+++ b/tests/v2/test_genai_handlers_deterministic.py
@@ -68,18 +68,26 @@ def test_reask_genai_tools_with_function_call_appends_user_response(
     assert "Validation Error found" in function_response["response"]["error"]
 
 
-def test_reask_genai_structured_outputs_appends_model_content(
+def test_reask_genai_structured_outputs_ends_on_user_turn(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install_fake_genai_types(monkeypatch)
-    kwargs = {"contents": []}
+    original_contents = [
+        FakeContent(role="user", parts=[FakePart(text="Name a color")])
+    ]
+    kwargs = {"contents": original_contents}
     response = SimpleNamespace(text='{"bad": true}')
 
     result = reask_genai_structured_outputs(kwargs, response, ValueError("bad json"))
 
-    assert isinstance(result["contents"][-1], FakeModelContent)
+    assert result["contents"] is not original_contents
+    assert len(original_contents) == 1
+    assert isinstance(result["contents"][-2], FakeModelContent)
+    assert result["contents"][-2].parts[0].text == '{"bad": true}'
+    assert result["contents"][-1].role == "user"
     assert "bad json" in result["contents"][-1].parts[0].text
-    assert '{"bad": true}' in result["contents"][-1].parts[0].text
+    assert "Recall the function correctly" in result["contents"][-1].parts[0].text
+    assert '{"bad": true}' not in result["contents"][-1].parts[0].text
 
 
 def test_tools_handler_prepare_request_without_response_model(


### PR DESCRIPTION
## Describe your changes

`Mode.JSON` (`GENAI_STRUCTURED_OUTPUTS`) reask after a validation failure stuffed the correction into a `ModelContent` and left the request ending on a model turn. Gemini then returns:

```
400 INVALID_ARGUMENT: Requests ending with a model turn are not supported.
```

so the *retry* fails instead of repairing the schema error.

This matches the already-fixed `reask_genai_tools` shape:

- copy `contents` so the caller’s list is not mutated
- keep the failed output as a model turn
- append the validation error as `role="user"` so the request ends on a user turn

Closes #2631.

## Issue ticket number and link

https://github.com/567-labs/instructor/issues/2631

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] If it is a core feature, I have added documentation.

### Evidence

```
uv run pytest tests/v2/test_genai_handlers_deterministic.py tests/test_genai_reask.py -q
9 passed
```
