### PR TITLE
fix(validation): traverse set containers in async validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- **Async validation**: Run nested async validators inside `set` and `frozenset` fields while preserving container types. ([#2643](https://github.com/567-labs/instructor/pull/2643))
+
 ## [1.17.1] - 2026-09-09
 
 ### Upgrade Notes

--- a/instructor/v2/validation/async_validators.py
+++ b/instructor/v2/validation/async_validators.py
@@ -121,7 +121,7 @@ def model_declares_async_validators(model_cls: Any) -> bool:
 async def run_async_validators(value: Any, *, context: dict[str, Any] | None) -> Any:
     """Recursively run declared async field/model validators over a parsed value.
 
-    Nested `BaseModel` instances (directly, or inside lists/tuples/dicts) are
+    Nested `BaseModel` instances (directly, or inside lists/tuples/sets/dicts) are
     validated depth-first so a parent model's async validators see already
     -validated children. Returns the (possibly updated) value; raises
     `AsyncValidationError` aggregating every failure found in the subtree.
@@ -132,6 +132,12 @@ async def run_async_validators(value: Any, *, context: dict[str, Any] | None) ->
         return [await run_async_validators(item, context=context) for item in value]
     if isinstance(value, tuple):
         return tuple(
+            [await run_async_validators(item, context=context) for item in value]
+        )
+    if isinstance(value, set):
+        return {await run_async_validators(item, context=context) for item in value}
+    if isinstance(value, frozenset):
+        return frozenset(
             [await run_async_validators(item, context=context) for item in value]
         )
     if isinstance(value, dict):

--- a/tests/v2/test_async_validator_contracts.py
+++ b/tests/v2/test_async_validator_contracts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 from openai import AsyncOpenAI, OpenAI
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 import instructor
 
@@ -96,6 +96,32 @@ async def test_nested_container_transformations_preserve_original() -> None:
     assert result.children["group"][1][0].value == "prefix:b:suffix"
     assert original.children["group"][0].value == "a"
     assert original.children["group"][1][0].value == "b"
+
+
+@pytest.mark.asyncio
+async def test_set_container_transformations_preserve_type_and_original() -> None:
+    class HashableOrdered(Ordered):
+        model_config = ConfigDict(frozen=True)
+
+        def __hash__(self) -> int:
+            return hash(self.value)
+
+    class Parent(BaseModel):
+        mutable: set[HashableOrdered]
+        immutable: frozenset[HashableOrdered]
+
+    original = Parent(
+        mutable={HashableOrdered(value="a")},
+        immutable=frozenset({HashableOrdered(value="b")}),
+    )
+    result = await run_async_validators(original, context=None)
+
+    assert isinstance(result.mutable, set)
+    assert isinstance(result.immutable, frozenset)
+    assert {item.value for item in result.mutable} == {"prefix:a:suffix"}
+    assert {item.value for item in result.immutable} == {"prefix:b:suffix"}
+    assert {item.value for item in original.mutable} == {"a"}
+    assert {item.value for item in original.immutable} == {"b"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- recursively execute nested async validators in `set` and `frozenset` values
- preserve mutable and immutable set container types
- add a regression test covering transformations and caller-owned originals

## Problem
`model_declares_async_validators()` detects validators nested in set annotations, but `run_async_validators()` did not traverse set values. As a result, nested validation was silently skipped for these containers.

## Testing
- `uv run pytest tests/v2/test_async_validator_contracts.py -q` (14 passed)
- `uv run pytest tests/v2 -q` (1937 passed, 189 skipped)
- `uv run ruff check instructor/v2/validation/async_validators.py tests/v2/test_async_validator_contracts.py`
- `uv run ruff format --check instructor/v2/validation/async_validators.py tests/v2/test_async_validator_contracts.py`
- `uv run ty check instructor/v2/validation/async_validators.py tests/v2/test_async_validator_contracts.py`

## AI assistance
This PR was written with OpenAI Codex assistance and manually reviewed, reproduced, and tested by the contributor.