### PR TITLE
fix(batch): require defaulted fields in OpenAI strict schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
-- **OpenAI batches**: Include fields with defaults in strict schemas' required lists, including nested response models, while preserving nullable types and field aliases. ([#2641](https://github.com/567-labs/instructor/pull/2641))
+- **OpenAI batches**: Include fields with defaults in strict schemas' required lists and remove null defaults, including in nested response models, while preserving nullable types and field aliases. ([#2641](https://github.com/567-labs/instructor/pull/2641))
 
 ## [1.17.1] - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Fixed
-- **OpenAI batches**: Include fields with defaults in strict schemas' required lists, including nested response models, while preserving nullable types and field aliases.
+- **OpenAI batches**: Include fields with defaults in strict schemas' required lists, including nested response models, while preserving nullable types and field aliases. ([#2641](https://github.com/567-labs/instructor/pull/2641))
 
 ## [1.17.1] - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **OpenAI batches**: Include fields with defaults in strict schemas' required lists, including nested response models, while preserving nullable types and field aliases.
+
 ## [1.17.1] - 2026-09-09
 
 ### Upgrade Notes

--- a/instructor/batch/request.py
+++ b/instructor/batch/request.py
@@ -64,6 +64,8 @@ class BatchRequest(BaseModel, Generic[T]):
         def make_strict_schema(schema_dict):
             """Recursively require all properties for OpenAI strict mode."""
             if isinstance(schema_dict, dict):
+                if "default" in schema_dict and schema_dict["default"] is None:
+                    del schema_dict["default"]
                 if "type" in schema_dict:
                     if schema_dict["type"] == "object":
                         schema_dict["additionalProperties"] = False

--- a/instructor/batch/request.py
+++ b/instructor/batch/request.py
@@ -60,9 +60,9 @@ class BatchRequest(BaseModel, Generic[T]):
         """Convert to OpenAI batch format with JSON schema"""
         schema = self.get_json_schema()
 
-        # OpenAI strict mode requires additionalProperties to be false
+        # OpenAI strict mode requires all fields and disallows extra properties.
         def make_strict_schema(schema_dict):
-            """Recursively add additionalProperties: false for OpenAI strict mode"""
+            """Recursively require all properties for OpenAI strict mode."""
             if isinstance(schema_dict, dict):
                 if "type" in schema_dict:
                     if schema_dict["type"] == "object":
@@ -72,6 +72,7 @@ class BatchRequest(BaseModel, Generic[T]):
 
                 # Recursively process properties
                 if "properties" in schema_dict:
+                    schema_dict["required"] = list(schema_dict["properties"])
                     for prop_name, prop_schema in schema_dict["properties"].items():
                         schema_dict["properties"][prop_name] = make_strict_schema(
                             prop_schema

--- a/tests/coverage/test_batch_api_coverage.py
+++ b/tests/coverage/test_batch_api_coverage.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from instructor.batch import (
     BatchError,
@@ -385,6 +385,39 @@ def test_openai_batch_request_preserves_boolean_property_schema() -> None:
 
     assert schema["additionalProperties"] is False
     assert schema["properties"]["forbidden"] is False
+
+
+@pytest.mark.parametrize("nested", [False, True], ids=["root", "nested-array"])
+def test_openai_batch_request_requires_fields_with_defaults(nested: bool) -> None:
+    class Contact(BaseModel):
+        name: str
+        phone: str | None = Field(default=None, alias="phone_number")
+
+    class Contacts(BaseModel):
+        contacts: list[Contact] = Field(default_factory=list)
+
+    request = BatchRequest(
+        custom_id="contacts-1",
+        messages=[{"role": "user", "content": "Extract contact details."}],
+        response_model=Contacts if nested else Contact,
+        model="gpt-4o-mini",
+    )
+    buffer = io.BytesIO()
+    request.save_to_file(buffer, provider="openai")
+    result = json.loads(buffer.getvalue())
+    response_format = result["body"]["response_format"]["json_schema"]
+    schema = response_format["schema"]
+
+    assert response_format["strict"] is True
+    if nested:
+        assert schema["required"] == ["contacts"]
+        schema = schema["$defs"]["Contact"]
+
+    assert schema["required"] == ["name", "phone_number"]
+    assert {"type": "null"} in schema["properties"]["phone_number"]["anyOf"]
+    # Requiring fields in the request must not change local Pydantic defaults.
+    assert Contact(name="Ada").phone is None
+    assert Contacts().contacts == []
 
 
 def test_anthropic_batch_request_extracts_system_message_and_completes_schema() -> None:

--- a/tests/coverage/test_batch_api_coverage.py
+++ b/tests/coverage/test_batch_api_coverage.py
@@ -414,6 +414,7 @@ def test_openai_batch_request_requires_fields_with_defaults(nested: bool) -> Non
         schema = schema["$defs"]["Contact"]
 
     assert schema["required"] == ["name", "phone_number"]
+    assert "default" not in schema["properties"]["phone_number"]
     assert {"type": "null"} in schema["properties"]["phone_number"]["anyOf"]
     # Requiring fields in the request must not change local Pydantic defaults.
     assert Contact(name="Ada").phone is None


### PR DESCRIPTION
## Describe your changes

OpenAI batch requests already enable `strict: true`, but fields with Pydantic defaults are missing from their schemas' `required` lists. For example, a model with `name: str` and `phone: str | None = None` currently requires only `name`, contrary to the [Structured Outputs contract](https://developers.openai.com/api/docs/guides/structured-outputs#all-fields-must-be-required).

Populate `required` from the schema's property names and strip null defaults during the existing recursive conversion, matching the OpenAI SDK's handling of nullable defaults. This covers root and nested models, uses field aliases, and preserves nullable types. The regression test exercises the serialized JSONL request and models with both a nullable default and a default factory.

Validation (Windows, Python 3.13):
- Both new parametrized cases fail before the fix and pass after it.
- 105 batch tests passed across `tests/coverage/test_batch_api_coverage.py`, `test_batch_openai_coverage.py`, `test_batch_anthropic_coverage.py`, `tests/test_batch_in_memory.py`, and `tests/test_batch_processor_coverage.py`.
- Ruff 0.9.9 lint passed for `instructor tests examples`; repository formatting passed (591 files).
- ty 0.0.44 passed for both changed Python files, using `ty-tests.toml` for the test.
- Whole-repository lint reports 36 existing findings in untouched notebooks/scripts. The full provider type check is incomplete because optional SDK dependencies are not installed. No live provider request was made; these are offline schema and batch tests.

## Issue ticket number and link

Found while inspecting batch schema generation; no existing issue identified.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation. (Changelog entry; no new public API.)

This PR was written and tested with OpenAI Codex, including AI-generated code, tests, and this description.