### PR TITLE
chore(metadata): remove personal maintainer email

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     { name = "Ivan Leo" },
 ]
 maintainers = [
-    { email = "jason@jxnl.co" },
+    { name = "Jason Liu" },
     { email = "ivan@jxnl.co" },
 ]
 license = { text = "MIT" }


### PR DESCRIPTION
Remove Jason's personal email from public package metadata while retaining his maintainer name. Future packages built from this source will omit the address; existing releases and repository history require separate handling.

Validation: parsed the updated TOML, verified maintainer attribution remains present, and passed git diff --check. This changes metadata only; no provider API tests were run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to `pyproject.toml` with no effect on application logic or APIs.
> 
> **Overview**
> Updates **`pyproject.toml`** so Jason Liu stays listed as a maintainer by **name** instead of a **public email** (`jason@jxnl.co`). Ivan Leo’s maintainer entry is unchanged.
> 
> This is **packaging metadata only**—future builds from this tree will publish the revised maintainer block; it does not change runtime code or dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca1fe9e902abdb5a1aea9eab04afdb133ae39c83. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->