### PR TITLE
fix(v2): stop misclassifying custom classes as simple types on Python 3.10+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Response model validation**: Custom (non-BaseModel) classes used as `list[...]` element types are no longer misclassified as simple types on Python 3.10+ (`__or__` now lives on `type` itself, so probing for it matched every class), and `prepare_response_model` raises a clear `TypeError` for unsupported element types instead of an opaque Pydantic schema error. ([#2613](https://github.com/567-labs/instructor/issues/2613))
+
 ## [1.17.1] - 2026-09-09
 
 ### Upgrade Notes

--- a/instructor/v2/core/response_model.py
+++ b/instructor/v2/core/response_model.py
@@ -65,6 +65,18 @@ def is_simple_type(typehint: type[T]) -> bool:
     return _is_simple_type(typehint)
 
 
+def _is_model_type(candidate: Any) -> bool:
+    """True for BaseModel subclasses, TypedDicts, and unions of those."""
+    if is_typed_dict(candidate):
+        return True
+    if inspect.isclass(candidate) and issubclass(candidate, BaseModel):
+        return True
+    return get_origin(candidate) in _UNION_ORIGINS and all(
+        inspect.isclass(member) and issubclass(member, BaseModel)
+        for member in get_args(candidate)
+    )
+
+
 def prepare_response_model(response_model: type[T] | None) -> type[T] | None:
     """Normalize user response-model inputs into runtime-ready model classes."""
     from instructor.v2.validation.async_validators import reject_async_validators
@@ -78,16 +90,6 @@ def prepare_response_model(response_model: type[T] | None) -> type[T] | None:
     if origin is list and is_simple_type(working_model):
         args = get_args(working_model)
         inner = args[0] if args else None
-
-        def _is_model_type(candidate: Any) -> bool:
-            if is_typed_dict(candidate):
-                return True
-            if inspect.isclass(candidate) and issubclass(candidate, BaseModel):
-                return True
-            return get_origin(candidate) in _UNION_ORIGINS and all(
-                inspect.isclass(member) and issubclass(member, BaseModel)
-                for member in get_args(candidate)
-            )
 
         if inner is not None and _is_model_type(inner):
             origin = list
@@ -112,6 +114,12 @@ def prepare_response_model(response_model: type[T] | None) -> type[T] | None:
         iterable_element_class = args[0]
         if is_typed_dict(iterable_element_class):
             iterable_element_class = _typed_dict_to_model(iterable_element_class)
+        if not _is_model_type(iterable_element_class):
+            raise TypeError(
+                f"Unsupported response_model {response_model!r}: elements of "
+                "list[...] / Iterable[...] must be BaseModel subclasses, "
+                f"TypedDicts, or unions of those; got {iterable_element_class!r}."
+            )
         working_model = IterableModel(cast(type[BaseModel], iterable_element_class))
 
     if is_simple_type(working_model):

--- a/instructor/v2/dsl/simple_type.py
+++ b/instructor/v2/dsl/simple_type.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 from inspect import isclass
+import sys
 import typing
 from pydantic import BaseModel, create_model
 from enum import Enum
 
 from instructor.v2.dsl.partial import Partial
+
+if sys.version_info >= (3, 10):
+    from types import UnionType
+
+    _UNION_ORIGINS: tuple[typing.Any, ...] = (typing.Union, UnionType)
+else:  # pragma: no cover - Python 3.9 has no runtime ``X | Y`` syntax
+    _UNION_ORIGINS = (typing.Union,)
 
 T = typing.TypeVar("T")
 
@@ -100,8 +108,13 @@ def is_simple_type(
                 except TypeError:
                     pass
 
-                # Check for Python 3.10+ pipe syntax
-                if hasattr(inner_arg, "__or__"):
+                # Check for Python 3.10+ pipe syntax, e.g. list[int | str]:
+                # get_origin(X | Y) is types.UnionType (typing.Union origins are
+                # handled above). Do NOT probe `hasattr(inner_arg, "__or__")` --
+                # on 3.10+ `__or__` lives on `type` itself (PEP 604), so every
+                # class satisfies it and custom non-BaseModel classes are then
+                # misclassified as simple types, crashing schema generation.
+                if inner_origin in _UNION_ORIGINS:
                     return True
 
                 # For simple list with basic types, also return True
@@ -127,8 +140,11 @@ def is_simple_type(
             ):
                 return True
 
-            # Check for Python 3.10+ pipe syntax
-            if hasattr(inner_arg, "__or__"):
+            # Check for Python 3.10+ pipe syntax, e.g. Iterable[int | str]:
+            # get_origin(X | Y) is types.UnionType. Do NOT probe
+            # `hasattr(inner_arg, "__or__")` -- on 3.10+ `__or__` lives on `type`
+            # itself (PEP 604), so every class satisfies it.
+            if inner_origin in _UNION_ORIGINS:
                 return True
 
             # For simple list with basic types, also return True

--- a/tests/coverage/test_dsl_small_coverage.py
+++ b/tests/coverage/test_dsl_small_coverage.py
@@ -198,7 +198,9 @@ def test_is_simple_type_covers_list_shapes_and_old_issubclass_behavior(
 ) -> None:
     assert is_simple_type(list[typing.Union[int, str]])
     assert not is_simple_type(list[User])
-    assert is_simple_type(list[object]) is hasattr(object, "__or__")
+    # A plain class is never a simple type; on Python 3.10+ every class satisfies
+    # hasattr(cls, "__or__") (PEP 604), so the old probe misclassified list[object].
+    assert not is_simple_type(list[object])
     assert is_simple_type(typing.List)  # noqa: UP006
 
     monkeypatch.setattr(simple_type, "hasattr", lambda *_: False, raising=False)

--- a/tests/dsl/test_simple_types.py
+++ b/tests/dsl/test_simple_types.py
@@ -86,6 +86,32 @@ def test_list_of_base_model_not_simple():
     assert not is_simple_type(List[Item])  # noqa: UP006
 
 
+def test_list_of_custom_class_not_simple():
+    """A custom non-BaseModel class is not a simple type.
+
+    On Python 3.10+ every class satisfies ``hasattr(cls, "__or__")`` because PEP
+    604 put ``__or__`` on ``type`` itself, so probing for ``__or__`` misclassified
+    e.g. ``list[MyClass]`` as a simple type and crashed schema generation.
+    https://github.com/jxnl/instructor/issues/2613
+    """
+
+    class MyClass:
+        pass
+
+    assert not is_simple_type(list[MyClass])
+    assert not is_simple_type(Iterable[MyClass])
+
+
+def test_prepare_response_model_with_custom_class_raises_clear_error():
+    """A custom class inside list[...] must fail with a clear TypeError."""
+
+    class MyClass:
+        pass
+
+    with pytest.raises(TypeError, match="BaseModel subclasses"):
+        prepare_response_model(list[MyClass])
+
+
 @pytest.mark.skipif(
     sys.version_info < (3, 10),
     reason="Union pipe syntax is only available in Python 3.10+",


### PR DESCRIPTION
## Describe your changes

`is_simple_type()` misclassifies response models like `list[MyClass]` (where `MyClass` is a custom, non-`BaseModel` class) as simple types on Python 3.10+, so `prepare_response_model` crashes with an opaque `PydanticSchemaGenerationError` instead of handling the unsupported input gracefully.

Root cause: the function probed `hasattr(inner_arg, "__or__")` to detect PEP 604 pipe unions. On Python 3.10+ `__or__` lives on `type` itself, so **every** class satisfies that check and any custom class inside `list[...]` is misrouted into `ModelAdapter` / `IterableModel`, which then explodes inside Pydantic.

Changes:

- `instructor/v2/dsl/simple_type.py`: replace both `hasattr(..., "__or__")` probes with a real union-origin check (`get_origin(X | Y) is types.UnionType`), using the same version-guarded `_UNION_ORIGINS` tuple already used in `iterable.py` and `response_model.py`. The `typing.Union[...]` checks directly above already cover `List[Union[int, str]]`, so behavior for genuine unions is unchanged.
- `instructor/v2/core/response_model.py`: hoist the list-element `_is_model_type` helper to module scope (unchanged logic) and raise a clear `TypeError` when a `list[...]`/`Iterable[...]` element is not a `BaseModel` subclass, `TypedDict`, or a union of those — instead of the opaque Pydantic error.
- `tests/dsl/test_simple_types.py`: regression tests for the issue repro (`is_simple_type(list[MyClass]) is False` and `prepare_response_model(list[MyClass])` raises `TypeError`).
- `tests/coverage/test_dsl_small_coverage.py`: update one assertion that hard-coded the old behavior as a tautology (`is_simple_type(list[object]) is hasattr(object, "__or__")` → `not is_simple_type(list[object])`).
- `CHANGELOG.md`: entry under `[Unreleased]` per the repo's changelog policy.

## Issue ticket number and link

Fixes #2613

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] If it is a core feature, I have added documentation.
